### PR TITLE
docs(changelog): prepare 0.9.17-alpha.1 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.17-alpha.1] - 2026-08-29
+
 ### Fixed
 
 - Idle intercom brokers now exit after the 5-second shutdown window even when no session ever registered, including sockets that close before register. An evicted incumbent does not delete a successor's socket or pid file ([#2765](https://github.com/bastani-inc/atomic/issues/2765)).

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.17-alpha.1] - 2026-08-29
+
 ### Fixed
 
 - Idle brokers now exit after the 5-second shutdown window even when no session ever registered, including sockets that close before `register`. An evicted incumbent does not delete a successor's socket or pid file ([#2765](https://github.com/bastani-inc/atomic/issues/2765)).


### PR DESCRIPTION
## Summary

Prepares the package changelogs for the `0.9.17-alpha.1` prerelease by moving the accumulated `[Unreleased]` entries into dated release sections. This changelog-only PR must merge before the release tag is cut.

## Changes

- Records the idle-intercom-broker retirement fix: brokers now exit after the 5-second shutdown window even when no session ever registered, including sockets that close before register, and an evicted incumbent does not delete a successor's socket or pid file ([#2765](https://github.com/bastani-inc/atomic/issues/2765)).

## Scope

The diff contains only these files:

- `packages/coding-agent/CHANGELOG.md`
- `packages/intercom/CHANGELOG.md`

All eight package manifests, workspace lock entries, Cargo metadata, and generated native version checks remain at `0.0.0`. The target version appears nowhere outside package changelogs.

`main` stays versionless. After this PR merges, `scripts/cut-release.ts` will stamp `0.9.17-alpha.1` only on the detached release commit. Pushing that tag starts `publish.yml`; this PR does not tag or publish.

## Validation

- `bun run vitest --run --project unit test/unit/build-release-notes.test.ts test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/bump-version-script.test.ts` (35 tests passed)
- `bun run scripts/build-release-notes.ts 0.9.17-alpha.1`
- Bun-based versionless invariant check across package manifests, `package-lock.json`, Cargo metadata, and `packages/natives/native/index.js`
- `git diff --check`
- Pre-commit `npm run check` (biome + typecheck + shrinkwrap) passed on this exact commit

Assistant-model: Grok 4.6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790617681&installation_model_id=10562&pr_number=2768&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2768&signature=2a3d31bdacb8d500af6eed76372eaa8b0762611fc8e4e0da92470fc1b89d8cdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepares the `0.9.17-alpha.1` release notes by moving the idle-intercom-broker fix from the unreleased sections into dated release sections.
- Adds the `0.9.17-alpha.1` section to the coding-agent changelog.
- Adds the corresponding release section to the intercom changelog.

<h3>Confidence Score: 5/5</h3>

The changelog-only PR appears safe to merge.

The new headings follow the release tooling’s supported version and date format, preserve the empty Unreleased sections, and correctly associate the existing fix entries with the pending prerelease.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/coding-agent/CHANGELOG.md | Adds a correctly formatted `0.9.17-alpha.1` release heading and attributes the bundled intercom broker fix to coding-agent. |
| packages/intercom/CHANGELOG.md | Adds a correctly formatted `0.9.17-alpha.1` release heading for the idle-broker lifecycle fix. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.17-alpha.1 ..."](https://github.com/bastani-inc/atomic/commit/82a4775d4a4ee05d1da3fc2044e65e1dda0b7160) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58248444)</sub>

<!-- /greptile_comment -->