### PR TITLE
docs(changelog): prepare 0.9.17 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.9.17] - 2026-08-29
+
+Cumulative release of the `0.9.17-alpha.1` prerelease. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease section below.
+
+### Fixed
+
+- Idle intercom brokers now exit after the 5-second shutdown window even when no session ever registered, including sockets that close before register. An evicted incumbent does not delete a successor's socket or pid file ([#2765](https://github.com/bastani-inc/atomic/issues/2765)).
+
 ## [0.9.17-alpha.1] - 2026-08-29
 
 ### Fixed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.17] - 2026-08-29
+
+Cumulative release of the `0.9.17-alpha.1` prerelease. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease section below.
+
+### Fixed
+
+- Idle brokers now exit after the 5-second shutdown window even when no session ever registered, including sockets that close before `register`. An evicted incumbent does not delete a successor's socket or pid file ([#2765](https://github.com/bastani-inc/atomic/issues/2765)).
+
 ## [0.9.17-alpha.1] - 2026-08-29
 
 ### Fixed


### PR DESCRIPTION
## Summary

Prepares the release notes for **0.9.17**. Changelog-only; no code, manifest, lockfile, or Cargo changes.

Each package gains a dated `## [0.9.17] - 2026-08-29` section under `[Unreleased]`, summarizing the cumulative `0.9.17-alpha.1` prerelease. Per-change detail stays in the existing prerelease sections, which are untouched.

| Package | Prereleases covered |
| --- | --- |
| `coding-agent` | alpha.1 |
| `intercom` | alpha.1 |

`ai`, `mcp`, `natives`, `subagents`, `web-access`, and `workflows` have no `0.9.17` prerelease notes, so they are unchanged.

## Release-base invariants

- Diff is **purely additive**: 16 insertions, 0 deletions, across 2 `CHANGELOG.md` files only.
- No already-released version section was modified.
- Every shipped package manifest, `package-lock.json` entry, Cargo manifest, and generated native version check remains at the `0.0.0` placeholder.
- `scripts/cut-release.ts` stamps the real version on the detached `Release 0.9.17` commit after this PR merges. Pushing that tag starts `publish.yml`; no publication is dispatched from here.

## Validation

- `bun run vitest --run --project unit test/unit/build-release-notes.test.ts test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/bump-version-script.test.ts` (35 tests passed)
- `bun run scripts/build-release-notes.ts 0.9.17`
- Bun-based versionless invariant check across package manifests, `package-lock.json`, Cargo metadata, and `packages/natives/native/index.js`
- `git diff --check`
- Pre-commit `npm run check` (biome + typecheck + shrinkwrap) passed on this exact commit

Assistant-model: Grok 4.6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790619708&installation_model_id=10562&pr_number=2769&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2769&signature=6cf0e58584c79cbb742787716bd0c324e6e4ef7f40ef42324a0ad4875367003e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds stable 0.9.17 sections to the coding-agent and intercom changelogs. Generating the 0.9.17 release notes succeeds, but the published output lists the same #2765 idle-broker fix twice because both package sections describe it with slightly different wording.

The shared broker fix should appear once in the generated release notes before merging.

<h3>Confidence Score: 4/5</h3>

Not ready to merge until the duplicate release-note entry is consolidated or explicitly deduplicated.

The release-note generator was executed successfully against the changed checkout, and its captured output directly demonstrates that one shipped fix is presented twice.

**Files Needing Attention:** packages/coding-agent/CHANGELOG.md and packages/intercom/CHANGELOG.md contain the two overlapping stable-release entries.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The team produced a proof for a posted P2 finding and attached three artifacts showing the release-note generator outputs before and after the 0.9.17 changelog entries, plus the exact TypeScript source used for validation.
- A second proof for a different posted P2 finding was produced, with no artifacts attached.
- A general-contract-validation-proof was produced, confirming how the release notes deduplicate and append package sections, and explaining that identical preambles are de-duplicated while semantically equivalent entries are both emitted.

<a href="https://app.greptile.com/trex/runs/21410891/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **0.9.17 release notes duplicate one intercom broker fix**

   - **Bug**
     - `bun run scripts/build-release-notes.ts 0.9.17` emits two bullets for the same #2765 idle-broker/socket-pid-file fix—one from `coding-agent` and one from `intercom`. This incorrectly represents the single stable-release change twice.
   - **Cause**
     - `buildReleaseNotes` combines every package's section entries without entry-level de-duplication. The two new changelog bullets are semantically the same but not byte-identical (for example, `intercom brokers` vs. `brokers`, and quoted vs. unquoted `register`), so the existing preamble-only de-duplication cannot collapse them.
   - **Fix**
     - Keep the stable-release fix in one package changelog entry, or make the release-note generator support intentional cross-package de-duplication with an explicit shared identifier rather than relying on exact prose equality.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/CHANGELOG.md:11
**Release notes duplicate the broker fix**

Generating the 0.9.17 release notes emits this #2765 fix twice: once from `coding-agent` and once from `intercom`. The entries describe the same idle-broker shutdown and successor socket/pid-file preservation change, but differ slightly in wording, so the merger does not collapse them. Keep the stable-release entry in one package changelog, or add an explicit shared-entry mechanism so the published release does not present one fix as two.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.17 release ..."](https://github.com/bastani-inc/atomic/commit/4138eba0462596f177d989b38d51b5b4318dacfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58253377)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->