### PR TITLE
fix(intercom): retire idle brokers that never register a session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Idle intercom brokers now exit after the 5-second shutdown window even when no session ever registered, including sockets that close before register ([#2765](https://github.com/bastani-inc/atomic/issues/2765)).
+- Idle intercom brokers now exit after the 5-second shutdown window even when no session ever registered, including sockets that close before register. An evicted incumbent does not delete a successor's socket or pid file ([#2765](https://github.com/bastani-inc/atomic/issues/2765)).
 
 ## [0.9.16] - 2026-08-29
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Idle intercom brokers now exit after the 5-second shutdown window even when no session ever registered, including sockets that close before register ([#2765](https://github.com/bastani-inc/atomic/issues/2765)).
+
 ## [0.9.16] - 2026-08-29
 
 Cumulative release of the `0.9.16-alpha.1` – `0.9.16-alpha.11` prereleases. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease sections below.

--- a/packages/coding-agent/docs/intercom.md
+++ b/packages/coding-agent/docs/intercom.md
@@ -470,7 +470,7 @@ graph TB
     B2 <-->|Local Socket/Pipe| B3
 ```
 
-The broker is a standalone process that manages session registration and message routing. It auto-spawns when the first session that invokes Intercom needs it and exits 5 seconds after the last connected session disconnects; clients reconnect automatically if the broker restarts. A spawn lock keyed by PID and timestamp prevents duplicate brokers when multiple sessions start at once.
+The broker is a standalone process that manages session registration and message routing. It auto-spawns when the first session that invokes Intercom needs it and exits 5 seconds after it last has no registered sessions, including brokers that never received a connection and sockets that close before register; clients reconnect automatically if the broker restarts. A spawn lock keyed by PID and timestamp prevents duplicate brokers when multiple sessions start at once.
 
 Transport is local IPC only — a Unix domain socket on macOS/Linux or a named pipe on Windows — using length-prefixed JSON (4-byte length + payload) with request correlation for session listing, explicit delivery failures, and validation of malformed or out-of-order messages. `ask` stays client-side: the broker routes plain messages, and the client waits for the matching reply before returning it as the tool result.
 

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ### Fixed
 
-- Idle brokers now exit after the 5-second shutdown window even when no session ever registered, including sockets that close before `register` ([#2765](https://github.com/bastani-inc/atomic/issues/2765)).
+- Idle brokers now exit after the 5-second shutdown window even when no session ever registered, including sockets that close before `register`. An evicted incumbent does not delete a successor's socket or pid file ([#2765](https://github.com/bastani-inc/atomic/issues/2765)).
 
 ## [0.9.16] - 2026-08-29
 

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Fixed
+
+- Idle brokers now exit after the 5-second shutdown window even when no session ever registered, including sockets that close before `register` ([#2765](https://github.com/bastani-inc/atomic/issues/2765)).
+
 ## [0.9.16] - 2026-08-29
 
 Cumulative release of the `0.9.16-alpha.1` – `0.9.16-alpha.11` prereleases. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease sections below.

--- a/packages/intercom/README.md
+++ b/packages/intercom/README.md
@@ -451,7 +451,7 @@ graph TB
     B2 <-->|Local Socket/Pipe| B3
 ```
 
-The broker is a standalone TypeScript process that manages session registration and message routing. It auto-spawns when the first session that invokes Intercom needs it and exits after 5 seconds when the last connected session disconnects. Clients now reconnect automatically if the broker disappears and later comes back.
+The broker is a standalone TypeScript process that manages session registration and message routing. It auto-spawns when the first session that invokes Intercom needs it and exits after 5 seconds when it last has no registered sessions, including brokers that never received a connection and sockets that close before register. Clients now reconnect automatically if the broker disappears and later comes back.
 
 Messages use length-prefixed JSON over a local socket/pipe transport (4-byte length + JSON payload) to handle fragmentation properly. The protocol includes request correlation for session listing, explicit delivery failures, and validation for malformed or out-of-order messages.
 

--- a/packages/intercom/broker/broker.ts
+++ b/packages/intercom/broker/broker.ts
@@ -146,6 +146,7 @@ class IntercomBroker {
     this.server.listen(SOCKET_PATH, () => {
       writeFileSync(PID_PATH, String(process.pid));
       console.log(`Intercom broker started (pid: ${process.pid})`);
+      this.scheduleShutdownCheck();
     });
     process.on("SIGTERM", () => this.shutdown());
     process.on("SIGINT", () => this.shutdown());
@@ -166,10 +167,8 @@ class IntercomBroker {
     socket.on("data", reader);
 
     socket.on("close", () => {
-      if (sessionId) {
-        this.disconnectSession(sessionId);
-        this.scheduleShutdownCheck();
-      }
+      if (sessionId) this.disconnectSession(sessionId);
+      this.scheduleShutdownCheck();
     });
 
     socket.on("error", (error) => {

--- a/packages/intercom/broker/broker.ts
+++ b/packages/intercom/broker/broker.ts
@@ -2,7 +2,7 @@
 // only position from which the stderr cap covers the other modules' own initialization.
 import "./bounded-stderr-install.js";
 import net from "net";
-import { writeFileSync, unlinkSync, mkdirSync } from "fs";
+import { writeFileSync, unlinkSync, mkdirSync, readFileSync } from "fs";
 import { randomUUID } from "crypto";
 import { writeMessage, createMessageReader } from "./framing.js";
 import { getBrokerPidPath, getBrokerSocketPath, getIntercomDirPath } from "./paths.js";
@@ -917,6 +917,33 @@ class IntercomBroker {
     }
   }
 
+  private readPidFile(): number | undefined {
+    try {
+      const pid = Number.parseInt(readFileSync(PID_PATH, "utf-8").trim(), 10);
+      return Number.isFinite(pid) ? pid : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Unlink socket/pid only while this process still owns PID_PATH. */
+  private unlinkRuntimeFilesIfOwned(): void {
+    if (this.readPidFile() !== process.pid) return;
+    if (process.platform !== "win32") {
+      try {
+        unlinkSync(SOCKET_PATH);
+      } catch {
+        // The socket may already be gone if shutdown started after a disconnect.
+      }
+    }
+    if (this.readPidFile() !== process.pid) return;
+    try {
+      unlinkSync(PID_PATH);
+    } catch {
+      // The PID file may already be gone if startup never completed.
+    }
+  }
+
   private shutdown(): void {
     console.log("Broker shutting down");
 
@@ -930,18 +957,7 @@ class IntercomBroker {
     this.liveWorkflowStageRouteActivations.clear();
 	for (const pending of this.pendingStageNotificationAcknowledgments.values()) clearTimeout(pending.timeout);
 	this.pendingStageNotificationAcknowledgments.clear();
-    if (process.platform !== "win32") {
-      try {
-        unlinkSync(SOCKET_PATH);
-      } catch {
-        // The socket may already be gone if shutdown started after a disconnect.
-      }
-    }
-	try {
-		unlinkSync(PID_PATH);
-    } catch {
-      // The PID file may already be gone if startup never completed.
-    }
+    this.unlinkRuntimeFilesIfOwned();
     this.server.close();
     process.exit(0);
   }

--- a/packages/intercom/broker/broker.ts
+++ b/packages/intercom/broker/broker.ts
@@ -926,16 +926,8 @@ class IntercomBroker {
     }
   }
 
-  /** Unlink socket/pid only while this process still owns PID_PATH. */
+  /** Unlink the pid file only while this process still owns PID_PATH. */
   private unlinkRuntimeFilesIfOwned(): void {
-    if (this.readPidFile() !== process.pid) return;
-    if (process.platform !== "win32") {
-      try {
-        unlinkSync(SOCKET_PATH);
-      } catch {
-        // The socket may already be gone if shutdown started after a disconnect.
-      }
-    }
     if (this.readPidFile() !== process.pid) return;
     try {
       unlinkSync(PID_PATH);
@@ -957,8 +949,14 @@ class IntercomBroker {
     this.liveWorkflowStageRouteActivations.clear();
 	for (const pending of this.pendingStageNotificationAcknowledgments.values()) clearTimeout(pending.timeout);
 	this.pendingStageNotificationAcknowledgments.clear();
+    const ownsRuntime = this.readPidFile() === process.pid;
     this.unlinkRuntimeFilesIfOwned();
-    this.server.close();
+    // Node unlinks a Unix socket path on server.close() even after a successor
+    // rebound that path. Skip close when we no longer own the pid; process.exit
+    // still closes our fd. Windows named pipes are not path-unlinked this way.
+    if (process.platform === "win32" || ownsRuntime) {
+      this.server.close();
+    }
     process.exit(0);
   }
 }

--- a/test/helpers/intercom-broker-idle-retirement-e2e.mjs
+++ b/test/helpers/intercom-broker-idle-retirement-e2e.mjs
@@ -10,22 +10,16 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const WINDOW_MS = 7_000;
 const STARTUP_MS = 30_000;
+const UNIX_SOCKET_PATH_MAX = 104;
 const INTERNAL_BROKER_ARG = "--atomic-internal-intercom-broker";
-
 const runtime = process.argv.find((arg) => arg.startsWith("--runtime="))?.slice("--runtime=".length);
 if (runtime !== "source" && runtime !== "compiled") {
 	console.error("usage: node test/helpers/intercom-broker-idle-retirement-e2e.mjs --runtime=source|compiled");
 	process.exit(2);
 }
 
-function sleep(ms) {
-	return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
-}
-
-function pidPath(agentDir) {
-	return join(agentDir, "intercom", "broker.pid");
-}
-
+const sleep = (ms) => new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+const pidPath = (agentDir) => join(agentDir, "intercom", "broker.pid");
 function socketPath(agentDir) {
 	if (process.platform === "win32") {
 		const segment = agentDir.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "").toLowerCase() || "default";
@@ -33,7 +27,6 @@ function socketPath(agentDir) {
 	}
 	return join(agentDir, "intercom", "broker.sock");
 }
-
 function pidAlive(pid) {
 	try {
 		process.kill(pid, 0);
@@ -42,14 +35,12 @@ function pidAlive(pid) {
 		return false;
 	}
 }
-
 function bunBin() {
 	const override = process.env.ATOMIC_BUN_EXECUTABLE;
 	if (override && existsSync(override)) return override;
 	const homeBun = join(process.env.HOME ?? "", ".bun", "bin", "bun");
 	if (existsSync(homeBun)) return homeBun;
-	const found = spawnSync("bun", ["--version"], { encoding: "utf8" });
-	if (found.status === 0) return "bun";
+	if (spawnSync("bun", ["--version"], { encoding: "utf8" }).status === 0) return "bun";
 	throw new Error("bun is required to launch the source Atomic CLI");
 }
 function ensureCompiled() {
@@ -62,52 +53,35 @@ function ensureCompiled() {
 		env: process.env,
 	});
 	if (built.status !== 0) throw new Error("npm --workspace=@bastani/atomic run build:binary failed");
-	if (!existsSync(bin) || !existsSync(broker)) {
-		throw new Error(`compiled broker artifacts missing: ${bin} ${broker}`);
-	}
+	if (!existsSync(bin) || !existsSync(broker)) throw new Error(`compiled broker artifacts missing: ${bin} ${broker}`);
 	return { bin, broker };
 }
-
-function writeSpawnExtension(dir) {
-	const spawnHref = pathToFileURL(join(repoRoot, "packages/intercom/broker/spawn.ts")).href;
-	const file = join(dir, "spawn-broker-extension.ts");
-	writeFileSync(
-		file,
-		`export default function () {\n` +
-			`  void import(${JSON.stringify(spawnHref)}).then((mod) =>\n` +
-			`    mod.spawnBrokerIfNeeded("npx", ["--no-install", "tsx"]),\n` +
-			`  );\n` +
-			`}\n`,
-	);
-	return file;
-}
-
 function launchBroker(agentDir) {
 	const env = { ...process.env, ATOMIC_CODING_AGENT_DIR: agentDir, PI_CODING_AGENT_DIR: undefined };
 	if (runtime === "compiled") {
 		const { bin, broker } = ensureCompiled();
 		console.log(`[idle-retirement] launch compiled ${bin} ${INTERNAL_BROKER_ARG} ${broker}`);
-		return {
-			kind: "broker",
-			child: spawn(bin, [INTERNAL_BROKER_ARG, broker], { env, stdio: ["ignore", "pipe", "pipe"] }),
-		};
+		return { child: spawn(bin, [INTERNAL_BROKER_ARG, broker], { env, stdio: ["ignore", "pipe", "pipe"] }) };
 	}
-	const project = mkdtempSync(join(tmpdir(), "intercom-idle-cli-project-"));
-	const extension = writeSpawnExtension(project);
+	const project = mkdtempSync(join(tmpdir(), "icli-"));
+	const spawnHref = pathToFileURL(join(repoRoot, "packages/intercom/broker/spawn.ts")).href;
+	const extension = join(project, "spawn-broker-extension.ts");
+	writeFileSync(
+		extension,
+		`export default function () {\n  void import(${JSON.stringify(spawnHref)}).then((mod) =>\n    mod.spawnBrokerIfNeeded("npx", ["--no-install", "tsx"]),\n  );\n}\n`,
+	);
 	const cli = join(repoRoot, "packages/coding-agent/src/cli.ts");
 	const bun = bunBin();
 	console.log(`[idle-retirement] launch source ${bun} ${cli}`);
 	return {
-		kind: "cli",
 		project,
-		child: spawn(
-			bun,
-			[cli, "--mode", "rpc", "--offline", "--no-session", "--extension", extension],
-			{ cwd: project, env, stdio: ["pipe", "pipe", "pipe"] },
-		),
+		child: spawn(bun, [cli, "--mode", "rpc", "--offline", "--no-session", "--extension", extension], {
+			cwd: project,
+			env,
+			stdio: ["pipe", "pipe", "pipe"],
+		}),
 	};
 }
-
 async function waitPid(agentDir, child) {
 	const deadline = Date.now() + STARTUP_MS;
 	while (Date.now() < deadline) {
@@ -122,7 +96,6 @@ async function waitPid(agentDir, child) {
 	}
 	throw new Error("broker pid file did not appear");
 }
-
 async function waitPidExit(pid, timeoutMs) {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
@@ -131,7 +104,6 @@ async function waitPidExit(pid, timeoutMs) {
 	}
 	throw new Error(`broker pid ${pid} did not exit within ${timeoutMs}ms`);
 }
-
 function connect(agentDir) {
 	return new Promise((resolveConnected, reject) => {
 		const socket = net.createConnection(socketPath(agentDir));
@@ -139,7 +111,6 @@ function connect(agentDir) {
 		socket.once("error", reject);
 	});
 }
-
 function registerFrame() {
 	const payload = Buffer.from(
 		JSON.stringify({
@@ -159,37 +130,33 @@ function registerFrame() {
 	header.writeUInt32BE(payload.length);
 	return Buffer.concat([header, payload]);
 }
-
 async function stopLaunch(launch) {
 	if (launch.child.exitCode === null && launch.child.signalCode === null) {
 		launch.child.kill("SIGTERM");
-		await Promise.race([
-			new Promise((resolveExit) => launch.child.once("exit", resolveExit)),
-			sleep(1_000),
-		]);
+		await Promise.race([new Promise((resolveExit) => launch.child.once("exit", resolveExit)), sleep(1_000)]);
 	}
 	if (launch.project) rmSync(launch.project, { recursive: true, force: true });
 }
-
 async function runCase(name, body) {
-	const agentDir = mkdtempSync(join(tmpdir(), `intercom-idle-e2e-${runtime}-${name}-`));
+	const runtimeMark = runtime === "compiled" ? "c" : "s";
+	const agentDir = mkdtempSync(join(tmpdir(), `i${runtimeMark}${name[0]}-`));
+	if (process.platform !== "win32") {
+		const path = socketPath(agentDir);
+		if (Buffer.byteLength(path) >= UNIX_SOCKET_PATH_MAX) {
+			throw new Error(`broker socket path exceeds Unix sockaddr limit (${Buffer.byteLength(path)}): ${path}`);
+		}
+	}
 	const launch = launchBroker(agentDir);
 	try {
 		const pid = await waitPid(agentDir, launch.child);
 		const armedAt = Date.now();
 		console.log(`[idle-retirement] runtime=${runtime} case=${name} pid=${pid} armedAt=${armedAt}`);
-		await body({ agentDir, pid, armedAt, launch });
+		await body({ agentDir, pid, armedAt });
 	} finally {
 		try {
 			if (existsSync(pidPath(agentDir))) {
 				const pid = Number.parseInt(readFileSync(pidPath(agentDir), "utf8").trim(), 10);
-				if (Number.isFinite(pid)) {
-					try {
-						process.kill(pid, "SIGTERM");
-					} catch {
-						// Already gone.
-					}
-				}
+				if (Number.isFinite(pid)) process.kill(pid, "SIGTERM");
 			}
 		} catch {
 			// Cleanup is best-effort.
@@ -203,11 +170,8 @@ await runCase("no-connection", async ({ pid, armedAt }) => {
 	await waitPidExit(pid, WINDOW_MS);
 	const elapsedMs = Date.now() - armedAt;
 	if (elapsedMs > WINDOW_MS) throw new Error(`no-connection exceeded window: ${elapsedMs}ms`);
-	console.log(
-		`[idle-retirement] runtime=${runtime} case=no-connection pid=${pid} elapsedMs=${elapsedMs} exit=0`,
-	);
+	console.log(`[idle-retirement] runtime=${runtime} case=no-connection pid=${pid} elapsedMs=${elapsedMs} exit=0`);
 });
-
 await runCase("pre-register", async ({ agentDir, pid }) => {
 	const socket = await connect(agentDir);
 	await new Promise((resolveClosed) => {
@@ -218,20 +182,14 @@ await runCase("pre-register", async ({ agentDir, pid }) => {
 	await waitPidExit(pid, WINDOW_MS);
 	const elapsedMs = Date.now() - closedAt;
 	if (elapsedMs > WINDOW_MS) throw new Error(`pre-register exceeded window: ${elapsedMs}ms`);
-	console.log(
-		`[idle-retirement] runtime=${runtime} case=pre-register pid=${pid} elapsedMs=${elapsedMs} exit=0`,
-	);
+	console.log(`[idle-retirement] runtime=${runtime} case=pre-register pid=${pid} elapsedMs=${elapsedMs} exit=0`);
 });
-
 await runCase("live", async ({ agentDir, pid }) => {
 	const socket = await connect(agentDir);
 	socket.write(registerFrame());
 	await sleep(WINDOW_MS);
 	if (!pidAlive(pid)) throw new Error("registered live session was retired during the idle window");
-	console.log(
-		`[idle-retirement] runtime=${runtime} case=live pid=${pid} aliveAfterMs=${WINDOW_MS} alive=true`,
-	);
+	console.log(`[idle-retirement] runtime=${runtime} case=live pid=${pid} aliveAfterMs=${WINDOW_MS} alive=true`);
 	socket.end();
 });
-
 console.log(`[idle-retirement] runtime=${runtime} ok`);

--- a/test/helpers/intercom-broker-idle-retirement-e2e.mjs
+++ b/test/helpers/intercom-broker-idle-retirement-e2e.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/** #2765 public-boundary idle retirement: --runtime=source|compiled */
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const WINDOW_MS = 7_000;
+const STARTUP_MS = 30_000;
+const INTERNAL_BROKER_ARG = "--atomic-internal-intercom-broker";
+
+const runtime = process.argv.find((arg) => arg.startsWith("--runtime="))?.slice("--runtime=".length);
+if (runtime !== "source" && runtime !== "compiled") {
+	console.error("usage: node test/helpers/intercom-broker-idle-retirement-e2e.mjs --runtime=source|compiled");
+	process.exit(2);
+}
+
+function sleep(ms) {
+	return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function pidPath(agentDir) {
+	return join(agentDir, "intercom", "broker.pid");
+}
+
+function socketPath(agentDir) {
+	if (process.platform === "win32") {
+		const segment = agentDir.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "").toLowerCase() || "default";
+		return `\\\\.\\pipe\\pi-intercom-${segment}`;
+	}
+	return join(agentDir, "intercom", "broker.sock");
+}
+
+function pidAlive(pid) {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function bunBin() {
+	const override = process.env.ATOMIC_BUN_EXECUTABLE;
+	if (override && existsSync(override)) return override;
+	const homeBun = join(process.env.HOME ?? "", ".bun", "bin", "bun");
+	if (existsSync(homeBun)) return homeBun;
+	const found = spawnSync("bun", ["--version"], { encoding: "utf8" });
+	if (found.status === 0) return "bun";
+	throw new Error("bun is required to launch the source Atomic CLI");
+}
+function ensureCompiled() {
+	const bin = process.env.ATOMIC_COMPILED_BINARY || join(repoRoot, "packages/coding-agent/dist/atomic");
+	const broker = join(dirname(bin), "builtin", "intercom", "broker", "broker.ts");
+	if (existsSync(bin) && existsSync(broker)) return { bin, broker };
+	const built = spawnSync("npm", ["--workspace=@bastani/atomic", "run", "build:binary"], {
+		cwd: repoRoot,
+		stdio: "inherit",
+		env: process.env,
+	});
+	if (built.status !== 0) throw new Error("npm --workspace=@bastani/atomic run build:binary failed");
+	if (!existsSync(bin) || !existsSync(broker)) {
+		throw new Error(`compiled broker artifacts missing: ${bin} ${broker}`);
+	}
+	return { bin, broker };
+}
+
+function writeSpawnExtension(dir) {
+	const spawnHref = pathToFileURL(join(repoRoot, "packages/intercom/broker/spawn.ts")).href;
+	const file = join(dir, "spawn-broker-extension.ts");
+	writeFileSync(
+		file,
+		`export default function () {\n` +
+			`  void import(${JSON.stringify(spawnHref)}).then((mod) =>\n` +
+			`    mod.spawnBrokerIfNeeded("npx", ["--no-install", "tsx"]),\n` +
+			`  );\n` +
+			`}\n`,
+	);
+	return file;
+}
+
+function launchBroker(agentDir) {
+	const env = { ...process.env, ATOMIC_CODING_AGENT_DIR: agentDir, PI_CODING_AGENT_DIR: undefined };
+	if (runtime === "compiled") {
+		const { bin, broker } = ensureCompiled();
+		console.log(`[idle-retirement] launch compiled ${bin} ${INTERNAL_BROKER_ARG} ${broker}`);
+		return {
+			kind: "broker",
+			child: spawn(bin, [INTERNAL_BROKER_ARG, broker], { env, stdio: ["ignore", "pipe", "pipe"] }),
+		};
+	}
+	const project = mkdtempSync(join(tmpdir(), "intercom-idle-cli-project-"));
+	const extension = writeSpawnExtension(project);
+	const cli = join(repoRoot, "packages/coding-agent/src/cli.ts");
+	const bun = bunBin();
+	console.log(`[idle-retirement] launch source ${bun} ${cli}`);
+	return {
+		kind: "cli",
+		project,
+		child: spawn(
+			bun,
+			[cli, "--mode", "rpc", "--offline", "--no-session", "--extension", extension],
+			{ cwd: project, env, stdio: ["pipe", "pipe", "pipe"] },
+		),
+	};
+}
+
+async function waitPid(agentDir, child) {
+	const deadline = Date.now() + STARTUP_MS;
+	while (Date.now() < deadline) {
+		if (child.exitCode !== null || child.signalCode !== null) {
+			throw new Error(`launcher exited before broker pid (code ${child.exitCode} signal ${child.signalCode})`);
+		}
+		if (existsSync(pidPath(agentDir))) {
+			const pid = Number.parseInt(readFileSync(pidPath(agentDir), "utf8").trim(), 10);
+			if (Number.isFinite(pid) && pidAlive(pid)) return pid;
+		}
+		await sleep(20);
+	}
+	throw new Error("broker pid file did not appear");
+}
+
+async function waitPidExit(pid, timeoutMs) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!pidAlive(pid)) return;
+		await sleep(20);
+	}
+	throw new Error(`broker pid ${pid} did not exit within ${timeoutMs}ms`);
+}
+
+function connect(agentDir) {
+	return new Promise((resolveConnected, reject) => {
+		const socket = net.createConnection(socketPath(agentDir));
+		socket.once("connect", () => resolveConnected(socket));
+		socket.once("error", reject);
+	});
+}
+
+function registerFrame() {
+	const payload = Buffer.from(
+		JSON.stringify({
+			type: "register",
+			session: {
+				cwd: "/tmp/idle-e2e",
+				model: "test-model",
+				pid: process.pid,
+				startedAt: Date.now(),
+				lastActivity: Date.now(),
+				name: "idle-e2e-live",
+			},
+		}),
+		"utf8",
+	);
+	const header = Buffer.alloc(4);
+	header.writeUInt32BE(payload.length);
+	return Buffer.concat([header, payload]);
+}
+
+async function stopLaunch(launch) {
+	if (launch.child.exitCode === null && launch.child.signalCode === null) {
+		launch.child.kill("SIGTERM");
+		await Promise.race([
+			new Promise((resolveExit) => launch.child.once("exit", resolveExit)),
+			sleep(1_000),
+		]);
+	}
+	if (launch.project) rmSync(launch.project, { recursive: true, force: true });
+}
+
+async function runCase(name, body) {
+	const agentDir = mkdtempSync(join(tmpdir(), `intercom-idle-e2e-${runtime}-${name}-`));
+	const launch = launchBroker(agentDir);
+	try {
+		const pid = await waitPid(agentDir, launch.child);
+		const armedAt = Date.now();
+		console.log(`[idle-retirement] runtime=${runtime} case=${name} pid=${pid} armedAt=${armedAt}`);
+		await body({ agentDir, pid, armedAt, launch });
+	} finally {
+		try {
+			if (existsSync(pidPath(agentDir))) {
+				const pid = Number.parseInt(readFileSync(pidPath(agentDir), "utf8").trim(), 10);
+				if (Number.isFinite(pid)) {
+					try {
+						process.kill(pid, "SIGTERM");
+					} catch {
+						// Already gone.
+					}
+				}
+			}
+		} catch {
+			// Cleanup is best-effort.
+		}
+		await stopLaunch(launch);
+		rmSync(agentDir, { recursive: true, force: true });
+	}
+}
+
+await runCase("no-connection", async ({ pid, armedAt }) => {
+	await waitPidExit(pid, WINDOW_MS);
+	const elapsedMs = Date.now() - armedAt;
+	if (elapsedMs > WINDOW_MS) throw new Error(`no-connection exceeded window: ${elapsedMs}ms`);
+	console.log(
+		`[idle-retirement] runtime=${runtime} case=no-connection pid=${pid} elapsedMs=${elapsedMs} exit=0`,
+	);
+});
+
+await runCase("pre-register", async ({ agentDir, pid }) => {
+	const socket = await connect(agentDir);
+	await new Promise((resolveClosed) => {
+		socket.once("close", resolveClosed);
+		socket.destroy();
+	});
+	const closedAt = Date.now();
+	await waitPidExit(pid, WINDOW_MS);
+	const elapsedMs = Date.now() - closedAt;
+	if (elapsedMs > WINDOW_MS) throw new Error(`pre-register exceeded window: ${elapsedMs}ms`);
+	console.log(
+		`[idle-retirement] runtime=${runtime} case=pre-register pid=${pid} elapsedMs=${elapsedMs} exit=0`,
+	);
+});
+
+await runCase("live", async ({ agentDir, pid }) => {
+	const socket = await connect(agentDir);
+	socket.write(registerFrame());
+	await sleep(WINDOW_MS);
+	if (!pidAlive(pid)) throw new Error("registered live session was retired during the idle window");
+	console.log(
+		`[idle-retirement] runtime=${runtime} case=live pid=${pid} aliveAfterMs=${WINDOW_MS} alive=true`,
+	);
+	socket.end();
+});
+
+console.log(`[idle-retirement] runtime=${runtime} ok`);

--- a/test/unit/intercom-broker-idle-retirement.test.ts
+++ b/test/unit/intercom-broker-idle-retirement.test.ts
@@ -53,9 +53,9 @@ async function waitForBrokerPid(agentDir: string, broker: ChildProcess): Promise
 		if (broker.exitCode !== null || broker.signalCode !== null) {
 			throw new Error(`Broker exited during startup with code ${broker.exitCode} signal ${broker.signalCode}`);
 		}
-		if (existsSync(pidPath)) {
+		if (existsSync(pidPath) && broker.pid !== undefined) {
 			const pid = Number.parseInt(readFileSync(pidPath, "utf8").trim(), 10);
-			if (Number.isFinite(pid)) return pid;
+			if (pid === broker.pid) return pid;
 		}
 		await sleep(20);
 	}
@@ -163,6 +163,38 @@ test(
 		await sleep(BROKER_IDLE_SHUTDOWN_WINDOW_MS);
 		assert.equal(isBrokerAlive(broker), true, "registered broker exited while a live session was still connected");
 		socket.end();
+	},
+	REAL_BROKER_IDLE_RETIREMENT_TIMEOUT_MS,
+);
+
+// #2765
+test(
+	"an evicted idle broker does not unlink a successor's socket or pid",
+	async () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "intercom-idle-evict-"));
+		const incumbent = spawnBroker(agentDir);
+		const incumbentPid = await waitForBrokerPid(agentDir, incumbent);
+		const successor = spawnBroker(agentDir);
+		const successorPid = await waitForBrokerPid(agentDir, successor);
+		assert.notEqual(successorPid, incumbentPid);
+		const live = await connect(agentDir);
+		writeMessage(live, {
+			type: "register",
+			session: {
+				cwd: agentDir,
+				model: "test-model",
+				pid: process.pid,
+				startedAt: 1,
+				lastActivity: 1,
+				name: "evict-live",
+			},
+		});
+
+		const code = await waitForExit(incumbent, BROKER_IDLE_SHUTDOWN_WINDOW_MS);
+		assert.equal(code, 0);
+		assert.equal(isBrokerAlive(successor), true, "successor broker exited when the incumbent shut down");
+		assert.equal(Number.parseInt(readFileSync(getBrokerPidPath(agentDir), "utf8").trim(), 10), successorPid);
+		live.end();
 	},
 	REAL_BROKER_IDLE_RETIREMENT_TIMEOUT_MS,
 );

--- a/test/unit/intercom-broker-idle-retirement.test.ts
+++ b/test/unit/intercom-broker-idle-retirement.test.ts
@@ -15,8 +15,9 @@ const extensionDir = join(repoRoot, "packages/intercom");
 /** Documented idle window before a broker with no registered sessions exits. */
 const BROKER_IDLE_SHUTDOWN_MS = 5_000;
 const BROKER_IDLE_SHUTDOWN_GRACE_MS = 2_000;
-/** Real broker child plus the idle shutdown window. */
-const BROKER_IDLE_RETIREMENT_TIMEOUT_MS = 15_000;
+const BROKER_IDLE_SHUTDOWN_WINDOW_MS = BROKER_IDLE_SHUTDOWN_MS + BROKER_IDLE_SHUTDOWN_GRACE_MS;
+/** Real broker child, jiti startup, and the idle shutdown window. */
+const REAL_BROKER_IDLE_RETIREMENT_TIMEOUT_MS = 30_000;
 const BROKER_STARTUP_MS = 10_000;
 
 const fixtures: Array<{ agentDir: string; broker: ChildProcess }> = [];
@@ -100,17 +101,17 @@ test(
 	async () => {
 		const agentDir = mkdtempSync(join(tmpdir(), "intercom-idle-none-"));
 		const broker = spawnBroker(agentDir);
-		const startedAt = Date.now();
 		await waitForBrokerPid(agentDir, broker);
+		const armedAt = Date.now();
 
-		const code = await waitForExit(broker, BROKER_IDLE_SHUTDOWN_MS + BROKER_IDLE_SHUTDOWN_GRACE_MS);
+		const code = await waitForExit(broker, BROKER_IDLE_SHUTDOWN_WINDOW_MS);
 		assert.equal(code, 0);
 		assert.ok(
-			Date.now() - startedAt <= BROKER_IDLE_SHUTDOWN_MS + BROKER_IDLE_SHUTDOWN_GRACE_MS,
-			"idle broker exceeded the shutdown window",
+			Date.now() - armedAt <= BROKER_IDLE_SHUTDOWN_WINDOW_MS,
+			"idle broker exceeded the shutdown window after listen armed the check",
 		);
 	},
-	BROKER_IDLE_RETIREMENT_TIMEOUT_MS,
+	REAL_BROKER_IDLE_RETIREMENT_TIMEOUT_MS,
 );
 
 // #2765
@@ -128,14 +129,14 @@ test(
 		});
 
 		const closedAt = Date.now();
-		const code = await waitForExit(broker, BROKER_IDLE_SHUTDOWN_MS + BROKER_IDLE_SHUTDOWN_GRACE_MS);
+		const code = await waitForExit(broker, BROKER_IDLE_SHUTDOWN_WINDOW_MS);
 		assert.equal(code, 0);
 		assert.ok(
-			Date.now() - closedAt <= BROKER_IDLE_SHUTDOWN_MS + BROKER_IDLE_SHUTDOWN_GRACE_MS,
+			Date.now() - closedAt <= BROKER_IDLE_SHUTDOWN_WINDOW_MS,
 			"pre-register disconnect exceeded the shutdown window",
 		);
 	},
-	BROKER_IDLE_RETIREMENT_TIMEOUT_MS,
+	REAL_BROKER_IDLE_RETIREMENT_TIMEOUT_MS,
 );
 
 // #2765
@@ -159,9 +160,9 @@ test(
 			},
 		});
 
-		await sleep(BROKER_IDLE_SHUTDOWN_MS + BROKER_IDLE_SHUTDOWN_GRACE_MS);
+		await sleep(BROKER_IDLE_SHUTDOWN_WINDOW_MS);
 		assert.equal(isBrokerAlive(broker), true, "registered broker exited while a live session was still connected");
 		socket.end();
 	},
-	BROKER_IDLE_RETIREMENT_TIMEOUT_MS,
+	REAL_BROKER_IDLE_RETIREMENT_TIMEOUT_MS,
 );

--- a/test/unit/intercom-broker-idle-retirement.test.ts
+++ b/test/unit/intercom-broker-idle-retirement.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, test } from "vitest";
+import { writeMessage } from "../../packages/intercom/broker/framing.js";
+import { getBrokerPidPath, getBrokerSocketPath } from "../../packages/intercom/broker/paths.js";
+import { getJitiCliPath } from "../../packages/intercom/broker/spawn.js";
+import { sleep } from "../helpers/runtime.ts";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+const extensionDir = join(repoRoot, "packages/intercom");
+/** Documented idle window before a broker with no registered sessions exits. */
+const BROKER_IDLE_SHUTDOWN_MS = 5_000;
+const BROKER_IDLE_SHUTDOWN_GRACE_MS = 2_000;
+/** Real broker child plus the idle shutdown window. */
+const BROKER_IDLE_RETIREMENT_TIMEOUT_MS = 15_000;
+const BROKER_STARTUP_MS = 10_000;
+
+const fixtures: Array<{ agentDir: string; broker: ChildProcess }> = [];
+
+afterEach(async () => {
+	while (fixtures.length > 0) {
+		const fixture = fixtures.pop();
+		if (!fixture) continue;
+		if (fixture.broker.exitCode === null && fixture.broker.signalCode === null) {
+			const exited = new Promise<void>((resolveExit) => {
+				fixture.broker.once("exit", () => resolveExit());
+			});
+			fixture.broker.kill("SIGTERM");
+			await Promise.race([exited, sleep(1_000)]);
+		}
+		rmSync(fixture.agentDir, { recursive: true, force: true });
+	}
+});
+
+function spawnBroker(agentDir: string): ChildProcess {
+	const broker = spawn(process.execPath, [getJitiCliPath(extensionDir), join(extensionDir, "broker/broker.ts")], {
+		env: { ...process.env, ATOMIC_CODING_AGENT_DIR: agentDir, PI_CODING_AGENT_DIR: undefined },
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	fixtures.push({ agentDir, broker });
+	return broker;
+}
+
+async function waitForBrokerPid(agentDir: string, broker: ChildProcess): Promise<number> {
+	const pidPath = getBrokerPidPath(agentDir);
+	const deadline = Date.now() + BROKER_STARTUP_MS;
+	while (Date.now() < deadline) {
+		if (broker.exitCode !== null || broker.signalCode !== null) {
+			throw new Error(`Broker exited during startup with code ${broker.exitCode} signal ${broker.signalCode}`);
+		}
+		if (existsSync(pidPath)) {
+			const pid = Number.parseInt(readFileSync(pidPath, "utf8").trim(), 10);
+			if (Number.isFinite(pid)) return pid;
+		}
+		await sleep(20);
+	}
+	throw new Error("Broker pid file did not appear");
+}
+
+function waitForExit(broker: ChildProcess, timeoutMs: number): Promise<number | null> {
+	if (broker.exitCode !== null || broker.signalCode !== null) {
+		return Promise.resolve(broker.exitCode);
+	}
+	return new Promise((resolveExit, reject) => {
+		const timer = setTimeout(() => {
+			broker.off("exit", onExit);
+			reject(new Error(`Broker did not exit within ${timeoutMs}ms`));
+		}, timeoutMs);
+		const onExit = (code: number | null) => {
+			clearTimeout(timer);
+			resolveExit(code);
+		};
+		broker.once("exit", onExit);
+	});
+}
+
+function isBrokerAlive(broker: ChildProcess): boolean {
+	return broker.exitCode === null && broker.signalCode === null;
+}
+
+async function connect(agentDir: string): Promise<net.Socket> {
+	const socketPath = getBrokerSocketPath(process.platform, agentDir);
+	const socket = net.createConnection(socketPath);
+	socket.on("error", () => {});
+	if (!socket.connecting) return socket;
+	await new Promise<void>((resolveConnected, reject) => {
+		socket.once("connect", () => resolveConnected());
+		socket.once("error", reject);
+	});
+	return socket;
+}
+
+// #2765
+test(
+	"a broker that receives no connection exits within the idle shutdown window",
+	async () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "intercom-idle-none-"));
+		const broker = spawnBroker(agentDir);
+		const startedAt = Date.now();
+		await waitForBrokerPid(agentDir, broker);
+
+		const code = await waitForExit(broker, BROKER_IDLE_SHUTDOWN_MS + BROKER_IDLE_SHUTDOWN_GRACE_MS);
+		assert.equal(code, 0);
+		assert.ok(
+			Date.now() - startedAt <= BROKER_IDLE_SHUTDOWN_MS + BROKER_IDLE_SHUTDOWN_GRACE_MS,
+			"idle broker exceeded the shutdown window",
+		);
+	},
+	BROKER_IDLE_RETIREMENT_TIMEOUT_MS,
+);
+
+// #2765
+test(
+	"a connection that closes before register still retires the broker",
+	async () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "intercom-idle-prereg-"));
+		const broker = spawnBroker(agentDir);
+		await waitForBrokerPid(agentDir, broker);
+
+		const socket = await connect(agentDir);
+		await new Promise<void>((resolveClosed) => {
+			socket.once("close", () => resolveClosed());
+			socket.destroy();
+		});
+
+		const closedAt = Date.now();
+		const code = await waitForExit(broker, BROKER_IDLE_SHUTDOWN_MS + BROKER_IDLE_SHUTDOWN_GRACE_MS);
+		assert.equal(code, 0);
+		assert.ok(
+			Date.now() - closedAt <= BROKER_IDLE_SHUTDOWN_MS + BROKER_IDLE_SHUTDOWN_GRACE_MS,
+			"pre-register disconnect exceeded the shutdown window",
+		);
+	},
+	BROKER_IDLE_RETIREMENT_TIMEOUT_MS,
+);
+
+// #2765
+test(
+	"a registered live session is not retired during the idle shutdown window",
+	async () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "intercom-idle-live-"));
+		const broker = spawnBroker(agentDir);
+		await waitForBrokerPid(agentDir, broker);
+
+		const socket = await connect(agentDir);
+		writeMessage(socket, {
+			type: "register",
+			session: {
+				cwd: agentDir,
+				model: "test-model",
+				pid: process.pid,
+				startedAt: Date.now(),
+				lastActivity: Date.now(),
+				name: "idle-live",
+			},
+		});
+
+		await sleep(BROKER_IDLE_SHUTDOWN_MS + BROKER_IDLE_SHUTDOWN_GRACE_MS);
+		assert.equal(isBrokerAlive(broker), true, "registered broker exited while a live session was still connected");
+		socket.end();
+	},
+	BROKER_IDLE_RETIREMENT_TIMEOUT_MS,
+);

--- a/test/unit/intercom-broker-idle-retirement.test.ts
+++ b/test/unit/intercom-broker-idle-retirement.test.ts
@@ -5,7 +5,7 @@ import net from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, test } from "vitest";
-import { writeMessage } from "../../packages/intercom/broker/framing.js";
+import { createMessageReader, writeMessage } from "../../packages/intercom/broker/framing.js";
 import { getBrokerPidPath, getBrokerSocketPath } from "../../packages/intercom/broker/paths.js";
 import { getJitiCliPath } from "../../packages/intercom/broker/spawn.js";
 import { sleep } from "../helpers/runtime.ts";
@@ -19,6 +19,8 @@ const BROKER_IDLE_SHUTDOWN_WINDOW_MS = BROKER_IDLE_SHUTDOWN_MS + BROKER_IDLE_SHU
 /** Real broker child, jiti startup, and the idle shutdown window. */
 const REAL_BROKER_IDLE_RETIREMENT_TIMEOUT_MS = 30_000;
 const BROKER_STARTUP_MS = 10_000;
+/** Unix unlink-and-rebind is the only eviction path; a live Windows named pipe returns EADDRINUSE. */
+const unixEvictionTest = process.platform === "win32" ? test.skip : test;
 
 const fixtures: Array<{ agentDir: string; broker: ChildProcess }> = [];
 
@@ -95,6 +97,25 @@ async function connect(agentDir: string): Promise<net.Socket> {
 	return socket;
 }
 
+async function waitRegistered(socket: net.Socket): Promise<void> {
+	await new Promise<void>((resolveRegistered, reject) => {
+		const timer = setTimeout(() => reject(new Error("timed out waiting for registered")), BROKER_STARTUP_MS);
+		const reader = createMessageReader(
+			(message) => {
+				if (typeof message === "object" && message !== null && "type" in message && message.type === "registered") {
+					clearTimeout(timer);
+					resolveRegistered();
+				}
+			},
+			(error) => {
+				clearTimeout(timer);
+				reject(error);
+			},
+		);
+		socket.on("data", reader);
+	});
+}
+
 // #2765
 test(
 	"a broker that receives no connection exits within the idle shutdown window",
@@ -168,7 +189,7 @@ test(
 );
 
 // #2765
-test(
+unixEvictionTest(
 	"an evicted idle broker does not unlink a successor's socket or pid",
 	async () => {
 		const agentDir = mkdtempSync(join(tmpdir(), "intercom-idle-evict-"));
@@ -178,6 +199,7 @@ test(
 		const successorPid = await waitForBrokerPid(agentDir, successor);
 		assert.notEqual(successorPid, incumbentPid);
 		const live = await connect(agentDir);
+		const registered = waitRegistered(live);
 		writeMessage(live, {
 			type: "register",
 			session: {
@@ -189,11 +211,16 @@ test(
 				name: "evict-live",
 			},
 		});
+		await registered;
 
 		const code = await waitForExit(incumbent, BROKER_IDLE_SHUTDOWN_WINDOW_MS);
 		assert.equal(code, 0);
 		assert.equal(isBrokerAlive(successor), true, "successor broker exited when the incumbent shut down");
 		assert.equal(Number.parseInt(readFileSync(getBrokerPidPath(agentDir), "utf8").trim(), 10), successorPid);
+		const socketPath = getBrokerSocketPath(process.platform, agentDir);
+		assert.equal(existsSync(socketPath), true, "incumbent shutdown unlinked the successor socket");
+		const probe = await connect(agentDir);
+		probe.end();
 		live.end();
 	},
 	REAL_BROKER_IDLE_RETIREMENT_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

Idle intercom brokers that never served a registered client never scheduled the existing 5-second shutdown check, so they leaked one process per spawn. This PR arms that check on listen and on every socket close (including pre-register disconnects), keeps a live registered session from retiring early, and stops an evicted Unix incumbent from deleting a successor's socket or pid file.

Closes #2765

## Changes

- Schedule the idle shutdown check when the broker starts listening.
- Schedule it on every socket close, including connections that close before `register`.
- Unlink socket and pid files only while this process still owns the pid file.
- Skip Unix `server.close` after eviction so Node does not unlink a successor's rebound socket.
- Add unit coverage for idle, pre-register, live, and Unix eviction.
- Add a public-boundary helper that launches the source CLI and compiled binary with isolated `ATOMIC_CODING_AGENT_DIR` values.

## Tests

- `npm run test:unit -- test/unit/intercom-broker-idle-retirement.test.ts`
- `node test/helpers/intercom-broker-idle-retirement-e2e.mjs --runtime=source`
- `node test/helpers/intercom-broker-idle-retirement-e2e.mjs --runtime=compiled`

Idle and pre-register brokers must exit inside the 7s window; a registered live session must still be alive after that window.

## Notes

User-facing intercom docs and the Unreleased changelogs for `@bastani/atomic` and the intercom package record the retirement behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790591036&installation_model_id=10562&pr_number=2767&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2767&signature=b4dde5f40fb3f641334b2c7f70da50b47a5601578da3b1430c4b7b69a6a3ad9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds idle retirement for brokers with no registered sessions and protects Unix runtime files owned by a successor process. A real socket-level reproduction found that the broker can shut down and disconnect a client that has connected but has not finished sending its registration. The focused root test also needs to use the repository’s required `.js` ESM import convention.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until idle retirement no longer treats an accepted, pre-registration client as inactivity.

The registration failure was reproduced against the real broker using a deterministic Unix-socket interaction. The remaining test-import issue is limited to repository ESM convention consistency.

**Files Needing Attention:** `packages/intercom/broker/broker.ts` needs to account for accepted sockets that have not registered yet. `test/unit/intercom-broker-idle-retirement.test.ts` needs its helper import updated to the required ESM extension.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and linked it to the corresponding review comment.
- T-Rex produced a second proof for another posted P1 finding and linked it to the corresponding review comment.
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Idle retirement closes accepted clients before registration**

   - **Bug**
     - The broker retains its listen-time idle timer after accepting a socket. If that socket has not yet supplied a complete registration when the timer fires, it is not in `sessions`, so shutdown closes it and the process exits.
   - **Cause**
     - `scheduleShutdownCheck()` is armed at listen and its callback tests only registered sessions (`this.sessions.size`). `handleConnection()` does not track pre-registration sockets or otherwise defer/cancel this shutdown timer on connection acceptance.
   - **Fix**
     - Track accepted pre-registration connections and suppress idle shutdown while any are open, or cancel/defer the listen-time timer in `handleConnection()` and schedule a new check only after an unregistered socket closes. Preserve the existing registered-session behavior.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/intercom/broker/broker.ts:149
**Idle retirement closes pending registrations**

The listen-time shutdown timer remains active after a client socket is accepted. If the client connects near the five-second deadline but has not completed its `register` frame, it is absent from `sessions`; the timer then shuts down the broker and closes the active connection. Track pre-registration sockets, or defer the idle check until such a socket closes, so a normal initial handshake is not interrupted.

### Issue 2
test/unit/intercom-broker-idle-retirement.test.ts:11
**Root test uses ts import**

This root-suite test imports the runtime helper with a `.ts` specifier instead of the repository's required `.js` ESM convention, creating inconsistent resolution when tests are compiled or run against emitted modules.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(intercom): skip unix server.close af..."](https://github.com/bastani-inc/atomic/commit/d6a09ab772a30b6386b239986a857cf5820879f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58193960)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->