### PR TITLE
docs(readme): add GRiDD case study and long-run expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@
 </p>
 
 <p align="center">
+  Atomic trades speed for quality. Complex runs can take hours, days, or weeks because Atomic researches, implements, and verifies the work that quick coding-agent passes tend to leave to you.
+</p>
+
+<p align="center">
+  Engineers using Atomic tell us this means less babysitting and less stress. The end result is work built and verified for production review, backed by evidence instead of another round of manual prompting.
+</p>
+
+<p align="center">
   <a href="#get-started"><b>Get started →</b></a>
   &nbsp;·&nbsp;
   <a href="#how-atomic-works">How it works</a>
@@ -25,6 +33,7 @@
 <p align="center">
   <a href="https://docs.bastani.ai/"><img src="https://img.shields.io/badge/docs-atomic-blue" alt="Docs"></a>
   <a href="https://discord.gg/9CvdXUGXR4"><img src="https://img.shields.io/badge/join%20community-discord-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://bastani.ai/case-studies/gridd/"><img src="https://img.shields.io/badge/case%20study-GRiDD-7C3AED" alt="GRiDD case study"></a>
   <a href="https://deepwiki.com/bastani-inc/atomic"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
   <a href="./package.json"><img src="https://img.shields.io/badge/TypeScript-7.x-3178C6?logo=typescript&logoColor=white" alt="TypeScript"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>


### PR DESCRIPTION
## Summary

Set clearer expectations for Atomic's long-running engineering work and link readers to GRiDD's real-world case study.

## Changes

- preserve the existing README hero positioning while explaining that complex runs may take hours, days, or weeks
- frame the added runtime as an explicit speed-for-quality tradeoff that reduces babysitting and manual prompting
- add a GRiDD case-study pill to the top README badge row

## Notes

- Commit and push hooks passed, including `npm run check`.
- The GRiDD case-study page and badge endpoint both returned HTTP 200.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790639823&installation_model_id=10562&pr_number=2770&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2770&signature=96e96e0bd8fb32674e5608199c15ea08f4b2e868024f04791b6728201ce1cdbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This README update explains that complex Atomic runs may take longer in exchange for more research, implementation, and verification, and adds a GRiDD case-study badge. Live checks confirmed that the GRiDD case-study URL returns the intended page and that the Shields badge returns a valid SVG. Before-and-after Markdown rendering also confirmed that the two new paragraphs and case-study badge render correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the README content renders correctly and the new public resources are reachable.

No defects were found after validating the changed HTML and Markdown structure, the case-study destination, and the badge asset.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a live HTTPS validator for the GRiDD case-study URL and the Shields badge, and the case-study page returned HTTP 200 with GRiDD content while the badge delivered an SVG image.
- I rendered README.md before and after the change with the Markdown renderer, and the baseline lacked the new elements while the updated README shows two new paragraphs and one case-study badge.
- I compared validator sources and outputs to confirm the new README fragment and its external resources work as intended, using the readme-case-study-source.log and readme-markdown-render-source.log.
- I reviewed the artifact evidence to verify that live retrieval produced a GRiDD 200 response and an SVG badge and that the before/after render logs reflect the changes.

<a href="https://app.greptile.com/trex/runs/21433531/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): add case study and long-ru..."](https://github.com/bastani-inc/atomic/commit/913f07ce65edd4331c4fa5ef74dbdcc36e065e50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58295076)</sub>

<!-- /greptile_comment -->