### PR TITLE
feat(extensions): add Bun host-module bridge

### DIFF
--- a/.impl-host-bridge-report.md
+++ b/.impl-host-bridge-report.md
@@ -1,0 +1,58 @@
+# Host-module bridge implementation report
+
+## Outcome
+
+Implemented the first independently reviewable Bun-runtime host-module bridge layer in commit `83176a3bf0fc492bf53d81fd7a64aefb5a14b1b2` (`feat(extensions): add Bun host-module bridge`). The bridge uses the compiled-binary-proven `Bun.plugin` `build.module()` object-loader surface and is not called by production extension routing.
+
+## Acceptance evidence
+
+| Criterion | Current-checkout evidence |
+|---|---|
+| Reuse exact live host module objects without duplicate package state | `host-module-bridge.ts` imports the existing memoized `getVirtualModules()` accessor; `extensions-host-module-bridge.test.ts` proves every registered specifier matches the map and every callback's `exports` is reference-identical with `toBe`. |
+| Real compiled-launcher boundary with an external precompiled ESM bundle | `test/ci/extension-host-module-bridge-boundary.test.ts` builds `extension.mjs` via `bun build --target=bun --format=esm --external=proper-lockfile`, asserts its bare import remains, builds the CJS sidecar, compiles a bytecode split launcher, and runs it. It proves named/default exports, `Object.is` identity, and mutation in both directions. |
+| Production routing unchanged | The only edit to `loader-virtual-modules.ts` exports `getVirtualModules`; search finds `installHostModuleBridge` only in its definition and tests. `loadExtensionModule`, `loadTransformedExtensionModule`, and `importExtensionModule` control flow are unchanged. |
+| Node/npm and source checkout unchanged | Installer returns `{ installed: false, specifiers: [] }` unless `isBunBinary || isBundledBuild` and a callable Bun plugin runtime exists. Unit coverage proves the ordinary Node test environment never invokes `Bun.plugin`. |
+| Idempotent and retryable | Unit coverage proves two installs return the same result and register once; a registration failure clears the memo and a second call succeeds. |
+| Probe evidence preserved | Moved the authoritative report to `research/evidence/native-builtin-host-bridge/bun-compiled-plugin-probe.md`. |
+| Docs current; no misleading changelog | `packages/coding-agent/docs/extensions.md` documents the internal seam and explicitly says production routing still uses jiti. No changelog entry was added because shipped behavior is unchanged. |
+
+The interface preserves `Object.keys()` insertion order, does not normalize or deduplicate specifiers, and returns a mutable `string[]` as requested. The omitted/inert result uses an empty list. Duplicate handling is inherited verbatim from the existing `Record<string, object>` host map, whose keys are unique by JavaScript object semantics.
+
+## Commands and outcomes
+
+- `npm ci --ignore-scripts` — exit 0; installed 554 packages.
+- `npm run build` — exit 0; generated/built `@bastani/pi-ai`, restored its alias, and built the native N-API binding required by tests.
+- `npm run test --workspace=@bastani/atomic -- extensions-host-module-bridge.test.ts` — exit 0; 1 file, 4 tests passed.
+- `npx vitest --run --project ci test/ci/extension-host-module-bridge-boundary.test.ts` — exit 0; 1 file, 1 test passed after restoration. The executable printed `compiled host-module bridge probe: OK`.
+- `npm run test --workspace=@bastani/atomic` — exit 0; 498 files passed, 4 skipped; 4109 tests passed, 40 skipped.
+- First `npm run test:unit` — exit 1 because required generated `packages/coding-agent/dist/builtin/intercom` and the built `@bastani/atomic/workflows` export were absent. This was checkout setup, not an implementation failure.
+- `npm run build --workspace=@bastani/atomic` — exit 0; produced the documented built-package fixtures.
+- Second `npm run test:unit` — exit 0; 723 files and 7265 tests passed, 23 skipped.
+- `npm run test:ci-contracts` — exit 0; 14 files and 75 tests passed.
+- `npm run check` — exit 0; Biome completed with one pre-existing informational `noUselessStringRaw` diagnostic in `test/ci/ci-workflow-contracts.test.ts`; both root `tsc` and coding-agent `tsgo` typechecks passed; shrinkwrap was current.
+- Commit hook reran repository checks successfully before creating `83176a3bf0`.
+
+## Required negative control
+
+Temporarily inserted an unconditional not-installed return at the start of `installHostModuleBridge()`, then ran:
+
+```text
+npx vitest --run --project ci test/ci/extension-host-module-bridge-boundary.test.ts
+```
+
+It exited 1. The compiled executable exited 1 with stderr `host bridge did not install exactly once`, and the Vitest assertion reported `1 !== 0` at the startup exit-code check. The source was restored from a byte-for-byte saved copy; the same focused boundary command then exited 0 with 1 test passed. This proves the executable scenario cannot pass with the bridge disabled.
+
+## Files changed
+
+- `packages/coding-agent/src/core/extensions/host-module-bridge.ts`
+- `packages/coding-agent/src/core/extensions/loader-virtual-modules.ts`
+- `packages/coding-agent/test/extensions-host-module-bridge.test.ts`
+- `test/ci/extension-host-module-bridge-boundary.test.ts`
+- `packages/coding-agent/docs/extensions.md`
+- `research/evidence/native-builtin-host-bridge/bun-compiled-plugin-probe.md`
+
+## Risks and deferred work
+
+- This slice intentionally does not install the bridge from production extension routing; native builtin routing is the next independently reviewable layer.
+- Shared mutation evidence covers properties on exact exported object/function references, not reassignment of an ESM binding after registration. That distinction is recorded in the authoritative probe and is outside this contract.
+- No out-of-contract defects were changed.

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -243,7 +243,9 @@ export default function (pi: ExtensionAPI) {
 }
 ```
 
-Extensions are loaded via [jiti](https://github.com/unjs/jiti), so TypeScript works without compilation.
+Extensions are loaded via [jiti](https://github.com/unjs/jiti), so TypeScript works without compilation. Atomic's
+single-file Bun builds also contain an internal host-module bridge that can expose the same live host package objects
+to precompiled ESM bundles. This bridge is an optimization seam only: production extension routing still uses jiti.
 
 If the factory returns a `Promise`, Atomic awaits it before continuing startup. That means async initialization completes before `session_start`, before `resources_discover`, and before provider registrations queued via `pi.registerProvider()` are flushed.
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -243,9 +243,7 @@ export default function (pi: ExtensionAPI) {
 }
 ```
 
-Extensions are loaded via [jiti](https://github.com/unjs/jiti), so TypeScript works without compilation. Atomic's
-single-file Bun builds also contain an internal host-module bridge that can expose the same live host package objects
-to precompiled ESM bundles. This bridge is an optimization seam only: production extension routing still uses jiti.
+Extensions are loaded via [jiti](https://github.com/unjs/jiti), so TypeScript works without compilation.
 
 If the factory returns a `Promise`, Atomic awaits it before continuing startup. That means async initialization completes before `session_start`, before `resources_discover`, and before provider registrations queued via `pi.registerProvider()` are flushed.
 

--- a/packages/coding-agent/src/bun/cli.ts
+++ b/packages/coding-agent/src/bun/cli.ts
@@ -4,7 +4,7 @@ import { registerBunOAuthFlows } from "@bastani/pi-ai/bun-oauth";
 // Register before the application graph loads so Bun's standalone compiler embeds every login adapter.
 registerBunOAuthFlows();
 
-import { APP_NAME } from "../config.ts";
+import { APP_NAME } from "../config.js";
 
 process.title = APP_NAME;
 process.emitWarning = (() => {}) as typeof process.emitWarning;

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -9,7 +9,7 @@
  * attribution, and the disabled-by-default lifecycle seam. The full CLI graph
  * loads dynamically so metadata fast paths (for example `--version`) skip it.
  */
-import { APP_NAME, VERSION } from "./config.ts";
+import { APP_NAME, VERSION } from "./config.js";
 import { markLifecycleTiming } from "./core/lifecycle-timings.ts";
 import { ATOMIC_AI_AGENT } from "./utils/agent-attribution.ts";
 import { enablePersistentCompileCache } from "./utils/compile-cache.ts";

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -13,7 +13,7 @@ import {
 	ENV_SESSION_DIR,
 	ENV_SHARE_VIEWER_URL,
 	ENV_TELEMETRY,
-} from "../config.ts";
+} from "../config.js";
 import type { ExtensionFlag } from "../core/extensions/types.ts";
 
 export type Mode = "text" | "json" | "rpc";

--- a/packages/coding-agent/src/cli/auth-command.ts
+++ b/packages/coding-agent/src/cli/auth-command.ts
@@ -1,4 +1,4 @@
-import { APP_NAME } from "../config.ts";
+import { APP_NAME } from "../config.js";
 import type { Args } from "./args.ts";
 
 export type AuthCommandKind = "check" | "api_key" | "bearer_token";

--- a/packages/coding-agent/src/cli/session-picker.ts
+++ b/packages/coding-agent/src/cli/session-picker.ts
@@ -3,7 +3,7 @@
  */
 
 import { ProcessTerminal, setCapabilityOverrides, setKeybindings, TuiMainScreen } from "@earendil-works/pi-tui";
-import { getAgentDir } from "../config.ts";
+import { getAgentDir } from "../config.js";
 import { KeybindingsManager } from "../core/keybindings.ts";
 import type { SessionInfo, SessionListProgress } from "../core/session-manager.ts";
 import type { SettingsManager } from "../core/settings-manager.ts";

--- a/packages/coding-agent/src/cli/startup-ui.ts
+++ b/packages/coding-agent/src/cli/startup-ui.ts
@@ -6,7 +6,7 @@ import {
 	type TUI,
 	TuiMainScreen,
 } from "@earendil-works/pi-tui";
-import { ENV_AGENT_DIR, getAgentDir, getEnvValue, getSettingsPath } from "../config.ts";
+import { ENV_AGENT_DIR, getAgentDir, getEnvValue, getSettingsPath } from "../config.js";
 import { KeybindingsManager } from "../core/keybindings.ts";
 import type { SettingsManager } from "../core/settings-manager.ts";
 import { ExtensionInputComponent } from "../modes/interactive/components/extension-input.ts";

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import type { Api, Model } from "@bastani/pi-ai/compat";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { getAgentDir } from "../config.ts";
+import { getAgentDir } from "../config.js";
 import { resolvePath } from "../utils/paths.ts";
 import type { SessionStartEvent, ToolDefinition } from "./extensions/index.ts";
 import { withMandatoryResourceLoader } from "./mandatory-resource-loader.ts";

--- a/packages/coding-agent/src/core/auth-guidance.ts
+++ b/packages/coding-agent/src/core/auth-guidance.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { getDocsPath } from "../config.ts";
+import { getDocsPath } from "../config.js";
 
 const UNKNOWN_PROVIDER = "unknown";
 

--- a/packages/coding-agent/src/core/auth-storage-backends.ts
+++ b/packages/coding-agent/src/core/auth-storage-backends.ts
@@ -1,7 +1,7 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
-import { getAgentDir } from "../config.ts";
+import { getAgentDir } from "../config.js";
 import { normalizePath } from "../utils/paths.ts";
 import { stripBom } from "../utils/text.ts";
 import type { AuthStorageData } from "./auth-storage.ts";

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -5,7 +5,7 @@
 
 import type { AuthOperationOptions, Credential, CredentialInfo, CredentialStore } from "@bastani/pi-ai";
 import { join } from "path";
-import { getAgentConfigPaths, getAgentDir } from "../config.ts";
+import { getAgentConfigPaths, getAgentDir } from "../config.js";
 import { stripBom } from "../utils/text.ts";
 import {
 	type AuthStorageBackend,

--- a/packages/coding-agent/src/core/bash-executor.ts
+++ b/packages/coding-agent/src/core/bash-executor.ts
@@ -8,7 +8,7 @@
 
 import { randomBytes } from "node:crypto";
 import { join } from "node:path";
-import { APP_NAME } from "../config.ts";
+import { APP_NAME } from "../config.js";
 import { stripAnsi } from "../utils/ansi.ts";
 import { sanitizeBinaryOutput } from "../utils/shell.ts";
 import type { BashOperations, BashOutputChannel } from "./tools/bash.ts";

--- a/packages/coding-agent/src/core/builtin-packages.ts
+++ b/packages/coding-agent/src/core/builtin-packages.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { getPackageDir } from "../config.ts";
+import { getPackageDir } from "../config.js";
 import { moduleDirFromMetaUrl } from "../utils/split-launcher.ts";
 import { stripBom } from "../utils/text.ts";
 import { type BuiltinPackageDirName, requiredEntriesForBuiltin } from "./builtin-install-layout.ts";

--- a/packages/coding-agent/src/core/experimental.ts
+++ b/packages/coding-agent/src/core/experimental.ts
@@ -1,5 +1,5 @@
 import type { ConstrainedSamplingConfig } from "@bastani/pi-ai/compat";
-import { APP_NAME, LEGACY_ENV_PREFIX } from "../config.ts";
+import { APP_NAME, LEGACY_ENV_PREFIX } from "../config.js";
 
 export function areExperimentalFeaturesEnabled(): boolean {
 	return (

--- a/packages/coding-agent/src/core/export-html/index.ts
+++ b/packages/coding-agent/src/core/export-html/index.ts
@@ -1,7 +1,7 @@
 import type { AgentState } from "@earendil-works/pi-agent-core";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { basename, join } from "path";
-import { APP_NAME, getExportTemplateDir } from "../../config.ts";
+import { APP_NAME, getExportTemplateDir } from "../../config.js";
 import { getResolvedThemeColors, getThemeExportColors } from "../../modes/interactive/theme/theme.ts";
 import { normalizePath, resolvePath } from "../../utils/paths.ts";
 import type { ToolDefinition } from "../extensions/types.ts";

--- a/packages/coding-agent/src/core/extensions/host-module-bridge.ts
+++ b/packages/coding-agent/src/core/extensions/host-module-bridge.ts
@@ -1,5 +1,5 @@
-import { isBunBinary, isBundledBuild } from "../../config.js";
-import { getVirtualModules } from "./loader-virtual-modules.js";
+import { isBunBinary, isBundledBuild } from "../../config.ts";
+import { getVirtualModules } from "./loader-virtual-modules.ts";
 
 export interface HostModuleBridgeInstallResult {
 	installed: boolean;

--- a/packages/coding-agent/src/core/extensions/host-module-bridge.ts
+++ b/packages/coding-agent/src/core/extensions/host-module-bridge.ts
@@ -1,0 +1,64 @@
+import { isBunBinary, isBundledBuild } from "../../config.ts";
+import { getVirtualModules } from "./loader-virtual-modules.ts";
+
+export interface HostModuleBridgeInstallResult {
+	installed: boolean;
+	specifiers: string[];
+}
+
+export interface HostModuleBridgeBuilder {
+	module(specifier: string, callback: () => { exports: object; loader: "object" }): HostModuleBridgeBuilder;
+}
+
+export interface HostModuleBridgePlugin {
+	name: string;
+	setup(build: HostModuleBridgeBuilder): void;
+}
+
+interface BunHostModuleBridgeRuntime {
+	plugin(plugin: HostModuleBridgePlugin): void;
+}
+
+function getBunRuntime(): BunHostModuleBridgeRuntime | undefined {
+	return (globalThis as typeof globalThis & { Bun?: BunHostModuleBridgeRuntime }).Bun;
+}
+
+/**
+ * Create the runtime plugin that exposes the host's existing module namespace
+ * objects to external ESM bundles without evaluating a second package graph.
+ */
+export function createHostModuleBridgePlugin(modules: Record<string, object>): HostModuleBridgePlugin {
+	return {
+		name: "atomic-host-module-bridge",
+		setup(build) {
+			for (const [specifier, hostModule] of Object.entries(modules)) {
+				build.module(specifier, () => ({ exports: hostModule, loader: "object" }));
+			}
+		},
+	};
+}
+
+let installPromise: Promise<HostModuleBridgeInstallResult> | null = null;
+
+/**
+ * Register live host module objects for external precompiled ESM bundles.
+ * Production extension routing does not call this seam yet.
+ */
+export function installHostModuleBridge(): Promise<HostModuleBridgeInstallResult> {
+	const bun = getBunRuntime();
+	if (!(isBunBinary || isBundledBuild) || !bun || typeof bun.plugin !== "function") {
+		return Promise.resolve({ installed: false, specifiers: [] });
+	}
+
+	installPromise ??= getVirtualModules()
+		.then((modules) => {
+			const specifiers = Object.keys(modules);
+			bun.plugin(createHostModuleBridgePlugin(modules));
+			return { installed: true, specifiers };
+		})
+		.catch((error: Error) => {
+			installPromise = null;
+			throw error;
+		});
+	return installPromise;
+}

--- a/packages/coding-agent/src/core/extensions/host-module-bridge.ts
+++ b/packages/coding-agent/src/core/extensions/host-module-bridge.ts
@@ -1,5 +1,5 @@
-import { isBunBinary, isBundledBuild } from "../../config.ts";
-import { getVirtualModules } from "./loader-virtual-modules.ts";
+import { isBunBinary, isBundledBuild } from "../../config.js";
+import { getVirtualModules } from "./loader-virtual-modules.js";
 
 export interface HostModuleBridgeInstallResult {
 	installed: boolean;

--- a/packages/coding-agent/src/core/extensions/loader-core.ts
+++ b/packages/coding-agent/src/core/extensions/loader-core.ts
@@ -11,7 +11,7 @@ import {
 	type WorkflowResourceProviderInput,
 } from "./loader-resources.ts";
 import { createExtensionRuntime } from "./loader-runtime.ts";
-import { type ExtensionCacheToken, loadExtensionModule, useExtensionCacheCwd } from "./loader-virtual-modules.ts";
+import { type ExtensionCacheToken, loadExtensionModule, useExtensionCacheCwd } from "./loader-virtual-modules.js";
 import type { Extension, ExtensionFactory, ExtensionRuntime, LoadExtensionsResult } from "./types.ts";
 
 /** Associate extension runtimes with the event bus used to construct their APIs. */

--- a/packages/coding-agent/src/core/extensions/loader-discovery.ts
+++ b/packages/coding-agent/src/core/extensions/loader-discovery.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { CONFIG_DIR_NAME, getAgentDir } from "../../config.ts";
+import { CONFIG_DIR_NAME, getAgentDir } from "../../config.js";
 import { resolvePath } from "../../utils/paths.ts";
 import type { EventBus } from "../event-bus.ts";
 import { readPiManifestFile } from "../package-manager-manifest.ts";

--- a/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
@@ -4,7 +4,7 @@ import { createRequire } from "node:module";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import { createJiti } from "jiti/static";
-import { getExtensionTranspileCacheDir, isBunBinary, isBundledBuild } from "../../config.ts";
+import { getExtensionTranspileCacheDir, isBunBinary, isBundledBuild } from "../../config.js";
 import { resolutionBaseUrl } from "../../utils/module-require.ts";
 import { resolvePath } from "../../utils/paths.ts";
 import { moduleDirFromMetaUrl } from "../../utils/split-launcher.ts";

--- a/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
@@ -84,7 +84,7 @@ async function loadVirtualModules(): Promise<Record<string, object>> {
 }
 
 /** Modules available to extensions via virtualModules (for compiled Bun binary). */
-async function getVirtualModules(): Promise<Record<string, object>> {
+export async function getVirtualModules(): Promise<Record<string, object>> {
 	if (_virtualModules) return _virtualModules;
 	_virtualModulesPromise ??= loadVirtualModules().then(
 		(virtualModules) => {

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -15,4 +15,4 @@ export type {
 	WorkflowResourceProviderInput,
 } from "./loader-resources.ts";
 export { createExtensionRuntime } from "./loader-runtime.ts";
-export { clearExtensionCache } from "./loader-virtual-modules.ts";
+export { clearExtensionCache } from "./loader-virtual-modules.js";

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -8,7 +8,7 @@ import {
 } from "@earendil-works/pi-tui";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { getAgentDir } from "../config.ts";
+import { getAgentDir } from "../config.js";
 import { stripBom } from "../utils/text.ts";
 
 export interface AppKeybindings {

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -28,7 +28,7 @@ import {
 	type Provider,
 } from "@bastani/pi-ai";
 import * as builtinProviderCatalog from "@bastani/pi-ai/providers/all";
-import { getAgentDir } from "../config.ts";
+import { getAgentDir } from "../config.js";
 import { operationSignal, raceWithAbortSignal } from "../utils/abort.js";
 import { normalizePath } from "../utils/paths.ts";
 import { AuthStorage as DefaultAuthStorage } from "./auth-storage.ts";

--- a/packages/coding-agent/src/core/models-store.ts
+++ b/packages/coding-agent/src/core/models-store.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import type { ModelsStore, ModelsStoreEntry } from "@bastani/pi-ai";
-import { getAgentDir } from "../config.ts";
+import { getAgentDir } from "../config.js";
 import { stripBom } from "../utils/text.ts";
 import { type AuthStorageBackend, FileAuthStorageBackend } from "./auth-storage-backends.ts";
 

--- a/packages/coding-agent/src/core/package-manager-auto-resources.ts
+++ b/packages/coding-agent/src/core/package-manager-auto-resources.ts
@@ -1,5 +1,5 @@
 import { dirname, join, resolve } from "node:path";
-import { getProjectConfigDirs } from "../config.ts";
+import { getProjectConfigDirs } from "../config.js";
 import { getBaseDirsForScope, getHomeDir } from "./package-manager-paths.ts";
 import { addResource, getTargetMap } from "./package-manager-resource-accumulator.ts";
 import {

--- a/packages/coding-agent/src/core/package-manager-env.ts
+++ b/packages/coding-agent/src/core/package-manager-env.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
-import { ENV_OFFLINE, getEnvValue } from "../config.ts";
+import { ENV_OFFLINE, getEnvValue } from "../config.js";
 import { createGitEnvironment } from "../utils/git-env.ts";
 
 export function getEnv(): NodeJS.ProcessEnv {

--- a/packages/coding-agent/src/core/package-manager-git.ts
+++ b/packages/coding-agent/src/core/package-manager-git.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve, sep } from "node:path";
-import { APP_NAME, getProjectConfigDirs } from "../config.ts";
+import { APP_NAME, getProjectConfigDirs } from "../config.js";
 import type { GitSource } from "../utils/git.ts";
 import { stripBom } from "../utils/text.ts";
 import { runCommand, runCommandCapture } from "./package-manager-command.ts";

--- a/packages/coding-agent/src/core/package-manager-manifest.ts
+++ b/packages/coding-agent/src/core/package-manager-manifest.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { APP_NAME } from "../config.ts";
+import { APP_NAME } from "../config.js";
 import { stripBom } from "../utils/text.ts";
 import type { PiManifest, ResourceType } from "./package-manager-types.ts";
 

--- a/packages/coding-agent/src/core/package-manager-npm.ts
+++ b/packages/coding-agent/src/core/package-manager-npm.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { gt, maxSatisfying, rcompare, satisfies } from "semver";
-import { APP_NAME, CONFIG_DIR_NAME, getProjectConfigDirs } from "../config.ts";
+import { APP_NAME, CONFIG_DIR_NAME, getProjectConfigDirs } from "../config.js";
 import { markPathIgnoredByCloudSync } from "../utils/paths.ts";
 import { stripBom } from "../utils/text.ts";
 import { runCommand, runCommandCapture, runCommandSync } from "./package-manager-command.ts";

--- a/packages/coding-agent/src/core/package-manager-paths.ts
+++ b/packages/coding-agent/src/core/package-manager-paths.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { APP_NAME, CONFIG_DIR_NAME, getAgentDir, getAgentDirs, getProjectConfigDirs } from "../config.ts";
+import { APP_NAME, CONFIG_DIR_NAME, getAgentDir, getAgentDirs, getProjectConfigDirs } from "../config.js";
 import { resolvePath } from "../utils/paths.ts";
 import type { PackageManagerContext, SourceScope } from "./package-manager-types.ts";
 

--- a/packages/coding-agent/src/core/package-manager-resolver.ts
+++ b/packages/coding-agent/src/core/package-manager-resolver.ts
@@ -1,6 +1,6 @@
 import { access, stat } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
-import { CONFIG_DIR_NAME } from "../config.ts";
+import { CONFIG_DIR_NAME } from "../config.js";
 import { addAutoDiscoveredResources, collectProjectLocalResources } from "./package-manager-auto-resources.ts";
 import { isOfflineModeEnabled } from "./package-manager-env.ts";
 import { getExistingGitInstallPath, refreshTemporaryGitSource } from "./package-manager-git.ts";

--- a/packages/coding-agent/src/core/project-trust.ts
+++ b/packages/coding-agent/src/core/project-trust.ts
@@ -1,4 +1,4 @@
-import { APP_TITLE, CONFIG_DIR_NAME } from "../config.ts";
+import { APP_TITLE, CONFIG_DIR_NAME } from "../config.js";
 import { emitProjectTrustEvent } from "./extensions/runner.ts";
 import type { LoadExtensionsResult, ProjectTrustContext } from "./extensions/types.ts";
 import type { DefaultProjectTrust } from "./settings-manager.ts";

--- a/packages/coding-agent/src/core/prompt-templates-async.ts
+++ b/packages/coding-agent/src/core/prompt-templates-async.ts
@@ -1,6 +1,6 @@
 import { access, readdir, readFile, stat } from "node:fs/promises";
 import { basename, dirname, join, resolve, sep } from "node:path";
-import { CONFIG_DIR_NAME } from "../config.ts";
+import { CONFIG_DIR_NAME } from "../config.js";
 import { yieldToEventLoopIfSlow } from "../utils/event-loop.ts";
 import { parseFrontmatter } from "../utils/frontmatter.ts";
 import { resolvePath } from "../utils/paths.ts";

--- a/packages/coding-agent/src/core/prompt-templates.ts
+++ b/packages/coding-agent/src/core/prompt-templates.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import { basename, dirname, join, resolve, sep } from "path";
-import { CONFIG_DIR_NAME } from "../config.ts";
+import { CONFIG_DIR_NAME } from "../config.js";
 import { parseFrontmatter } from "../utils/frontmatter.ts";
 import { resolvePath } from "../utils/paths.ts";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.ts";

--- a/packages/coding-agent/src/core/provider-attribution.ts
+++ b/packages/coding-agent/src/core/provider-attribution.ts
@@ -1,5 +1,5 @@
 import type { Api, Model, ProviderHeaders } from "@bastani/pi-ai/compat";
-import { APP_NAME } from "../config.ts";
+import { APP_NAME } from "../config.js";
 import type { SettingsManager } from "./settings-manager.ts";
 import { isInstallTelemetryEnabled } from "./telemetry.ts";
 

--- a/packages/coding-agent/src/core/remote-catalog-provider.ts
+++ b/packages/coding-agent/src/core/remote-catalog-provider.ts
@@ -1,5 +1,5 @@
 import type { Api, Model, ModelsStoreEntry, Provider } from "@bastani/pi-ai";
-import { VERSION } from "../config.ts";
+import { VERSION } from "../config.js";
 import { fetchWithRetry } from "../utils/management-http.ts";
 import { getPiUserAgent } from "../utils/pi-user-agent.ts";
 

--- a/packages/coding-agent/src/core/resource-loader-assets.ts
+++ b/packages/coding-agent/src/core/resource-loader-assets.ts
@@ -1,6 +1,6 @@
 import { access, readdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
-import { getProjectConfigDirs } from "../config.ts";
+import { getProjectConfigDirs } from "../config.js";
 import { loadThemeFromContent, type Theme } from "../modes/interactive/theme/theme.ts";
 import { yieldToEventLoopIfSlow } from "../utils/event-loop.ts";
 import type { ResourceDiagnostic, ResourceOverlap } from "./diagnostics.ts";

--- a/packages/coding-agent/src/core/resource-loader-context-files.ts
+++ b/packages/coding-agent/src/core/resource-loader-context-files.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { basename, dirname, join, sep } from "node:path";
 import chalk from "chalk";
-import { getAgentDir, getAgentDirs } from "../config.ts";
+import { getAgentDir, getAgentDirs } from "../config.js";
 import { canonicalizePath, resolvePath } from "../utils/paths.ts";
 import { stripBom } from "../utils/text.ts";
 import { findGitPaths } from "./footer-data-provider.ts";

--- a/packages/coding-agent/src/core/resource-loader-discovery.ts
+++ b/packages/coding-agent/src/core/resource-loader-discovery.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { getProjectConfigDirs } from "../config.ts";
+import { getProjectConfigDirs } from "../config.js";
 import type { DefaultResourceLoader } from "./resource-loader-core.ts";
 import { resourceInternals } from "./resource-loader-internals.ts";
 import { getLoaderAgentDirs } from "./resource-loader-paths.ts";

--- a/packages/coding-agent/src/core/resource-loader-paths.ts
+++ b/packages/coding-agent/src/core/resource-loader-paths.ts
@@ -1,4 +1,4 @@
-import { getAgentDir, getAgentDirs } from "../config.ts";
+import { getAgentDir, getAgentDirs } from "../config.js";
 import { canonicalizePath, resolvePath } from "../utils/paths.ts";
 
 export function getLoaderAgentDirs(agentDir: string): string[] {

--- a/packages/coding-agent/src/core/resource-loader-source-info.ts
+++ b/packages/coding-agent/src/core/resource-loader-source-info.ts
@@ -1,6 +1,6 @@
 import { statSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
-import { getProjectConfigDirs } from "../config.ts";
+import { getProjectConfigDirs } from "../config.js";
 import type { Extension } from "./extensions/types.ts";
 import type { PathMetadata } from "./package-manager.ts";
 import type { DefaultResourceLoader } from "./resource-loader-core.ts";

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -8,7 +8,7 @@ import {
 	streamSimple,
 } from "@bastani/pi-ai/compat";
 import { Agent, type AgentMessage, setDefaultStreamFn, type ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { getAgentDir } from "../config.ts";
+import { getAgentDir } from "../config.js";
 import { resolvePath } from "../utils/paths.ts";
 import { AgentSession } from "./agent-session.ts";
 import { restoreAnthropicReplayThinkingBlocks } from "./anthropic-thinking-guard.ts";

--- a/packages/coding-agent/src/core/session-manager-core.ts
+++ b/packages/coding-agent/src/core/session-manager-core.ts
@@ -1,7 +1,7 @@
 import type { ImageContent, Message, TextContent, Usage } from "@bastani/pi-ai/compat";
 import { existsSync, statSync } from "fs";
 import { resolve } from "path";
-import { APP_TITLE } from "../config.ts";
+import { APP_TITLE } from "../config.js";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
 import type { VerbatimCompactionDetails } from "./compaction/compaction-types.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.ts";

--- a/packages/coding-agent/src/core/session-manager-list.ts
+++ b/packages/coding-agent/src/core/session-manager-list.ts
@@ -3,7 +3,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { existsSync } from "fs";
 import { readdir, readFile, stat } from "fs/promises";
 import { join } from "path";
-import { getSessionsDir } from "../config.ts";
+import { getSessionsDir } from "../config.js";
 import { yieldToEventLoopIfSlow } from "../utils/event-loop.ts";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
 import { classifiedWorkflowMetadata } from "./session-manager-classification.ts";

--- a/packages/coding-agent/src/core/session-manager-paths.ts
+++ b/packages/coding-agent/src/core/session-manager-paths.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync } from "fs";
 import { join } from "path";
-import { getAgentDir as getDefaultAgentDir } from "../config.ts";
+import { getAgentDir as getDefaultAgentDir } from "../config.js";
 import { resolvePath } from "../utils/paths.ts";
 
 /**

--- a/packages/coding-agent/src/core/settings-manager-core.ts
+++ b/packages/coding-agent/src/core/settings-manager-core.ts
@@ -4,7 +4,7 @@ import {
 	getAgentDir,
 	getCodexFastModeEnvironmentSettings,
 	getProjectConfigPaths,
-} from "../config.ts";
+} from "../config.js";
 import { parseJsonFileContent } from "../utils/json.ts";
 import { deepMergeSettings } from "./settings-merge.ts";
 import { FileSettingsStorage, InMemorySettingsStorage } from "./settings-storage.ts";

--- a/packages/coding-agent/src/core/settings-manager-ui-accessors.ts
+++ b/packages/coding-agent/src/core/settings-manager-ui-accessors.ts
@@ -1,5 +1,5 @@
 import type { ScrollViewScrollbar, TerminalCapabilities } from "@earendil-works/pi-tui";
-import { ENV_CLEAR_ON_SHRINK, ENV_HARDWARE_CURSOR, getEnvValue } from "../config.ts";
+import { ENV_CLEAR_ON_SHRINK, ENV_HARDWARE_CURSOR, getEnvValue } from "../config.js";
 import { SettingsManager } from "./settings-manager-core.ts";
 import { settingsInternals } from "./settings-manager-internals.ts";
 import type { FullscreenExitOutput, MermaidRenderingMode, WarningSettings } from "./settings-types.ts";

--- a/packages/coding-agent/src/core/settings-storage.ts
+++ b/packages/coding-agent/src/core/settings-storage.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
-import { CONFIG_DIR_NAME } from "../config.ts";
+import { CONFIG_DIR_NAME } from "../config.js";
 import { parseJsonFileContent } from "../utils/json.ts";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
 import { deepMergeSettings } from "./settings-merge.ts";

--- a/packages/coding-agent/src/core/skills-async.ts
+++ b/packages/coding-agent/src/core/skills-async.ts
@@ -1,7 +1,7 @@
 import { access, readdir, readFile, stat } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import ignore from "ignore";
-import { CONFIG_DIR_NAME, getAgentDir } from "../config.ts";
+import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
 import { yieldToEventLoopIfSlow } from "../utils/event-loop.ts";
 import { parseFrontmatter } from "../utils/frontmatter.ts";
 import { canonicalizePath, resolvePath } from "../utils/paths.ts";

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -1,7 +1,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import ignore from "ignore";
 import { basename, dirname, join, relative, resolve, sep } from "path";
-import { CONFIG_DIR_NAME, getAgentDir } from "../config.ts";
+import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
 import { parseFrontmatter } from "../utils/frontmatter.ts";
 import { canonicalizePath, resolvePath } from "../utils/paths.ts";
 import type { ResourceDiagnostic } from "./diagnostics.ts";

--- a/packages/coding-agent/src/core/slash-commands.ts
+++ b/packages/coding-agent/src/core/slash-commands.ts
@@ -1,5 +1,5 @@
 import type { AutocompleteItem } from "@earendil-works/pi-tui";
-import { APP_NAME } from "../config.ts";
+import { APP_NAME } from "../config.js";
 import {
 	ATOMIC_GUIDE_COMMAND_DESCRIPTION,
 	ATOMIC_GUIDE_COMMAND_NAME,

--- a/packages/coding-agent/src/core/system-prompt.ts
+++ b/packages/coding-agent/src/core/system-prompt.ts
@@ -2,7 +2,7 @@
  * System prompt construction and project context loading
  */
 
-import { getDocsPath, getExamplesPath, getReadmePath } from "../config.ts";
+import { getDocsPath, getExamplesPath, getReadmePath } from "../config.js";
 import { formatSkillsForPrompt, type Skill } from "./skills.ts";
 
 const DEFAULT_PROMPT_TOOLS = ["read", "bash", "edit", "write", "find", "search", "ask_user_question", "todo"] as const;

--- a/packages/coding-agent/src/core/telemetry.ts
+++ b/packages/coding-agent/src/core/telemetry.ts
@@ -1,4 +1,4 @@
-import { ENV_TELEMETRY, getEnvValue } from "../config.ts";
+import { ENV_TELEMETRY, getEnvValue } from "../config.js";
 import type { SettingsManager } from "./settings-manager.ts";
 
 function isTruthyEnvFlag(value: string | undefined): boolean {

--- a/packages/coding-agent/src/core/timings.ts
+++ b/packages/coding-agent/src/core/timings.ts
@@ -3,7 +3,7 @@
  * Enable with the app-specific timing environment variable (for Atomic, ATOMIC_TIMING=1).
  */
 
-import { ENV_TIMING, getEnvValue } from "../config.ts";
+import { ENV_TIMING, getEnvValue } from "../config.js";
 
 const ENABLED = getEnvValue(ENV_TIMING) === "1";
 

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -5,7 +5,7 @@ import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { Container, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { spawn } from "child_process";
 import { type Static, Type } from "typebox";
-import { APP_NAME } from "../../config.ts";
+import { APP_NAME } from "../../config.js";
 import { parenthesizedKeyHint } from "../../modes/interactive/components/keybinding-hints.ts";
 import { truncateToVisualLines } from "../../modes/interactive/components/visual-truncate.ts";
 import { theme } from "../../modes/interactive/theme/theme.ts";

--- a/packages/coding-agent/src/core/tools/output-accumulator.ts
+++ b/packages/coding-agent/src/core/tools/output-accumulator.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { join } from "node:path";
-import { APP_NAME } from "../../config.ts";
+import { APP_NAME } from "../../config.js";
 import { PersistedOutputFile } from "./persisted-output-file.ts";
 import { ensureSessionTempDir } from "./session-temp-dir.ts";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, type TruncationResult, truncateTail } from "./truncate.ts";

--- a/packages/coding-agent/src/core/tools/powershell.ts
+++ b/packages/coding-agent/src/core/tools/powershell.ts
@@ -1,4 +1,4 @@
-import { APP_NAME } from "../../config.ts";
+import { APP_NAME } from "../../config.js";
 import { waitForChildProcess } from "../../utils/child-process.ts";
 import {
 	getPowerShellConfig,

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -5,7 +5,7 @@ import { Text } from "@earendil-works/pi-tui";
 import { constants } from "fs";
 import { access as fsAccess, readFile as fsReadFile, stat as fsStat } from "fs/promises";
 import { type Static, Type } from "typebox";
-import { getReadmePath } from "../../config.ts";
+import { getReadmePath } from "../../config.js";
 import { parenthesizedKeyHint } from "../../modes/interactive/components/keybinding-hints.ts";
 import { getLanguageFromPath, highlightCode, type Theme } from "../../modes/interactive/theme/theme.ts";
 import { processImage } from "../../utils/image-process.ts";

--- a/packages/coding-agent/src/core/tools/session-temp-cleanup.ts
+++ b/packages/coding-agent/src/core/tools/session-temp-cleanup.ts
@@ -46,7 +46,7 @@ import {
 	writeSync,
 } from "node:fs";
 import { join } from "node:path";
-import { getAgentConfigPaths } from "../../config.ts";
+import { getAgentConfigPaths } from "../../config.js";
 import { getErrnoCode } from "./errno.ts";
 import {
 	ensureTempDir,

--- a/packages/coding-agent/src/core/tools/session-temp-dir.ts
+++ b/packages/coding-agent/src/core/tools/session-temp-dir.ts
@@ -20,7 +20,7 @@ import { createHash } from "node:crypto";
 import { chmodSync, lstatSync, mkdirSync, realpathSync, rmSync, type Stats } from "node:fs";
 import { tmpdir, userInfo } from "node:os";
 import { dirname, join, sep } from "node:path";
-import { APP_NAME } from "../../config.ts";
+import { APP_NAME } from "../../config.js";
 import { getErrnoCode } from "./errno.ts";
 import {
 	resetWindowsDirectorySecurityStateForTesting,

--- a/packages/coding-agent/src/core/tools/todos-paths.ts
+++ b/packages/coding-agent/src/core/tools/todos-paths.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { APP_NAME, CONFIG_DIR_NAME, getEnvValue } from "../../config.ts";
+import { APP_NAME, CONFIG_DIR_NAME, getEnvValue } from "../../config.js";
 
 const TODO_DIR_NAME = `${CONFIG_DIR_NAME}/todos`;
 const TODO_PATH_ENV = `${APP_NAME.toUpperCase()}_TODO_PATH`;

--- a/packages/coding-agent/src/core/trust-manager.ts
+++ b/packages/coding-agent/src/core/trust-manager.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import lockfile from "proper-lockfile";
-import { CONFIG_DIR_NAMES } from "../config.ts";
+import { CONFIG_DIR_NAMES } from "../config.js";
 import { parseJsonFileContent } from "../utils/json.ts";
 import { canonicalizePath, getHomeDir, resolvePath } from "../utils/paths.ts";
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -36,7 +36,7 @@ export {
 	setEnvValue,
 	VERSION,
 	WORKFLOW_STAGE_SUBAGENT_GUARD_ENV,
-} from "./config.ts";
+} from "./config.js";
 export {
 	AgentSession,
 	type AgentSessionConfig,

--- a/packages/coding-agent/src/main-session.ts
+++ b/packages/coding-agent/src/main-session.ts
@@ -3,7 +3,7 @@ import { ProcessTerminal, setCapabilityOverrides, setKeybindings, TuiMainScreen 
 import chalk from "chalk";
 import type { Args } from "./cli/args.ts";
 import { selectSession } from "./cli/session-picker.ts";
-import { getAgentDir } from "./config.ts";
+import { getAgentDir } from "./config.js";
 import { KeybindingsManager } from "./core/keybindings.ts";
 import { formatMissingSessionCwdPrompt, type SessionCwdIssue } from "./core/session-cwd.ts";
 import { assertValidSessionId, SessionManager } from "./core/session-manager.ts";

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -38,7 +38,7 @@ import {
 	getPackageDir,
 	setEnvValue,
 	VERSION,
-} from "./config.ts";
+} from "./config.js";
 import type { CreateAgentSessionRuntimeFactory } from "./core/agent-session-runtime.ts";
 import {
 	type AgentSessionRuntimeDiagnostic,

--- a/packages/coding-agent/src/migrations.ts
+++ b/packages/coding-agent/src/migrations.ts
@@ -5,7 +5,7 @@
 import chalk from "chalk";
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
-import { CONFIG_DIR_NAME, getAgentConfigPaths, getAgentDir, getBinDir } from "./config.ts";
+import { CONFIG_DIR_NAME, getAgentConfigPaths, getAgentDir, getBinDir } from "./config.js";
 import { migrateKeybindingsConfig } from "./core/keybindings.ts";
 import { stripBom } from "./utils/text.ts";
 

--- a/packages/coding-agent/src/modes/interactive-engine/create-isolated-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/create-isolated-runtime.ts
@@ -1,6 +1,6 @@
 import { basename } from "node:path";
 import type { Args } from "../../cli/args.ts";
-import { ENV_AGENT_DIR, getEnvValue } from "../../config.ts";
+import { ENV_AGENT_DIR, getEnvValue } from "../../config.js";
 import {
 	type AgentSessionRuntime,
 	type CreateAgentSessionRuntimeFactory,

--- a/packages/coding-agent/src/modes/interactive-engine/engine-custom-ui.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/engine-custom-ui.ts
@@ -7,7 +7,7 @@ import {
 	type TUI,
 	TuiMainScreen,
 } from "@earendil-works/pi-tui";
-import { getAgentDir } from "../../config.ts";
+import { getAgentDir } from "../../config.js";
 import { runCallback } from "../../core/callback-activity.ts";
 import type { KeybindingsManager } from "../../core/keybindings.ts";
 import type { Theme } from "../interactive/theme/theme.ts";

--- a/packages/coding-agent/src/modes/interactive-engine/engine-render-service.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/engine-render-service.ts
@@ -1,6 +1,6 @@
 import type { Terminal } from "@earendil-works/pi-tui";
 import { type TUI, TuiMainScreen } from "@earendil-works/pi-tui";
-import { getAgentDir } from "../../config.ts";
+import { getAgentDir } from "../../config.js";
 import type { AgentSession } from "../../core/agent-session.ts";
 import { runCallback } from "../../core/callback-activity.ts";
 import type { CustomMessage } from "../../core/messages.ts";

--- a/packages/coding-agent/src/modes/interactive/chat-input-actions.ts
+++ b/packages/coding-agent/src/modes/interactive/chat-input-actions.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { TUI } from "@earendil-works/pi-tui";
-import { APP_NAME } from "../../config.ts";
+import { APP_NAME } from "../../config.js";
 import { readClipboardText } from "../../utils/clipboard.ts";
 import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipboard-image.ts";
 import { editInExternalEditor, resolveExternalEditorCommand } from "./external-editor.ts";

--- a/packages/coding-agent/src/modes/interactive/components/config-selector-list.ts
+++ b/packages/coding-agent/src/modes/interactive/components/config-selector-list.ts
@@ -8,7 +8,7 @@ import {
 	matchesKey,
 	truncateToWidth,
 } from "@earendil-works/pi-tui";
-import { CONFIG_DIR_NAME } from "../../../config.ts";
+import { CONFIG_DIR_NAME } from "../../../config.js";
 import type { PathMetadata, ResolvedPaths, ResolvedResource } from "../../../core/package-manager.ts";
 import type { PackageSource, SettingsManager } from "../../../core/settings-manager.ts";
 import { theme } from "../theme/theme.ts";

--- a/packages/coding-agent/src/modes/interactive/components/config-selector-project-scope.ts
+++ b/packages/coding-agent/src/modes/interactive/components/config-selector-project-scope.ts
@@ -1,5 +1,5 @@
 import { dirname, join, relative } from "node:path";
-import { CONFIG_DIR_NAME } from "../../../config.ts";
+import { CONFIG_DIR_NAME } from "../../../config.js";
 import type { PackageSource, SettingsManager } from "../../../core/settings-manager.ts";
 import { isLocalPath, resolvePath } from "../../../utils/paths.ts";
 import type { ResourceItem, ResourceType } from "./config-selector-list.ts";

--- a/packages/coding-agent/src/modes/interactive/components/config-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/config-selector.ts
@@ -7,7 +7,7 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
-import { CONFIG_DIR_NAME } from "../../../config.ts";
+import { CONFIG_DIR_NAME } from "../../../config.js";
 import type { ResolvedPaths } from "../../../core/package-manager.ts";
 import type { SettingsManager } from "../../../core/settings-manager.ts";
 import { theme } from "../theme/theme.ts";

--- a/packages/coding-agent/src/modes/interactive/components/earendil-announcement.ts
+++ b/packages/coding-agent/src/modes/interactive/components/earendil-announcement.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import { Container, Image, Spacer, Text } from "@earendil-works/pi-tui";
-import { getBundledInteractiveAssetPath } from "../../../config.ts";
+import { getBundledInteractiveAssetPath } from "../../../config.js";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 

--- a/packages/coding-agent/src/modes/interactive/components/first-time-setup.ts
+++ b/packages/coding-agent/src/modes/interactive/components/first-time-setup.ts
@@ -1,5 +1,5 @@
 import { Container, getKeybindings, Spacer, Text } from "@earendil-works/pi-tui";
-import { APP_NAME } from "../../../config.ts";
+import { APP_NAME } from "../../../config.js";
 import { type TerminalTheme, theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyHint, rawKeyHint } from "./keybinding-hints.ts";

--- a/packages/coding-agent/src/modes/interactive/external-editor.ts
+++ b/packages/coding-agent/src/modes/interactive/external-editor.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { APP_NAME } from "../../config.ts";
+import { APP_NAME } from "../../config.js";
 import { createChildProcessEnvironment } from "../../utils/child-process.ts";
 import { stripBom } from "../../utils/text.ts";
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-deps.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-deps.ts
@@ -61,7 +61,7 @@ export {
 	getShareViewerUrl,
 	setCodexFastModeEnvironmentSettings,
 	VERSION,
-} from "../../config.ts";
+} from "../../config.js";
 export { type AgentSession, type AgentSessionEvent, parseSkillBlock } from "../../core/agent-session.ts";
 export { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.ts";
 export { formatNoModelsAvailableMessage } from "../../core/auth-guidance.ts";

--- a/packages/coding-agent/src/modes/interactive/theme/global-theme.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/global-theme.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getCustomThemesDir } from "../../../config.ts";
+import { getCustomThemesDir } from "../../../config.js";
 import { closeWatcher, isSafeFsWatchPathError, watchWithErrorHandler } from "../../../utils/fs-watch.ts";
 import { getDefaultTheme } from "./terminal-detection.ts";
 import type { Theme } from "./theme-class.ts";

--- a/packages/coding-agent/src/modes/interactive/theme/theme-loading.ts
+++ b/packages/coding-agent/src/modes/interactive/theme/theme-loading.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getCustomThemesDir, getThemesDir } from "../../../config.ts";
+import { getCustomThemesDir, getThemesDir } from "../../../config.js";
 import { type ColorMode, detectColorMode, resolveThemeColors } from "./color-utils.ts";
 import { Theme, type ThemeBg, type ThemeColor, type WorkingIndicatorTone } from "./theme-class.ts";
 import { assertThemeNameIsValid, parseThemeJsonContent } from "./theme-parse.ts";

--- a/packages/coding-agent/src/package-manager-cli-parser.ts
+++ b/packages/coding-agent/src/package-manager-cli-parser.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { APP_NAME, CONFIG_DIR_NAME } from "./config.ts";
+import { APP_NAME, CONFIG_DIR_NAME } from "./config.js";
 
 export type PackageCommand = "install" | "remove" | "update" | "list";
 

--- a/packages/coding-agent/src/package-manager-cli.ts
+++ b/packages/coding-agent/src/package-manager-cli.ts
@@ -15,7 +15,7 @@ import {
 	type SelfUpdateCommand,
 	type SelfUpdateTarget,
 	VERSION,
-} from "./config.ts";
+} from "./config.js";
 import { parseConfigCommand } from "./config-command-parser.ts";
 import { AuthStorage } from "./core/auth-storage.ts";
 import type { InlineExtension } from "./core/extensions/types.ts";

--- a/packages/coding-agent/src/rpc-entry.ts
+++ b/packages/coding-agent/src/rpc-entry.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { insertForcedOptionsBeforeTerminator } from "./cli/args.ts";
-import { APP_NAME } from "./config.ts";
+import { APP_NAME } from "./config.js";
 import { configureHttpDispatcher } from "./core/http-dispatcher.ts";
 import { main } from "./main.ts";
 import { ATOMIC_AI_AGENT } from "./utils/agent-attribution.ts";

--- a/packages/coding-agent/src/self-update-plan.ts
+++ b/packages/coding-agent/src/self-update-plan.ts
@@ -1,5 +1,5 @@
 import { Markdown } from "@earendil-works/pi-tui";
-import { APP_NAME, PACKAGE_NAME, VERSION } from "./config.ts";
+import { APP_NAME, PACKAGE_NAME, VERSION } from "./config.js";
 import { getMarkdownTheme } from "./modes/interactive/theme/theme.ts";
 import {
 	formatVersionCheckError,

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -253,4 +253,4 @@ export function getEntriesForVersion(entries: ChangelogEntry[], version: string)
 }
 
 // Re-export getChangelogPath from paths.ts for convenience
-export { getChangelogPath } from "../config.ts";
+export { getChangelogPath } from "../config.js";

--- a/packages/coding-agent/src/utils/module-require.ts
+++ b/packages/coding-agent/src/utils/module-require.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
-import { isBunBinary } from "../config.ts";
+import { isBunBinary } from "../config.js";
 
 /**
  * createRequire anchored so bare-specifier resolution works in every runtime.

--- a/packages/coding-agent/src/utils/pi-user-agent.ts
+++ b/packages/coding-agent/src/utils/pi-user-agent.ts
@@ -1,4 +1,4 @@
-import { APP_NAME } from "../config.ts";
+import { APP_NAME } from "../config.js";
 
 export function getPiUserAgent(version: string): string {
 	const runtime = process.versions.bun ? `bun/${process.versions.bun}` : `node/${process.version}`;

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { delimiter, join } from "node:path";
 import { Worker } from "node:worker_threads";
 import { spawn, spawnSync } from "child_process";
-import { getBinDir } from "../config.ts";
+import { getBinDir } from "../config.js";
 import { createChildProcessEnvironment } from "./child-process.ts";
 
 export interface ShellConfig {

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -3,7 +3,7 @@ import { chmodSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync } fro
 import { writeFile } from "fs/promises";
 import { arch, platform } from "os";
 import { join } from "path";
-import { APP_NAME, ENV_OFFLINE, getBinDir, getEnvValue } from "../config.ts";
+import { APP_NAME, ENV_OFFLINE, getBinDir, getEnvValue } from "../config.js";
 import { createChildProcessEnvironment } from "./child-process.ts";
 import { fetchWithRetry } from "./management-http.ts";
 

--- a/packages/coding-agent/src/utils/version-check.ts
+++ b/packages/coding-agent/src/utils/version-check.ts
@@ -1,5 +1,5 @@
 import { compare, valid } from "semver";
-import { ENV_OFFLINE, ENV_SKIP_VERSION_CHECK, getEnvValue, PACKAGE_NAME } from "../config.ts";
+import { ENV_OFFLINE, ENV_SKIP_VERSION_CHECK, getEnvValue, PACKAGE_NAME } from "../config.js";
 import { fetchWithRetry } from "./management-http.ts";
 
 const LATEST_VERSION_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;

--- a/packages/coding-agent/src/utils/windows-self-update.ts
+++ b/packages/coding-agent/src/utils/windows-self-update.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { copyFileSync, existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
 import { basename, dirname, join, relative, resolve, toNamespacedPath } from "node:path";
-import { APP_NAME } from "../config.ts";
+import { APP_NAME } from "../config.js";
 import { getCwdRelativePath } from "./paths.ts";
 
 const QUARANTINE_DIR_NAME = `.${APP_NAME}-native-quarantine`;

--- a/packages/coding-agent/test/extensions-host-module-bridge.test.ts
+++ b/packages/coding-agent/test/extensions-host-module-bridge.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HostModuleBridgeBuilder } from "../src/core/extensions/host-module-bridge.ts";
+
+const REAL_HOST_MODULES_TEST_TIMEOUT_MS = 120_000;
+
+type ModuleRegistration = () => { exports: object; loader: "object" };
+
+function captureRegistrations(): {
+	builder: HostModuleBridgeBuilder;
+	registrations: Map<string, ModuleRegistration>;
+} {
+	const registrations = new Map<string, ModuleRegistration>();
+	const builder: HostModuleBridgeBuilder = {
+		module(specifier, callback) {
+			registrations.set(specifier, callback);
+			return builder;
+		},
+	};
+	return { builder, registrations };
+}
+
+afterEach(() => {
+	delete process.env.ATOMIC_BUNDLED_BUILD;
+	vi.unstubAllGlobals();
+	vi.resetModules();
+});
+
+describe("Bun host-module bridge", () => {
+	it(
+		"registers every virtual module with its exact live exports object",
+		async () => {
+			const [{ createHostModuleBridgePlugin }, { getVirtualModules }] = await Promise.all([
+				import("../src/core/extensions/host-module-bridge.ts"),
+				import("../src/core/extensions/loader-virtual-modules.ts"),
+			]);
+			const modules = await getVirtualModules();
+			const { builder, registrations } = captureRegistrations();
+			createHostModuleBridgePlugin(modules).setup(builder);
+
+			expect([...registrations.keys()]).toEqual(Object.keys(modules));
+			for (const [specifier, callback] of registrations) {
+				const loaded = callback();
+				expect(loaded.loader).toBe("object");
+				expect(loaded.exports).toBe(modules[specifier]);
+			}
+
+			const lockfileExports = registrations.get("proper-lockfile")?.().exports as {
+				default?: object;
+			};
+			expect(lockfileExports.default).toBeDefined();
+			expect(lockfileExports.default).toBe((modules["proper-lockfile"] as { default?: object }).default);
+		},
+		REAL_HOST_MODULES_TEST_TIMEOUT_MS,
+	);
+
+	it("is inert outside single-file builds without touching Bun.plugin", async () => {
+		const plugin = vi.fn();
+		vi.stubGlobal("Bun", { plugin });
+		const { installHostModuleBridge } = await import("../src/core/extensions/host-module-bridge.ts");
+
+		expect(await installHostModuleBridge()).toEqual({ installed: false, specifiers: [] });
+		expect(plugin).not.toHaveBeenCalled();
+	});
+
+	it(
+		"installs only once across repeated calls",
+		async () => {
+			process.env.ATOMIC_BUNDLED_BUILD = "1";
+			const registrations = captureRegistrations();
+			const plugin = vi.fn((bridge: { setup(build: HostModuleBridgeBuilder): void }) => {
+				bridge.setup(registrations.builder);
+			});
+			vi.stubGlobal("Bun", { plugin });
+			vi.resetModules();
+			const { installHostModuleBridge } = await import("../src/core/extensions/host-module-bridge.ts");
+
+			const first = await installHostModuleBridge();
+			const second = await installHostModuleBridge();
+			expect(first.installed).toBe(true);
+			expect(second).toBe(first);
+			expect(plugin).toHaveBeenCalledTimes(1);
+			expect([...registrations.registrations.keys()]).toEqual(first.specifiers);
+		},
+		REAL_HOST_MODULES_TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"allows a retry after plugin registration fails",
+		async () => {
+			process.env.ATOMIC_BUNDLED_BUILD = "1";
+			const registrations = captureRegistrations();
+			const plugin = vi
+				.fn((bridge: { setup(build: HostModuleBridgeBuilder): void }) => bridge.setup(registrations.builder))
+				.mockImplementationOnce(() => {
+					throw new Error("registration failed");
+				});
+			vi.stubGlobal("Bun", { plugin });
+			vi.resetModules();
+			const { installHostModuleBridge } = await import("../src/core/extensions/host-module-bridge.ts");
+
+			await expect(installHostModuleBridge()).rejects.toThrow("registration failed");
+			expect((await installHostModuleBridge()).installed).toBe(true);
+			expect(plugin).toHaveBeenCalledTimes(2);
+		},
+		REAL_HOST_MODULES_TEST_TIMEOUT_MS,
+	);
+});

--- a/research/evidence/native-builtin-host-bridge/bun-compiled-plugin-probe.md
+++ b/research/evidence/native-builtin-host-bridge/bun-compiled-plugin-probe.md
@@ -1,0 +1,439 @@
+# Authoritative compiled-binary host bridge probe
+
+## Environment
+
+- Bun: `1.4.0`
+- OS/architecture: `Darwin arm64` (`uname -sm` => `Darwin arm64`)
+- Repository branch: `perf/native-builtin-host-bridge`
+- Scratch directory: `/tmp/atomic-host-bridge-probe`
+- No tracked repository file was modified.
+
+## Result table
+
+| # | Answer | Evidence |
+|---|---|---|
+| 1 | **NO, for the requested onResolve/onLoad chain.** | In both a single-entry compiled executable and the production-shaped split executable, the plugin setup ran and `onResolve` saw the top-level external file path, but the external file's transitive bare imports bypassed `onResolve`; execution exited 1 with `Cannot find module '@bastani/getter'`. Thus runtime plugin registration exists, but the requested end-to-end external-module bridge does not work through `onResolve`/`onLoad`. |
+| 2 | **NO.** | The catch-all `onResolve({filter: /.*/})` printed three resolutions for the external file path and printed no resolution for `@bastani/getter`; Bun then emitted `Cannot find module '@bastani/getter'`. |
+| 3 | **N/A for onResolve/onLoad; YES through `build.module`.** | `onLoad` is unreachable because the bare specifier is not sent to `onResolve`. The adjacent supported `build.module` API delivered `named-value` correctly in all compiled shapes. |
+| 4 | **N/A for onResolve/onLoad; YES through `build.module`.** | `build.module` surfaced an object literal's `default` key to `import def`, with `sameDefault=true`. Passing the real `node:path` namespace directly also surfaced its default with `pathDefaultIdentity=true`. |
+| 5 | **N/A for onResolve/onLoad; YES through `build.module`.** | The external module and host both reported exact reference identity: `sameNamed=true`, `sameDefault=true`, `nsSame=true`, `pathNamedIdentity=true`, `pathDefaultIdentity=true`; host-side checks reported `shared=true default=true getter=true`. |
+| 6 | **N/A for onResolve/onLoad; YES through `build.module`.** | After import, host mutation produced `HOST to external=host-mutated`; external mutation produced `EXTERNAL to host=external-mutated`. |
+| 7 | **N/A for onResolve/onLoad; YES through `build.module`, without spreading/copying.** | The callback returned the real `await import("node:path")` namespace as `exports` and both named/default identity checks were true. A non-plain object with an enumerable getter also worked; the getter was read once (`getterReads=1`) and yielded the exact shared object. No error occurred and no spread was required. This proves object identity of exported values, not ongoing ESM binding reassignment after registration. |
+| 8 | **NO for onResolve/onLoad, with and without bytecode; YES for `build.module`, with and without bytecode.** | Both `final-single-no-bytecode` and `final-single-bytecode` failed identically in onResolve mode and passed identically in builder-module mode. The bytecode split launcher also passed with `build.module`. |
+| 9 | **YES, registration ordering matters.** | Import before registration failed with `Cannot find package '@bastani/order'`; a distinct external module imported after registration returned `ORDER after=registered`. Registration from bundled sibling `app.js` worked in the split executable when using `build.module`. |
+| 10 | **YES: `build.module` works. `target` does not repair onResolve/onLoad. bunfig preload can embed a working `build.module` registration; `--preload` is not a compile-time embedding surface in the tested forms.** | `build.module` passed in single/split, bytecode/non-bytecode executions. `PROBE_TARGET=bun` still failed under onResolve/onLoad; `build.module` passed with both `target=bun` and `target=node`, so the option was accepted but did not alter observed behavior. A `bunfig.toml` preload was embedded and produced `PRELOAD_RESULT preloaded-module identity=true`. `bun build --compile --preload=<file>` and `bun --preload=<file> build --compile ...` built successfully but their executables did not run the preload and failed resolving `@bastani/preload`. |
+
+## Verdict
+
+**The runtime `Bun.plugin` onResolve/onLoad object-module surface is falsified for this use because, inside Bun 1.4.0 compiled binaries, the catch-all `onResolve` sees the dynamic import of the external file but does not see that external file's transitive bare imports, so `onLoad` cannot supply the host objects.** This is identical in the single-entry and production-shaped split/bytecode executables.
+
+An adjacent supported runtime surface, `build.module(specifier, callback)`, **is proven to work** in the same compiled binaries and provides named/default exports, direct real ESM namespace objects, exact exported-object identity, and bidirectional shared-object mutation. It also works when registered from the bundled `app.js` sidecar and survives `--bytecode`.
+
+If a build-time alternative were nevertheless required, the smallest identity-preserving form demonstrated by these semantics would be to rewrite the extension bundle's host-package imports at extension build time to embedded shim modules whose exported constants read references from a host-populated `globalThis[Symbol.for(...)]` registry before the external bundle is imported. That preserves reference identity and shared-object mutation without copying package state. This build-time alternative was not implemented or executed because the supported runtime `build.module` surface succeeded.
+
+No numbered question remains unanswered. The one limitation explicitly distinguished above is that mutation testing covers properties of shared exported objects; it does not claim that reassigning a host ESM binding after `build.module` registration becomes a live ESM binding in the external module.
+
+## Fixture files (full text)
+
+### `entry.ts`
+
+```ts
+void (async () => {
+const external = process.argv[2];
+if (!external) throw new Error("missing external path");
+const shared = { value: "initial" };
+const defaultValue = { label: "default-object" };
+const hostNamespace = await import("node:path");
+let getterReads = 0;
+const getterExports = Object.defineProperty({}, "getterShared", { enumerable: true, get() { getterReads++; return shared; } });
+Object.assign(globalThis, {
+  __probeHostShared: shared,
+  __probeHostDefault: defaultValue,
+  __probeHostNamespace: hostNamespace,
+});
+const mode = process.env.PROBE_MODE ?? "plugin";
+const plugin = {
+  name: "atomic-host-bridge",
+  ...(process.env.PROBE_TARGET ? { target: process.env.PROBE_TARGET } : {}),
+  setup(build: any) {
+    console.log(`PLUGIN setup target=${process.env.PROBE_TARGET ?? "unset"}`);
+    if (mode === "builder-module") {
+      build.module("@bastani/atomic", () => ({
+        exports: { default: defaultValue, shared, named: "named-value", hostNamespace },
+        loader: "object",
+      }));
+      build.module("@bastani/path-namespace", () => ({ exports: hostNamespace, loader: "object" }));
+      build.module("@bastani/getter", () => ({ exports: getterExports, loader: "object" }));
+      return;
+    }
+    build.onResolve({ filter: /.*/ }, (args: any) => {
+      console.log(`RESOLVE ${args.path}`);
+      if (["@bastani/atomic", "@bastani/path-namespace", "@bastani/late"].includes(args.path)) return { path: args.path, namespace: "atomic-host" };
+      return undefined;
+    });
+    build.onLoad({ filter: /.*/, namespace: "atomic-host" }, (args: any) => {
+      console.log(`LOAD ${args.path}`);
+      if (args.path === "@bastani/path-namespace") return { exports: hostNamespace, loader: "object" };
+      return { exports: { default: defaultValue, shared, named: "named-value", hostNamespace }, loader: "object" };
+    });
+  },
+};
+Bun.plugin(plugin);
+const extension = await import(`${external}?mode=${mode}&target=${process.env.PROBE_TARGET ?? ""}`);
+console.log(`HOST identities shared=${Object.is(extension.importedShared, shared)} default=${Object.is(extension.importedDefault, defaultValue)} getter=${Object.is(extension.importedGetter, shared)} getterReads=${getterReads}`);
+shared.value = "host-mutated";
+console.log(`HOST to external=${extension.readShared()}`);
+extension.mutateShared("external-mutated");
+console.log(`EXTERNAL to host=${shared.value}`);
+})();
+```
+
+### `external.mjs`
+
+```js
+import { getterShared } from "@bastani/getter";
+import bridgeDefault, { shared, named, hostNamespace } from "@bastani/atomic";
+import pathDefault, { posix, delimiter } from "@bastani/path-namespace";
+
+console.log(`EXT named=${named} default=${bridgeDefault.label} sameNamed=${Object.is(shared, globalThis.__probeHostShared)} sameDefault=${Object.is(bridgeDefault, globalThis.__probeHostDefault)} nsSame=${Object.is(hostNamespace, globalThis.__probeHostNamespace)} pathPosix=${posix.sep} pathNamedIdentity=${Object.is(posix, globalThis.__probeHostNamespace.posix)} pathDefaultIdentity=${Object.is(pathDefault, globalThis.__probeHostNamespace.default)} delimiter=${delimiter}`);
+export function readShared() { return shared.value; }
+export function mutateShared(value) { shared.value = value; }
+export const importedDefault = bridgeDefault;
+export const importedShared = shared;
+export const importedGetter = getterShared;
+```
+
+### `app-entry.ts`
+
+```ts
+void import("./entry.ts");
+```
+
+### `split-loader.ts`
+
+```ts
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+void import(pathToFileURL(join(dirname(process.execPath), "app.js")).href);
+```
+
+### `ordering.ts`
+
+```ts
+void (async () => {
+try { await import(process.argv[2]); } catch (error) { console.log(`ORDER before=${String(error)}`); }
+const shared = { value: "registered" };
+Bun.plugin({ name: "order", setup(build) { console.log("ORDER setup"); build.module("@bastani/order", () => ({ exports: { shared }, loader: "object" })); }});
+const after = await import(process.argv[3]);
+console.log(`ORDER after=${after.value}`);
+})();
+```
+
+### `order-before.mjs`
+
+```js
+import { shared } from "@bastani/order";
+export const value = shared.value;
+```
+
+### `order-after.mjs`
+
+```js
+import { shared } from "@bastani/order";
+export const value = shared.value;
+```
+
+### `preload-module.ts`
+
+```ts
+const shared = { value: "preloaded-module" };
+(globalThis as any).__preloadedShared = shared;
+Bun.plugin({ name: "preload-module-bridge", setup(build) {
+  console.log("PRELOAD_MODULE setup");
+  build.module("@bastani/preload", () => ({ exports: { shared }, loader: "object" }));
+}});
+```
+
+### `preload-entry.ts`
+
+```ts
+void (async () => {
+const mod = await import(process.argv[2]);
+console.log(`PRELOAD_RESULT ${mod.result} identity=${Object.is(mod.shared, (globalThis as any).__preloadedShared)}`);
+})();
+```
+
+### `preload-external.mjs`
+
+```js
+import { shared } from "@bastani/preload";
+export { shared };
+export const result = shared.value;
+```
+
+### `bunfig.toml` (working preload case)
+
+```toml
+preload = ["./preload-module.ts"]
+```
+
+## Exact commands and observed outputs
+
+All build commands below were run from `/Users/tonystark/Documents/projects/atomic-native-builtin-host-bridge` unless the command explicitly starts with `cd /tmp/atomic-host-bridge-probe`.
+
+### Version/platform
+
+```text
+$ bun --version
+EXIT 0
+STDOUT:
+1.4.0
+STDERR:
+
+$ uname -sm
+EXIT 0
+STDOUT:
+Darwin arm64
+STDERR:
+```
+
+### Single-entry compiled executable, onResolve/onLoad, without bytecode
+
+```text
+$ bun build --compile --format=cjs --no-compile-autoload-dotenv --no-compile-autoload-bunfig /tmp/atomic-host-bridge-probe/entry.ts --outfile /tmp/atomic-host-bridge-probe/final-single-no-bytecode
+EXIT 0
+STDOUT:
+   [9ms]  bundle  1 modules
+  [83ms] compile  /tmp/atomic-host-bridge-probe/final-single-no-bytecode
+STDERR:
+
+$ /tmp/atomic-host-bridge-probe/final-single-no-bytecode /tmp/atomic-host-bridge-probe/external.mjs
+EXIT 1
+STDOUT:
+PLUGIN setup target=unset
+RESOLVE /tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target=
+RESOLVE /private/tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target=
+RESOLVE /private/tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target=
+STDERR:
+error: Cannot find module '@bastani/getter' from '/private/tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target='
+
+Bun v1.4.0 (macOS arm64)
+```
+
+### Single-entry compiled executable, onResolve/onLoad, with bytecode
+
+```text
+$ bun build --compile --bytecode --format=cjs --no-compile-autoload-dotenv --no-compile-autoload-bunfig /tmp/atomic-host-bridge-probe/entry.ts --outfile /tmp/atomic-host-bridge-probe/final-single-bytecode
+EXIT 0
+STDOUT:
+   [5ms]  bundle  1 modules
+  [64ms] compile  /tmp/atomic-host-bridge-probe/final-single-bytecode
+STDERR:
+
+$ /tmp/atomic-host-bridge-probe/final-single-bytecode /tmp/atomic-host-bridge-probe/external.mjs
+EXIT 1
+STDOUT:
+PLUGIN setup target=unset
+RESOLVE /tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target=
+RESOLVE /private/tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target=
+RESOLVE /private/tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target=
+STDERR:
+error: Cannot find module '@bastani/getter' from '/private/tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target='
+
+Bun v1.4.0 (macOS arm64)
+```
+
+### Single-entry compiled executable, working `build.module`, without and with bytecode
+
+```text
+$ env PROBE_MODE=builder-module /tmp/atomic-host-bridge-probe/final-single-no-bytecode /tmp/atomic-host-bridge-probe/external.mjs
+EXIT 0
+STDOUT:
+PLUGIN setup target=unset
+EXT named=named-value default=default-object sameNamed=true sameDefault=true nsSame=true pathPosix=/ pathNamedIdentity=true pathDefaultIdentity=true delimiter=:
+HOST identities shared=true default=true getter=true getterReads=1
+HOST to external=host-mutated
+EXTERNAL to host=external-mutated
+STDERR:
+
+$ env PROBE_MODE=builder-module /tmp/atomic-host-bridge-probe/final-single-bytecode /tmp/atomic-host-bridge-probe/external.mjs
+EXIT 0
+STDOUT:
+PLUGIN setup target=unset
+EXT named=named-value default=default-object sameNamed=true sameDefault=true nsSame=true pathPosix=/ pathNamedIdentity=true pathDefaultIdentity=true delimiter=:
+HOST identities shared=true default=true getter=true getterReads=1
+HOST to external=host-mutated
+EXTERNAL to host=external-mutated
+STDERR:
+```
+
+### Production-shaped split launcher/sidecar, exact flags, with bytecode
+
+```text
+$ bun build --target=bun --format=cjs /tmp/atomic-host-bridge-probe/app-entry.ts --outfile /tmp/atomic-host-bridge-probe/app.js
+EXIT 0
+STDOUT:
+Bundled 2 modules in 3ms
+
+  app.js  3.30 KB  (entry point)
+
+STDERR:
+
+$ bun build --compile --bytecode --format=cjs --no-compile-autoload-dotenv --no-compile-autoload-bunfig /tmp/atomic-host-bridge-probe/split-loader.ts --outfile /tmp/atomic-host-bridge-probe/final-split-bytecode
+EXIT 0
+STDOUT:
+   [3ms]  bundle  1 modules
+  [57ms] compile  /tmp/atomic-host-bridge-probe/final-split-bytecode
+STDERR:
+
+$ /tmp/atomic-host-bridge-probe/final-split-bytecode /tmp/atomic-host-bridge-probe/external.mjs
+EXIT 1
+STDOUT:
+PLUGIN setup target=unset
+RESOLVE /tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target=
+RESOLVE /private/tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target=
+RESOLVE /private/tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target=
+STDERR:
+error: Cannot find module '@bastani/getter' from '/private/tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target='
+
+Bun v1.4.0 (macOS arm64)
+
+$ env PROBE_MODE=builder-module /tmp/atomic-host-bridge-probe/final-split-bytecode /tmp/atomic-host-bridge-probe/external.mjs
+EXIT 0
+STDOUT:
+PLUGIN setup target=unset
+EXT named=named-value default=default-object sameNamed=true sameDefault=true nsSame=true pathPosix=/ pathNamedIdentity=true pathDefaultIdentity=true delimiter=:
+HOST identities shared=true default=true getter=true getterReads=1
+HOST to external=host-mutated
+EXTERNAL to host=external-mutated
+STDERR:
+```
+
+The same split sidecar was also run through a launcher compiled without `--bytecode`:
+
+```text
+$ bun build --compile --format=cjs --no-compile-autoload-dotenv --no-compile-autoload-bunfig /tmp/atomic-host-bridge-probe/split-loader.ts --outfile /tmp/atomic-host-bridge-probe/split-no-bytecode
+EXIT 0
+STDOUT:
+   [3ms]  bundle  1 modules
+  [64ms] compile  /tmp/atomic-host-bridge-probe/split-no-bytecode
+STDERR:
+
+$ env PROBE_MODE=builder-module /tmp/atomic-host-bridge-probe/split-no-bytecode /tmp/atomic-host-bridge-probe/external.mjs
+EXIT 0
+STDOUT:
+PLUGIN setup target=unset
+EXT named=named-value default=default-object sameNamed=true sameDefault=true nsSame=true pathPosix=/ delimiter=:
+HOST identities shared=true default=true
+HOST to external=host-mutated
+EXTERNAL to host=external-mutated
+STDERR:
+```
+
+(The no-bytecode split execution preceded the additional namespace-default/getter assertions; the final bytecode and both final single-entry runs include those stronger assertions.)
+
+### Registration ordering
+
+```text
+$ bun build --compile --bytecode --format=cjs --no-compile-autoload-dotenv --no-compile-autoload-bunfig /tmp/atomic-host-bridge-probe/ordering.ts --outfile /tmp/atomic-host-bridge-probe/ordering
+EXIT 0
+STDOUT:
+   [5ms]  bundle  1 modules
+  [64ms] compile  /tmp/atomic-host-bridge-probe/ordering
+STDERR:
+
+$ /tmp/atomic-host-bridge-probe/ordering /tmp/atomic-host-bridge-probe/order-before.mjs /tmp/atomic-host-bridge-probe/order-after.mjs
+EXIT 0
+STDOUT:
+ORDER before=ResolveMessage: Cannot find package '@bastani/order' imported from /private/tmp/atomic-host-bridge-probe/order-before.mjs
+ORDER setup
+ORDER after=registered
+STDERR:
+```
+
+### Plugin `target` option
+
+```text
+$ env PROBE_TARGET=bun /tmp/atomic-host-bridge-probe/single-no-bytecode /tmp/atomic-host-bridge-probe/external.mjs
+EXIT 1
+STDOUT:
+PLUGIN setup target=bun
+STDERR:
+error: Cannot find module '@bastani/atomic' from '/private/tmp/atomic-host-bridge-probe/external.mjs?mode=plugin&target=bun'
+
+Bun v1.4.0 (macOS arm64)
+
+$ env PROBE_MODE=builder-module PROBE_TARGET=bun /tmp/atomic-host-bridge-probe/single-getter /tmp/atomic-host-bridge-probe/external.mjs
+EXIT 0
+STDOUT:
+PLUGIN setup target=bun
+EXT named=named-value default=default-object sameNamed=true sameDefault=true nsSame=true pathPosix=/ pathNamedIdentity=true pathDefaultIdentity=true delimiter=:
+HOST identities shared=true default=true getter=true getterReads=1
+HOST to external=host-mutated
+EXTERNAL to host=external-mutated
+STDERR:
+
+$ env PROBE_MODE=builder-module PROBE_TARGET=node /tmp/atomic-host-bridge-probe/single-getter /tmp/atomic-host-bridge-probe/external.mjs
+EXIT 0
+STDOUT:
+PLUGIN setup target=node
+EXT named=named-value default=default-object sameNamed=true sameDefault=true nsSame=true pathPosix=/ pathNamedIdentity=true pathDefaultIdentity=true delimiter=:
+HOST identities shared=true default=true getter=true getterReads=1
+HOST to external=host-mutated
+EXTERNAL to host=external-mutated
+STDERR:
+```
+
+### Preload surfaces
+
+Working bunfig preload (build run from the scratch directory):
+
+```text
+$ cd /tmp/atomic-host-bridge-probe && bun build --compile --format=cjs ./preload-entry.ts --outfile ./preload-module-bunfig
+EXIT 0
+STDOUT:
+   [4ms]  bundle  1 modules
+  [71ms] compile  ./preload-module-bunfig
+STDERR:
+
+$ /tmp/atomic-host-bridge-probe/preload-module-bunfig /tmp/atomic-host-bridge-probe/preload-external.mjs
+EXIT 0
+STDOUT:
+PRELOAD_MODULE setup
+PRELOAD_RESULT preloaded-module identity=true
+STDERR:
+```
+
+`--preload` forms did not embed the preload into the resulting executable:
+
+```text
+$ bun build --compile --preload=/tmp/atomic-host-bridge-probe/preload-module.ts --format=cjs /tmp/atomic-host-bridge-probe/preload-entry.ts --outfile /tmp/atomic-host-bridge-probe/preload-equals
+EXIT 0
+STDOUT:
+   [8ms]  bundle  1 modules
+  [83ms] compile  /tmp/atomic-host-bridge-probe/preload-equals
+STDERR:
+
+$ /tmp/atomic-host-bridge-probe/preload-equals /tmp/atomic-host-bridge-probe/preload-external.mjs
+EXIT 1
+STDOUT:
+STDERR:
+error: Cannot find module '@bastani/preload' from '/private/tmp/atomic-host-bridge-probe/preload-external.mjs'
+
+Bun v1.4.0 (macOS arm64)
+
+$ bun --preload=/tmp/atomic-host-bridge-probe/preload-module.ts build --compile --format=cjs /tmp/atomic-host-bridge-probe/preload-entry.ts --outfile /tmp/atomic-host-bridge-probe/preload-global
+EXIT 0
+STDOUT:
+   [2ms]  bundle  1 modules
+  [58ms] compile  /tmp/atomic-host-bridge-probe/preload-global
+STDERR:
+
+$ /tmp/atomic-host-bridge-probe/preload-global /tmp/atomic-host-bridge-probe/preload-external.mjs
+EXIT 1
+STDOUT:
+STDERR:
+error: Cannot find module '@bastani/preload' from '/private/tmp/atomic-host-bridge-probe/preload-external.mjs'
+
+Bun v1.4.0 (macOS arm64)
+```

--- a/research/evidence/native-builtin-host-bridge/implementation-validation.md
+++ b/research/evidence/native-builtin-host-bridge/implementation-validation.md
@@ -18,6 +18,11 @@ Implemented the first independently reviewable Bun-runtime host-module bridge la
 
 The interface preserves `Object.keys()` insertion order, does not normalize or deduplicate specifiers, and returns a mutable `string[]` as requested. The omitted/inert result uses an empty list. Duplicate handling is inherited verbatim from the existing `Record<string, object>` host map, whose keys are unique by JavaScript object semantics.
 
+Production relative imports follow the repository's `.js` specifier convention. The spelling-neutral
+`module-import-specifier-consistency` test requires every importer of a resolved module to use one spelling, so the
+bridge could not adopt `.js` for `config` and `loader-virtual-modules` in isolation. Every production importer of those
+two modules migrated together; no other module's specifiers changed.
+
 ## Commands and outcomes
 
 - `npm ci --ignore-scripts` — exit 0; installed 554 packages.
@@ -29,6 +34,7 @@ The interface preserves `Object.keys()` insertion order, does not normalize or d
 - `npm run build --workspace=@bastani/atomic` — exit 0; produced the documented built-package fixtures.
 - Second `npm run test:unit` — exit 0; 723 files and 7265 tests passed, 23 skipped.
 - `npm run test:ci-contracts` — exit 0; 14 files and 75 tests passed.
+- `npx vitest --run --project unit test/unit/module-import-specifier-consistency.test.ts` — exit 0; 1 file and 1 test passed after the `.js` migration closed both target-module spelling groups.
 - `npm run check` — exit 0; Biome completed with one pre-existing informational `noUselessStringRaw` diagnostic in `test/ci/ci-workflow-contracts.test.ts`; both root `tsc` and coding-agent `tsgo` typechecks passed; shrinkwrap was current.
 - Commit hook reran repository checks successfully before creating `83176a3bf0`.
 

--- a/research/evidence/native-builtin-host-bridge/implementation-validation.md
+++ b/research/evidence/native-builtin-host-bridge/implementation-validation.md
@@ -9,7 +9,7 @@ Implemented the first independently reviewable Bun-runtime host-module bridge la
 | Criterion | Current-checkout evidence |
 |---|---|
 | Reuse exact live host module objects without duplicate package state | `host-module-bridge.ts` imports the existing memoized `getVirtualModules()` accessor; `extensions-host-module-bridge.test.ts` proves every registered specifier matches the map and every callback's `exports` is reference-identical with `toBe`. |
-| Real compiled-launcher boundary with an external precompiled ESM bundle | `test/ci/extension-host-module-bridge-boundary.test.ts` builds `extension.mjs` via `bun build --target=bun --format=esm --external=proper-lockfile`, asserts its bare import remains, builds the CJS sidecar, compiles a bytecode split launcher, and runs it. It proves named/default exports, `Object.is` identity, and mutation in both directions. |
+| Real compiled-launcher boundary with an external precompiled ESM bundle | `test/ci/extension-host-module-bridge-boundary.test.ts` keeps bare imports for `proper-lockfile`, `@bastani/atomic`, `@bastani/pi-ai`, and `@earendil-works/pi-ai`, builds the CJS sidecar, compiles a bytecode split launcher, and runs it. It proves CommonJS default/named identity, first-party ESM named-export identity and bidirectional shared mutation, and shared identity across the two pi-ai aliases. |
 | Production routing unchanged | The only edit to `loader-virtual-modules.ts` exports `getVirtualModules`; search finds `installHostModuleBridge` only in its definition and tests. `loadExtensionModule`, `loadTransformedExtensionModule`, and `importExtensionModule` control flow are unchanged. |
 | Node/npm and source checkout unchanged | Installer returns `{ installed: false, specifiers: [] }` unless `isBunBinary || isBundledBuild` and a callable Bun plugin runtime exists. Unit coverage proves the ordinary Node test environment never invokes `Bun.plugin`. |
 | Idempotent and retryable | Unit coverage proves two installs return the same result and register once; a registration failure clears the memo and a second call succeeds. |
@@ -42,6 +42,8 @@ npx vitest --run --project ci test/ci/extension-host-module-bridge-boundary.test
 
 It exited 1. The compiled executable exited 1 with stderr `host bridge did not install exactly once`, and the Vitest assertion reported `1 !== 0` at the startup exit-code check. The source was restored from a byte-for-byte saved copy; the same focused boundary command then exited 0 with 1 test passed. This proves the executable scenario cannot pass with the bridge disabled.
 
+The broadened first-party path was also negative-controlled by temporarily comparing the external `@bastani/atomic` `createEventBus` export with a shallow copy of the host function. The focused boundary test exited 1 with `AssertionError: @bastani/atomic named export identity changed`. Restoring the source byte-for-byte made the same command exit 0 with one test passed.
+
 ## Files changed
 
 - `packages/coding-agent/src/core/extensions/host-module-bridge.ts`
@@ -50,6 +52,7 @@ It exited 1. The compiled executable exited 1 with stderr `host bridge did not i
 - `test/ci/extension-host-module-bridge-boundary.test.ts`
 - `packages/coding-agent/docs/extensions.md`
 - `research/evidence/native-builtin-host-bridge/bun-compiled-plugin-probe.md`
+- `research/evidence/native-builtin-host-bridge/implementation-validation.md`
 
 ## Risks and deferred work
 

--- a/research/evidence/native-builtin-host-bridge/implementation-validation.md
+++ b/research/evidence/native-builtin-host-bridge/implementation-validation.md
@@ -42,7 +42,36 @@ npx vitest --run --project ci test/ci/extension-host-module-bridge-boundary.test
 
 It exited 1. The compiled executable exited 1 with stderr `host bridge did not install exactly once`, and the Vitest assertion reported `1 !== 0` at the startup exit-code check. The source was restored from a byte-for-byte saved copy; the same focused boundary command then exited 0 with 1 test passed. This proves the executable scenario cannot pass with the bridge disabled.
 
-The broadened first-party path was also negative-controlled by temporarily comparing the external `@bastani/atomic` `createEventBus` export with a shallow copy of the host function. The focused boundary test exited 1 with `AssertionError: @bastani/atomic named export identity changed`. Restoring the source byte-for-byte made the same command exit 0 with one test passed.
+The original validation report incorrectly described comparing the external `@bastani/atomic` `createEventBus`
+export with `{ ...createEventBus }` as an identity negative control. That comparison is vacuous: spreading a function
+produces a plain object, so it only proves that the function is not that unrelated object. The meaningful
+namespace-container variant does not break the boundary test either: spreading a host namespace changes its container
+identity while retaining the same exported function and object references, which are the identities the boundary test
+checks.
+
+A genuine value-identity control temporarily changed the `@bastani/atomic` registration so its `createEventBus` export
+was a fresh wrapper function that delegated to the host function. The focused command exited 1 with:
+
+```text
+FAIL  |ci| test/ci/extension-host-module-bridge-boundary.test.ts > compiled launcher exposes exact live host modules to an external ESM bundle
+AssertionError: @bastani/atomic named export identity changed
+
+1 !== 0
+
+Test Files  1 failed (1)
+Tests  1 failed (1)
+```
+
+The temporary implementation change was then restored byte-for-byte (`sha256` before and after:
+`9de9bee75f353b8ebf6ccc35b20fc76fe6faa1c667abbaa07174f39664b0d713`). Re-running the same command exited 0:
+
+```text
+Test Files  1 passed (1)
+Tests  1 passed (1)
+```
+
+This control breaks the exported value's reference identity rather than only replacing its namespace container, so it
+demonstrates that the compiled-boundary assertion detects value-identity loss.
 
 ## Files changed
 

--- a/test/ci/extension-host-module-bridge-boundary.test.ts
+++ b/test/ci/extension-host-module-bridge-boundary.test.ts
@@ -39,11 +39,18 @@ test(
 			writeTextSync(
 				join(fixture, "extension-entry.ts"),
 				'import lockfile, { lock } from "proper-lockfile";\n' +
+					'import { createEventBus } from "@bastani/atomic";\n' +
+					'import { StringEnum as bastaniStringEnum } from "@bastani/pi-ai";\n' +
+					'import { StringEnum as earendilStringEnum } from "@earendil-works/pi-ai";\n' +
 					"export const importedDefault = lockfile;\n" +
 					"export const importedNamed = lock;\n" +
+					"export const importedCreateEventBus = createEventBus;\n" +
+					"export const aliasesShareExport = Object.is(bastaniStringEnum, earendilStringEnum);\n" +
 					"export const namedType = typeof lock;\n" +
 					'export function readHostMutation(): string { return (lockfile as { bridgeMarker?: string }).bridgeMarker ?? ""; }\n' +
-					'export function mutateNamed(): void { (lock as { bridgeMarker?: string }).bridgeMarker = "external-mutated"; }\n',
+					'export function readAtomicHostMutation(): string { return (createEventBus as { bridgeMarker?: string }).bridgeMarker ?? ""; }\n' +
+					'export function mutateNamed(): void { (lock as { bridgeMarker?: string }).bridgeMarker = "external-mutated"; }\n' +
+					'export function mutateAtomicNamed(): void { (createEventBus as { bridgeMarker?: string }).bridgeMarker = "external-mutated"; }\n',
 			);
 			writeTextSync(
 				join(fixture, "app-entry.ts"),
@@ -56,14 +63,24 @@ test(
 					'  if (!firstInstall.installed || secondInstall !== firstInstall || !firstInstall.specifiers.includes("proper-lockfile")) throw new Error("host bridge did not install exactly once");\n' +
 					"  const modules = await getVirtualModules();\n" +
 					'  const host = modules["proper-lockfile"] as { default: { bridgeMarker?: string }; lock: { bridgeMarker?: string } };\n' +
+					'  const atomicHost = modules["@bastani/atomic"] as { createEventBus: { bridgeMarker?: string } };\n' +
 					"  const extension = await import(extensionPath);\n" +
-					'  if (extension.namedType !== "function") throw new Error("named export missing");\n' +
-					'  if (!Object.is(extension.importedDefault, host.default)) throw new Error("default export identity changed");\n' +
-					'  if (!Object.is(extension.importedNamed, host.lock)) throw new Error("named export identity changed");\n' +
+					'  if (extension.namedType !== "function") throw new Error("proper-lockfile named export missing");\n' +
+					'  if (!Object.is(extension.importedDefault, host.default)) throw new Error("proper-lockfile default export identity changed");\n' +
+					'  if (!Object.is(extension.importedNamed, host.lock)) throw new Error("proper-lockfile named export identity changed");\n' +
+					'  if (!Object.is(extension.importedCreateEventBus, atomicHost.createEventBus)) throw new Error("@bastani/atomic named export identity changed");\n' +
+					'  if (!extension.aliasesShareExport) throw new Error("pi-ai aliases duplicated host state");\n' +
 					'  host.default.bridgeMarker = "host-mutated";\n' +
-					'  if (extension.readHostMutation() !== "host-mutated") throw new Error("host mutation was not shared");\n' +
+					'  if (extension.readHostMutation() !== "host-mutated") throw new Error("proper-lockfile host mutation was not shared");\n' +
+					'  atomicHost.createEventBus.bridgeMarker = "host-mutated";\n' +
+					'  if (extension.readAtomicHostMutation() !== "host-mutated") throw new Error("@bastani/atomic host mutation was not shared");\n' +
 					"  extension.mutateNamed();\n" +
-					'  if (host.lock.bridgeMarker !== "external-mutated") throw new Error("extension mutation was not shared");\n' +
+					'  if (host.lock.bridgeMarker !== "external-mutated") throw new Error("proper-lockfile extension mutation was not shared");\n' +
+					"  extension.mutateAtomicNamed();\n" +
+					'  if (atomicHost.createEventBus.bridgeMarker !== "external-mutated") throw new Error("@bastani/atomic extension mutation was not shared");\n' +
+					"  delete host.default.bridgeMarker;\n" +
+					"  delete host.lock.bridgeMarker;\n" +
+					"  delete atomicHost.createEventBus.bridgeMarker;\n" +
 					'  console.log("compiled host-module bridge probe: OK");\n' +
 					"})().catch((error) => { console.error(error instanceof Error ? error.message : String(error)); process.exit(1); });\n",
 			);
@@ -81,6 +98,9 @@ test(
 				"--target=bun",
 				"--format=esm",
 				"--external=proper-lockfile",
+				"--external=@bastani/atomic",
+				"--external=@bastani/pi-ai",
+				"--external=@earendil-works/pi-ai",
 				join(fixture, "extension-entry.ts"),
 				"--outfile",
 				extensionPath,
@@ -88,6 +108,9 @@ test(
 			const extensionBuild = spawnSyncCollect(extensionBuildCommand, { cwd: root });
 			assert.equal(extensionBuild.exitCode, 0, extensionBuild.stderr.toString());
 			assert.match(readFileSync(extensionPath, "utf8"), /from\s+["']proper-lockfile["']/);
+			assert.match(readFileSync(extensionPath, "utf8"), /from\s+["']@bastani\/atomic["']/);
+			assert.match(readFileSync(extensionPath, "utf8"), /from\s+["']@bastani\/pi-ai["']/);
+			assert.match(readFileSync(extensionPath, "utf8"), /from\s+["']@earendil-works\/pi-ai["']/);
 
 			const nativeFiles = readdirSync(join(root, "packages/natives/native")).filter((name) =>
 				name.endsWith(".node"),

--- a/test/ci/extension-host-module-bridge-boundary.test.ts
+++ b/test/ci/extension-host-module-bridge-boundary.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { cpSync, mkdtempSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "vitest";
+import {
+	bunExecutable,
+	copyFileSync,
+	makeDirectorySync,
+	removeTempDirectory,
+	spawnSyncCollect,
+	writeTextSync,
+} from "../helpers/runtime.js";
+
+const root = fileURLToPath(new URL("../..", import.meta.url));
+/** Two real Bun builds plus execution across the compiled launcher/sidecar boundary. */
+const COMPILED_HOST_MODULE_BRIDGE_TIMEOUT_MS = 120_000;
+
+function sha256(path: string): string {
+	return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function formatCommand(command: readonly string[]): string {
+	return command.map((part) => JSON.stringify(part)).join(" ");
+}
+
+test(
+	"compiled launcher exposes exact live host modules to an external ESM bundle",
+	() => {
+		const fixture = mkdtempSync(join(root, ".tmp-host-module-bridge-boundary."));
+		const runtimeDir = join(fixture, "runtime");
+		const executablePath = join(runtimeDir, process.platform === "win32" ? "atomic.exe" : "atomic");
+		const appPath = join(runtimeDir, "app.js");
+		const extensionPath = join(fixture, "extension.mjs");
+		makeDirectorySync(runtimeDir, { recursive: true });
+
+		try {
+			writeTextSync(
+				join(fixture, "extension-entry.ts"),
+				'import lockfile, { lock } from "proper-lockfile";\n' +
+					"export const importedDefault = lockfile;\n" +
+					"export const importedNamed = lock;\n" +
+					"export const namedType = typeof lock;\n" +
+					'export function readHostMutation(): string { return (lockfile as { bridgeMarker?: string }).bridgeMarker ?? ""; }\n' +
+					'export function mutateNamed(): void { (lock as { bridgeMarker?: string }).bridgeMarker = "external-mutated"; }\n',
+			);
+			writeTextSync(
+				join(fixture, "app-entry.ts"),
+				`import { installHostModuleBridge } from ${JSON.stringify(join(root, "packages/coding-agent/src/core/extensions/host-module-bridge.ts"))};\n` +
+					`import { getVirtualModules } from ${JSON.stringify(join(root, "packages/coding-agent/src/core/extensions/loader-virtual-modules.ts"))};\n` +
+					"void (async () => {\n" +
+					'  const extensionPath = process.argv[2];\n  if (!extensionPath) throw new Error("missing extension path");\n' +
+					"  const firstInstall = await installHostModuleBridge();\n" +
+					"  const secondInstall = await installHostModuleBridge();\n" +
+					'  if (!firstInstall.installed || secondInstall !== firstInstall || !firstInstall.specifiers.includes("proper-lockfile")) throw new Error("host bridge did not install exactly once");\n' +
+					"  const modules = await getVirtualModules();\n" +
+					'  const host = modules["proper-lockfile"] as { default: { bridgeMarker?: string }; lock: { bridgeMarker?: string } };\n' +
+					"  const extension = await import(extensionPath);\n" +
+					'  if (extension.namedType !== "function") throw new Error("named export missing");\n' +
+					'  if (!Object.is(extension.importedDefault, host.default)) throw new Error("default export identity changed");\n' +
+					'  if (!Object.is(extension.importedNamed, host.lock)) throw new Error("named export identity changed");\n' +
+					'  host.default.bridgeMarker = "host-mutated";\n' +
+					'  if (extension.readHostMutation() !== "host-mutated") throw new Error("host mutation was not shared");\n' +
+					"  extension.mutateNamed();\n" +
+					'  if (host.lock.bridgeMarker !== "external-mutated") throw new Error("extension mutation was not shared");\n' +
+					'  console.log("compiled host-module bridge probe: OK");\n' +
+					"})().catch((error) => { console.error(error instanceof Error ? error.message : String(error)); process.exit(1); });\n",
+			);
+			writeTextSync(
+				join(fixture, "split-loader.ts"),
+				'process.env.ATOMIC_CODING_AGENT = "true";\n' +
+					'import { dirname, join } from "node:path";\n' +
+					'import { pathToFileURL } from "node:url";\n' +
+					'void import(pathToFileURL(join(dirname(process.execPath), "app.js")).href);\n',
+			);
+
+			const extensionBuildCommand = [
+				bunExecutable(),
+				"build",
+				"--target=bun",
+				"--format=esm",
+				"--external=proper-lockfile",
+				join(fixture, "extension-entry.ts"),
+				"--outfile",
+				extensionPath,
+			] as const;
+			const extensionBuild = spawnSyncCollect(extensionBuildCommand, { cwd: root });
+			assert.equal(extensionBuild.exitCode, 0, extensionBuild.stderr.toString());
+			assert.match(readFileSync(extensionPath, "utf8"), /from\s+["']proper-lockfile["']/);
+
+			const nativeFiles = readdirSync(join(root, "packages/natives/native")).filter((name) =>
+				name.endsWith(".node"),
+			);
+			assert.ok(nativeFiles.length > 0, "Atomic native binding must be built before the binary-boundary test");
+			cpSync(join(root, "packages/natives"), join(runtimeDir, "node_modules/@bastani/atomic-natives"), {
+				recursive: true,
+			});
+
+			const appBuildCommand = [
+				bunExecutable(),
+				"build",
+				"--target=bun",
+				"--format=cjs",
+				"--minify-syntax",
+				"--external=mupdf",
+				"--external=*native-modifiers.js",
+				join(fixture, "app-entry.ts"),
+				"--outfile",
+				appPath,
+			] as const;
+			const appBuild = spawnSyncCollect(appBuildCommand, { cwd: root });
+			assert.equal(appBuild.exitCode, 0, appBuild.stderr.toString());
+			copyFileSync(
+				join(root, "node_modules/@earendil-works/pi-tui/dist/native-modifiers.js"),
+				join(runtimeDir, "native-modifiers.js"),
+			);
+			copyFileSync(
+				join(root, "node_modules/@earendil-works/pi-tui/dist/native-module-path.js"),
+				join(runtimeDir, "native-module-path.js"),
+			);
+
+			const launcherBuildCommand = [
+				bunExecutable(),
+				"build",
+				"--compile",
+				"--bytecode",
+				"--format=cjs",
+				"--external=mupdf",
+				"--no-compile-autoload-dotenv",
+				"--no-compile-autoload-bunfig",
+				join(fixture, "split-loader.ts"),
+				"--outfile",
+				executablePath,
+			] as const;
+			const launcherBuild = spawnSyncCollect(launcherBuildCommand, { cwd: root });
+			assert.equal(launcherBuild.exitCode, 0, launcherBuild.stderr.toString());
+
+			console.log(`extension build: ${formatCommand(extensionBuildCommand)}`);
+			console.log(`app build: ${formatCommand(appBuildCommand)}`);
+			console.log(`launcher build: ${formatCommand(launcherBuildCommand)}`);
+			console.log(`extension.mjs sha256: ${sha256(extensionPath)}`);
+			console.log(`app.js sha256: ${sha256(appPath)}`);
+			console.log(`atomic sha256: ${sha256(executablePath)}`);
+
+			const startupCommand = [executablePath, extensionPath] as const;
+			console.log(`startup: ${formatCommand(startupCommand)}`);
+			const startup = spawnSyncCollect(startupCommand, { cwd: fixture });
+			assert.equal(startup.exitCode, 0, startup.stderr.toString());
+			assert.equal(startup.stdout.toString().trim(), "compiled host-module bridge probe: OK");
+		} finally {
+			removeTempDirectory(fixture);
+		}
+	},
+	COMPILED_HOST_MODULE_BRIDGE_TIMEOUT_MS,
+);


### PR DESCRIPTION
## Summary

- add a Bun runtime host-module bridge backed by `Bun.plugin(...).setup(build => build.module(...))`
- preserve exact named/default export object identity for host-provided extension modules
- prove the bridge in the production split-launcher and `--compile --bytecode` shape
- record the falsified `onResolve`/`onLoad` approach and the authoritative compiled-binary evidence

## Why

Atomic's fixed builtin extension bundles live outside the single-file Bun executable, but must import the exact host module instances embedded in the application sidecar. Jiti's `virtualModules` provides that identity today. This slice establishes and verifies the equivalent native ESM seam without changing production extension routing yet.

## Validation

- focused host-module bridge tests
- real external ESM bundle + CJS app sidecar + Bun bytecode launcher boundary test
- named and default export identity
- bidirectional shared-object mutation
- registration ordering and negative controls
- `npm run typecheck`

## Stack

1. **This PR:** host-module bridge and compiled-boundary proof
2. [#2774](https://github.com/bastani-inc/atomic/pull/2774): native-load the five fixed installed builtin bundles while retaining jiti for editable extensions/workflows

Base stack: `perf/windows-startup` ([#2771](https://github.com/bastani-inc/atomic/pull/2771)).






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a Bun host-module bridge intended to let precompiled extensions share the application's live module exports. The bridge is not invoked by the production extension-loading path, so compiled extensions can still load separate package instances and lose shared export identity and mutations. This should be corrected before merge.

<h3>Confidence Score: 4/5</h3>

External compiled extensions do not receive host-owned module objects because production startup never installs the bridge before extension evaluation.

One verified non-security failure remains in the compiled extension loading flow.

**Files Needing Attention:** packages/coding-agent/src/core/extensions/host-module-bridge.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and attached three artifacts: Minimal compiled launcher bridge probe source, Compiled launcher bridge probe output with comparison, and Existing host-module boundary test blocked by missing generated data.
- T-Rex produced a second proof for another posted P1 finding.
- T-Rex documented a general contract validation showing the before and after states of bridge registration and that the test command was blocked due to a missing generated data fixture.

<a href="https://app.greptile.com/trex/runs/21511128/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Host-module bridge is never installed on the production extension-loading path**

   - **Bug**
     - `installHostModuleBridge()` has no production caller. Compiled single-file extension loading proceeds through `loadExtensionModule()` and Jiti virtual modules, so the new Bun plugin is not registered before an external precompiled ESM extension is imported. The real compiled-sidecar probe shows the direct consequence: absent registration, the external module resolves a distinct host package export and mutations do not reach the host object.
   - **Cause**
     - The bridge was added as an isolated installer seam, but no compiled CLI/bootstrap or extension-loader path awaits it before external extension evaluation.
   - **Fix**
     - At the earliest compiled-Bun extension bootstrap point, await `installHostModuleBridge()` before any external precompiled ESM extension can be imported; retain an inert Node/source-build path and add an end-to-end routing test that invokes the actual extension loader rather than the installer directly.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/core/extensions/host-module-bridge.ts:47-63
**Host-module bridge is never installed**

`installHostModuleBridge()` has no production caller. The compiled extension-loading path can therefore evaluate an external precompiled ESM extension before the Bun plugin registers the host-owned module namespaces. That extension resolves a separate package graph, so exported object identity and mutations are not shared with the host. Install and await this bridge at the compiled-Bun extension bootstrap point before any external extension import.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(extensions): migrate config and..."](https://github.com/bastani-inc/atomic/commit/d5a92582f86d02f209f2943963f185c8bb8432f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58428378)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->