### PR TITLE
perf(extensions): native-load installed builtins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@types/bun": "1.3.14",
         "@types/tar-stream": "3.1.4",
         "@xterm/headless": "6.0.0",
+        "acorn": "8.15.0",
+        "acorn-walk": "8.3.4",
         "jszip": "3.10.1",
         "superjson": "1.13.3",
         "tar-stream": "3.2.0",
@@ -4514,6 +4516,32 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@types/bun": "1.3.14",
     "@types/tar-stream": "3.1.4",
     "@xterm/headless": "6.0.0",
+    "acorn": "8.15.0",
+    "acorn-walk": "8.3.4",
     "jszip": "3.10.1",
     "superjson": "1.13.3",
     "tar-stream": "3.2.0",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Interactive startup now paints the themed identity and focused editor before isolated-engine binding completes, while first submissions wait for the complete optional resource set. Escape cancels a submission still blocked on readiness, and `/reload` can retry after an extension failure without restarting Atomic. Failed transactional candidates do not publish host-managed settings, providers, tools, resources, event subscriptions, or system-prompt state. Compiled builds syntax-minify the shared application sidecar without identifier minification and now use Bun bytecode launchers on Windows x64 and ARM64, matching Linux and macOS. No measured Windows speedup is claimed yet.
+- Bun compiled and bundled single-file builds now native-import the five fixed Atomic builtin extension bundles once and reuse their evaluated factories across reloads, avoiding jiti source reads, transforms, hashing, and graph-manifest work for immutable shipped code. Editable user, project, and package extensions and user workflows continue to use content-hash invalidation and re-evaluate after direct or transitive source edits.
 
 ## [0.9.17] - 2026-08-29
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -243,7 +243,9 @@ export default function (pi: ExtensionAPI) {
 }
 ```
 
-Extensions are loaded via [jiti](https://github.com/unjs/jiti), so TypeScript works without compilation.
+Editable user, project, and package extensions and user workflows are loaded through [jiti](https://github.com/unjs/jiti), so TypeScript works without compilation. `/reload` uses content-hash invalidation across the complete imported file graph: a direct edit or a transitive dependency edit re-evaluates that extension's modules.
+
+In Bun compiled or bundled single-file builds, Atomic's five fixed installed builtin extension bundles (workflows, subagents, MCP, web access, and Intercom) take a separate startup path. Atomic installs its live host-module bridge, imports each precompiled bundle natively once, and reuses the evaluated factory across `/reload`. This avoids jiti source reads, transforms, hashing, and graph manifests for immutable shipped code. A builtin bundle's module-scoped state is therefore **not** re-evaluated by `/reload` in those builds. This optimization is limited to exact installed entries of identity-verified Atomic packages; editable extensions and workflows retain the dynamic behavior above.
 
 If the factory returns a `Promise`, Atomic awaits it before continuing startup. That means async initialization completes before `session_start`, before `resources_discover`, and before provider registrations queued via `pi.registerProvider()` are flushed.
 
@@ -2013,7 +2015,7 @@ Choose the store that matches the lifetime you need:
 - **`pi.appendEntry()`** — durable custom entries that survive process restart. They do not enter model context.
 - **`sessionScopedExtensionState()`** — in-memory objects that survive `/reload` for the current process. They do not survive process restart.
 
-Module-scoped variables do **not** survive `/reload`: reloading file extensions re-evaluates their module graph, so those singletons are new empty objects while the session keeps running.
+Module-scoped variables in editable file extensions do **not** survive `/reload`: reloading them re-evaluates their module graph, so those singletons are new empty objects while the session keeps running. The five fixed installed builtin bundles are the exception in Bun single-file builds: their evaluated factories and module state are reused as described above.
 
 Extensions with state that must follow conversation branches should store it in tool result `details`:
 

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -243,7 +243,7 @@ export default function (pi: ExtensionAPI) {
 }
 ```
 
-Editable user, project, and package extensions and user workflows are loaded through [jiti](https://github.com/unjs/jiti), so TypeScript works without compilation. `/reload` uses content-hash invalidation across the complete imported file graph: a direct edit or a transitive dependency edit re-evaluates that extension's modules.
+Editable user, project, and package extensions and user workflows are loaded through [jiti](https://github.com/unjs/jiti), so TypeScript works without compilation. `/reload` uses content-hash invalidation across the complete imported file graph: an unchanged graph can reuse its evaluated factory, while a direct edit or a transitive dependency edit re-evaluates that extension's modules.
 
 In Bun compiled or bundled single-file builds, Atomic's five fixed installed builtin extension bundles (workflows, subagents, MCP, web access, and Intercom) take a separate startup path. Atomic installs its live host-module bridge, imports each precompiled bundle natively once, and reuses the evaluated factory across `/reload`. This avoids jiti source reads, transforms, hashing, and graph manifests for immutable shipped code. A builtin bundle's module-scoped state is therefore **not** re-evaluated by `/reload` in those builds. This optimization is limited to exact installed entries of identity-verified Atomic packages; editable extensions and workflows retain the dynamic behavior above.
 
@@ -2015,7 +2015,7 @@ Choose the store that matches the lifetime you need:
 - **`pi.appendEntry()`** — durable custom entries that survive process restart. They do not enter model context.
 - **`sessionScopedExtensionState()`** — in-memory objects that survive `/reload` for the current process. They do not survive process restart.
 
-Module-scoped variables in editable file extensions do **not** survive `/reload`: reloading them re-evaluates their module graph, so those singletons are new empty objects while the session keeps running. The five fixed installed builtin bundles are the exception in Bun single-file builds: their evaluated factories and module state are reused as described above.
+In Bun single-file builds, an editable file extension whose imported graph is unchanged can reuse its evaluated factory, so its module-scoped variables may survive `/reload`. An edit anywhere in that graph re-evaluates its modules and resets those singletons. The five fixed installed builtin bundles always reuse their evaluated factories and module state across `/reload`, as described above.
 
 Extensions with state that must follow conversation branches should store it in tool result `details`:
 

--- a/packages/coding-agent/scripts/copy-builtin-packages.ts
+++ b/packages/coding-agent/scripts/copy-builtin-packages.ts
@@ -9,7 +9,8 @@ import {
 	statSync,
 	writeFileSync,
 } from "node:fs";
-import { basename, join, relative, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import {
 	INSTALLED_EXTENSION_ENTRIES,
 	WORKFLOWS_SDK_BUNDLE_ENTRY,
@@ -20,6 +21,9 @@ import {
 	INSTALLED_IMPORT_CLOSURE_ROOTS,
 	shouldSkipBuiltinCopyEntry,
 } from "./derive-import-closure.js";
+
+const require = createRequire(import.meta.url);
+const linkedomWorkerEntry = join(dirname(require.resolve("linkedom/package.json")), "worker.js");
 
 interface BuiltinCopy {
 	label: string;
@@ -68,12 +72,30 @@ const rawAuthoringSourcesToPrune = [
 const HOST_PROVIDED_EXTERNALS = [
 	"@bastani/atomic",
 	"@bastani/atomic/*",
+	"@bastani/atomic-natives",
+	"@bastani/pi-ai",
+	"@bastani/pi-ai/compat",
+	"@bastani/pi-ai/oauth",
+	"@bastani/pi-ai/api/cloudflare-gateway-binding",
 	"@earendil-works/*",
 	"@mariozechner/*",
 	"typebox",
 	"typebox/*",
 	"@sinclair/typebox",
 	"@sinclair/typebox/*",
+	"proper-lockfile",
+];
+
+const SELF_CONTAINED_BUILTIN_PLUGINS: Bun.BunPlugin[] = [
+	{
+		name: "atomic-builtin-dependency-resolution",
+		setup(build) {
+			// linkedom's default Node entry probes its optional native `canvas`
+			// peer. Builtins use its equivalent worker entry so the shipped bundle
+			// keeps the DOM parser without an unbundleable `.node` dependency.
+			build.onResolve({ filter: /^linkedom$/ }, () => ({ path: linkedomWorkerEntry }));
+		},
+	},
 ];
 
 const WORKSPACE_BUILTINS = [
@@ -249,8 +271,8 @@ async function bundleEntrypoint(entry: string, outfile: string, label: string): 
 		entrypoints: [entry],
 		target: "node",
 		format: "esm",
-		packages: "external",
 		external: HOST_PROVIDED_EXTERNALS,
+		plugins: SELF_CONTAINED_BUILTIN_PLUGINS,
 	});
 	const output = result.outputs[0];
 	if (!result.success || output === undefined) {
@@ -269,8 +291,8 @@ async function bundleWorkflowBuiltins(): Promise<void> {
 		root: builtinDir,
 		target: "node",
 		format: "esm",
-		packages: "external",
 		external: HOST_PROVIDED_EXTERNALS,
+		plugins: SELF_CONTAINED_BUILTIN_PLUGINS,
 		splitting: true,
 	});
 	if (!result.success) {

--- a/packages/coding-agent/scripts/copy-builtin-packages.ts
+++ b/packages/coding-agent/scripts/copy-builtin-packages.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import {
+	chmodSync,
 	cpSync,
 	existsSync,
 	mkdirSync,
@@ -24,7 +25,7 @@ import {
 
 const require = createRequire(import.meta.url);
 const linkedomWorkerEntry = join(dirname(require.resolve("linkedom/package.json")), "worker.js");
-
+const openXdgOpenEntry = join(dirname(require.resolve("open")), "xdg-open");
 interface BuiltinCopy {
 	label: string;
 	destinationName: BuiltinPackageDirName;
@@ -94,6 +95,9 @@ const SELF_CONTAINED_BUILTIN_PLUGINS: Bun.BunPlugin[] = [
 			// peer. Builtins use its equivalent worker entry so the shipped bundle
 			// keeps the DOM parser without an unbundleable `.node` dependency.
 			build.onResolve({ filter: /^linkedom$/ }, () => ({ path: linkedomWorkerEntry }));
+			// `open` stays bundled because unregistered bare imports cannot resolve
+			// from external files in compiled Bun. Its Linux fallback is a sibling
+			// executable, copied beside the MCP bundle below.
 		},
 	},
 ];
@@ -135,6 +139,7 @@ const INSTALLED_KEEP_PREFIXES: Record<BuiltinPackageDirName, readonly string[]> 
 		"LICENSE",
 		INSTALLED_EXTENSION_ENTRIES.mcp,
 		"app-bridge.bundle.js",
+		"xdg-open",
 	],
 	"web-access": [
 		"package.json",
@@ -437,6 +442,9 @@ await bundleEntrypoint(
 	join(distBuiltinDir, "mcp", INSTALLED_EXTENSION_ENTRIES.mcp),
 	"@bastani/mcp extension",
 );
+const installedXdgOpen = join(distBuiltinDir, "mcp", "xdg-open");
+cpSync(openXdgOpenEntry, installedXdgOpen);
+chmodSync(installedXdgOpen, 0o755);
 await bundleEntrypoint(
 	join(distBuiltinDir, "web-access", "index.ts"),
 	join(distBuiltinDir, "web-access", INSTALLED_EXTENSION_ENTRIES["web-access"]),

--- a/packages/coding-agent/src/core/builtin-packages.ts
+++ b/packages/coding-agent/src/core/builtin-packages.ts
@@ -19,6 +19,12 @@ interface BuiltinPackageCandidateContext {
 	readonly isSourceCheckout: boolean;
 }
 
+export interface BuiltinPackageLocation {
+	readonly packageName: string;
+	readonly distDirName: BuiltinPackageDirName;
+	readonly packageDir: string;
+}
+
 interface WorkspaceBuiltinSpec {
 	readonly packageName: string;
 	readonly workspaceDirName: BuiltinPackageDirName;
@@ -103,6 +109,20 @@ function getBuiltinPackageCandidateContext(): BuiltinPackageCandidateContext {
 	};
 }
 
+/** Atomic-owned builtin package roots paired with their verified descriptors. */
+export function getBuiltinPackageLocations(): BuiltinPackageLocation[] {
+	const context = getBuiltinPackageCandidateContext();
+	return BUILTIN_PACKAGES.flatMap((descriptor) => {
+		const packageDir = firstExistingPackageDir(
+			[...descriptor.sourceCandidates(context), ...distCandidates(context, descriptor)],
+			descriptor,
+		);
+		return packageDir
+			? [{ packageName: descriptor.packageName, distDirName: descriptor.distDirName, packageDir }]
+			: [];
+	});
+}
+
 /**
  * Built-in pi package roots shipped with this Atomic distribution.
  *
@@ -116,15 +136,7 @@ function getBuiltinPackageCandidateContext(): BuiltinPackageCandidateContext {
  *   process executable dir -> builtin/<package>
  */
 export function getBuiltinPackagePaths(): string[] {
-	const context = getBuiltinPackageCandidateContext();
-
-	return BUILTIN_PACKAGES.flatMap((descriptor) => {
-		const packageDir = firstExistingPackageDir(
-			[...descriptor.sourceCandidates(context), ...distCandidates(context, descriptor)],
-			descriptor,
-		);
-		return packageDir ? [packageDir] : [];
-	});
+	return getBuiltinPackageLocations().map(({ packageDir }) => packageDir);
 }
 
 /** Built-in package roots whose extensions Atomic must load in every model session. */

--- a/packages/coding-agent/src/core/extensions/host-module-bridge.ts
+++ b/packages/coding-agent/src/core/extensions/host-module-bridge.ts
@@ -1,5 +1,5 @@
 import { isBunBinary, isBundledBuild } from "../../config.js";
-import { getVirtualModules } from "./loader-virtual-modules.js";
+import { getVirtualModules } from "./loader-host-modules.js";
 
 export interface HostModuleBridgeInstallResult {
 	installed: boolean;
@@ -40,10 +40,7 @@ export function createHostModuleBridgePlugin(modules: Record<string, object>): H
 
 let installPromise: Promise<HostModuleBridgeInstallResult> | null = null;
 
-/**
- * Register live host module objects for external precompiled ESM bundles.
- * Production extension routing does not call this seam yet.
- */
+/** Register live host module objects before native builtin imports. */
 export function installHostModuleBridge(): Promise<HostModuleBridgeInstallResult> {
 	const bun = getBunRuntime();
 	if (!(isBunBinary || isBundledBuild) || !bun || typeof bun.plugin !== "function") {

--- a/packages/coding-agent/src/core/extensions/loader-host-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-host-modules.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { getPackageDir, isBunBinary } from "../../config.ts";
+import { getPackageDir, isBunBinary } from "../../config.js";
 import { createModuleRequire } from "../../utils/module-require.ts";
 
 let virtualModules: Record<string, object> | null = null;

--- a/packages/coding-agent/src/core/extensions/loader-host-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-host-modules.ts
@@ -5,15 +5,31 @@ import { createModuleRequire } from "../../utils/module-require.ts";
 let virtualModules: Record<string, object> | null = null;
 let virtualModulesPromise: Promise<Record<string, object>> | null = null;
 
+type HostModuleRequire = (specifier: string) => object;
+
+function loadOptionalAtomicNatives(requireFromHost: HostModuleRequire, specifier: string): object | undefined {
+	try {
+		return requireFromHost(specifier);
+	} catch {
+		// Keep a missing or unloadable platform binding proportional: only an
+		// extension that imports atomic-natives should fail, not every extension
+		// waiting for the shared host-module map.
+		return undefined;
+	}
+}
+
 export async function loadVirtualModules(): Promise<Record<string, object>> {
 	// Keep the native binding external to both the app sidecar and extension
 	// bundles while sharing its process-global control plane through the bridge.
+	// If the platform package is unavailable, omit only this registration so
+	// unrelated builtins can still load.
 	const requireFromHost = createModuleRequire(import.meta.url);
-	const atomicNatives = requireFromHost(
+	const atomicNatives = loadOptionalAtomicNatives(
+		requireFromHost,
 		isBunBinary
 			? join(getPackageDir(), "node_modules", "@bastani", "atomic-natives", "native", "index.js")
 			: "@bastani/atomic-natives",
-	) as object;
+	);
 	const [
 		typebox,
 		typeboxCompile,
@@ -64,7 +80,7 @@ export async function loadVirtualModules(): Promise<Record<string, object>> {
 		"@earendil-works/pi-ai/oauth": piAiOauth,
 		"@earendil-works/pi-ai/api/cloudflare-gateway-binding": piAiCloudflareGatewayBinding,
 		"proper-lockfile": properLockfile,
-		"@bastani/atomic-natives": atomicNatives,
+		...(atomicNatives ? { "@bastani/atomic-natives": atomicNatives } : {}),
 		"@bastani/atomic": piCodingAgent,
 		"@mariozechner/pi-agent-core": piAgentCore,
 		"@mariozechner/pi-tui": piTui,
@@ -75,6 +91,8 @@ export async function loadVirtualModules(): Promise<Record<string, object>> {
 		"@mariozechner/pi-ai/api/cloudflare-gateway-binding": piAiCloudflareGatewayBinding,
 	};
 }
+
+export const loaderHostModulesTestHooks = { loadOptionalAtomicNatives };
 
 /** Modules shared with extensions in Bun single-file builds. */
 export async function getVirtualModules(): Promise<Record<string, object>> {

--- a/packages/coding-agent/src/core/extensions/loader-host-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-host-modules.ts
@@ -1,7 +1,19 @@
+import { join } from "node:path";
+import { getPackageDir, isBunBinary } from "../../config.ts";
+import { createModuleRequire } from "../../utils/module-require.ts";
+
 let virtualModules: Record<string, object> | null = null;
 let virtualModulesPromise: Promise<Record<string, object>> | null = null;
 
 export async function loadVirtualModules(): Promise<Record<string, object>> {
+	// Keep the native binding external to both the app sidecar and extension
+	// bundles while sharing its process-global control plane through the bridge.
+	const requireFromHost = createModuleRequire(import.meta.url);
+	const atomicNatives = requireFromHost(
+		isBunBinary
+			? join(getPackageDir(), "node_modules", "@bastani", "atomic-natives", "native", "index.js")
+			: "@bastani/atomic-natives",
+	) as object;
 	const [
 		typebox,
 		typeboxCompile,
@@ -52,6 +64,7 @@ export async function loadVirtualModules(): Promise<Record<string, object>> {
 		"@earendil-works/pi-ai/oauth": piAiOauth,
 		"@earendil-works/pi-ai/api/cloudflare-gateway-binding": piAiCloudflareGatewayBinding,
 		"proper-lockfile": properLockfile,
+		"@bastani/atomic-natives": atomicNatives,
 		"@bastani/atomic": piCodingAgent,
 		"@mariozechner/pi-agent-core": piAgentCore,
 		"@mariozechner/pi-tui": piTui,

--- a/packages/coding-agent/src/core/extensions/loader-host-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-host-modules.ts
@@ -1,0 +1,80 @@
+let virtualModules: Record<string, object> | null = null;
+let virtualModulesPromise: Promise<Record<string, object>> | null = null;
+
+export async function loadVirtualModules(): Promise<Record<string, object>> {
+	const [
+		typebox,
+		typeboxCompile,
+		typeboxValue,
+		piAgentCore,
+		piTui,
+		piTuiLayout,
+		piAi,
+		piAiOauth,
+		piAiCloudflareGatewayBinding,
+		properLockfile,
+		piCodingAgent,
+	] = await Promise.all([
+		import("typebox"),
+		import("typebox/compile"),
+		import("typebox/value"),
+		import("@earendil-works/pi-agent-core"),
+		import("@earendil-works/pi-tui"),
+		import("@earendil-works/pi-tui/dist/layout.js"),
+		// pi 0.80.2: the old global pi-ai API moved off the root entrypoint onto
+		// `/compat` (a strict superset). Extensions still use the root specifier.
+		import("@bastani/pi-ai/compat"),
+		import("@bastani/pi-ai/oauth"),
+		import("@bastani/pi-ai/api/cloudflare-gateway-binding"),
+		// Keep proper-lockfile in the compiled host so extensions share its live
+		// CommonJS module state instead of evaluating it through jiti.
+		import("proper-lockfile"),
+		// loader.ts exports are not re-exported from index.ts, avoiding a cycle.
+		import("../../index.ts"),
+	]);
+
+	return {
+		typebox,
+		"typebox/compile": typeboxCompile,
+		"typebox/value": typeboxValue,
+		"@sinclair/typebox": typebox,
+		"@sinclair/typebox/compile": typeboxCompile,
+		"@sinclair/typebox/value": typeboxValue,
+		"@earendil-works/pi-agent-core": piAgentCore,
+		"@earendil-works/pi-tui": piTui,
+		"@earendil-works/pi-tui/dist/layout.js": piTuiLayout,
+		"@bastani/pi-ai": piAi,
+		"@bastani/pi-ai/compat": piAi,
+		"@bastani/pi-ai/oauth": piAiOauth,
+		"@bastani/pi-ai/api/cloudflare-gateway-binding": piAiCloudflareGatewayBinding,
+		"@earendil-works/pi-ai": piAi,
+		"@earendil-works/pi-ai/compat": piAi,
+		"@earendil-works/pi-ai/oauth": piAiOauth,
+		"@earendil-works/pi-ai/api/cloudflare-gateway-binding": piAiCloudflareGatewayBinding,
+		"proper-lockfile": properLockfile,
+		"@bastani/atomic": piCodingAgent,
+		"@mariozechner/pi-agent-core": piAgentCore,
+		"@mariozechner/pi-tui": piTui,
+		"@mariozechner/pi-tui/dist/layout.js": piTuiLayout,
+		"@mariozechner/pi-ai": piAi,
+		"@mariozechner/pi-ai/compat": piAi,
+		"@mariozechner/pi-ai/oauth": piAiOauth,
+		"@mariozechner/pi-ai/api/cloudflare-gateway-binding": piAiCloudflareGatewayBinding,
+	};
+}
+
+/** Modules shared with extensions in Bun single-file builds. */
+export async function getVirtualModules(): Promise<Record<string, object>> {
+	if (virtualModules) return virtualModules;
+	virtualModulesPromise ??= loadVirtualModules().then(
+		(modules) => {
+			virtualModules = modules;
+			return modules;
+		},
+		(error: Error) => {
+			virtualModulesPromise = null;
+			throw error;
+		},
+	);
+	return virtualModulesPromise;
+}

--- a/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
@@ -458,6 +458,7 @@ export const extensionLoaderTestHooks = {
 	loadTransformedExtensionModule: (extensionPath: string, cacheToken?: ExtensionCacheToken) =>
 		loadTransformedExtensionModule(extensionPath, cacheToken),
 	loadNativeBuiltinExtensionModule,
+	hasNativeBuiltinFactory: (extensionPath: string): boolean => nativeBuiltinFactories.has(extensionPath),
 };
 
 /**

--- a/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
@@ -8,96 +8,14 @@ import { getExtensionTranspileCacheDir, isBunBinary, isBundledBuild } from "../.
 import { resolutionBaseUrl } from "../../utils/module-require.ts";
 import { resolvePath } from "../../utils/paths.ts";
 import { moduleDirFromMetaUrl } from "../../utils/split-launcher.ts";
+import { installHostModuleBridge } from "./host-module-bridge.ts";
+import { getVirtualModules, loadVirtualModules } from "./loader-host-modules.ts";
+import { isNativeBuiltinExtensionPath } from "./native-builtin-entries.ts";
 import type { ExtensionFactory } from "./types.ts";
 
+export { getVirtualModules } from "./loader-host-modules.ts";
+
 const require = createRequire(import.meta.url);
-let _virtualModules: Record<string, object> | null = null;
-let _virtualModulesPromise: Promise<Record<string, object>> | null = null;
-
-async function loadVirtualModules(): Promise<Record<string, object>> {
-	const [
-		typebox,
-		typeboxCompile,
-		typeboxValue,
-		piAgentCore,
-		piTui,
-		piTuiLayout,
-		piAi,
-		piAiOauth,
-		piAiCloudflareGatewayBinding,
-		properLockfile,
-		piCodingAgent,
-	] = await Promise.all([
-		import("typebox"),
-		import("typebox/compile"),
-		import("typebox/value"),
-		import("@earendil-works/pi-agent-core"),
-		import("@earendil-works/pi-tui"),
-		import("@earendil-works/pi-tui/dist/layout.js"),
-		// pi 0.80.2: the old global pi-ai API moved off the root entrypoint onto
-		// `/compat` (a strict superset). Extensions still `import ... from
-		// "@bastani/pi-ai"`, so we load the compat module here and key it
-		// under the root specifier below to keep every extension working unchanged.
-		import("@bastani/pi-ai/compat"),
-		import("@bastani/pi-ai/oauth"),
-		// Re-exported from `@bastani/atomic`; jiti-loaded extensions (the builtin
-		// packages import the host entry) reach this specifier, so it needs a key
-		// of its own instead of falling through to the compat/root prefix alias.
-		import("@bastani/pi-ai/api/cloudflare-gateway-binding"),
-		// proper-lockfile mutates graceful-fs with a non-configurable cache
-		// symbol. Keep that dependency graph in the compiled host: evaluating it
-		// through Jiti would put its stale-value caching proxy in the middle.
-		import("proper-lockfile"),
-		// NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
-		// avoiding a circular dependency while preserving the package-name extension import path.
-		import("../../index.ts"),
-	]);
-
-	return {
-		typebox,
-		"typebox/compile": typeboxCompile,
-		"typebox/value": typeboxValue,
-		"@sinclair/typebox": typebox,
-		"@sinclair/typebox/compile": typeboxCompile,
-		"@sinclair/typebox/value": typeboxValue,
-		"@earendil-works/pi-agent-core": piAgentCore,
-		"@earendil-works/pi-tui": piTui,
-		"@earendil-works/pi-tui/dist/layout.js": piTuiLayout,
-		"@bastani/pi-ai": piAi,
-		"@bastani/pi-ai/compat": piAi,
-		"@bastani/pi-ai/oauth": piAiOauth,
-		"@bastani/pi-ai/api/cloudflare-gateway-binding": piAiCloudflareGatewayBinding,
-		"@earendil-works/pi-ai": piAi,
-		"@earendil-works/pi-ai/compat": piAi,
-		"@earendil-works/pi-ai/oauth": piAiOauth,
-		"@earendil-works/pi-ai/api/cloudflare-gateway-binding": piAiCloudflareGatewayBinding,
-		"proper-lockfile": properLockfile,
-		"@bastani/atomic": piCodingAgent,
-		"@mariozechner/pi-agent-core": piAgentCore,
-		"@mariozechner/pi-tui": piTui,
-		"@mariozechner/pi-tui/dist/layout.js": piTuiLayout,
-		"@mariozechner/pi-ai": piAi,
-		"@mariozechner/pi-ai/compat": piAi,
-		"@mariozechner/pi-ai/oauth": piAiOauth,
-		"@mariozechner/pi-ai/api/cloudflare-gateway-binding": piAiCloudflareGatewayBinding,
-	};
-}
-
-/** Modules available to extensions via virtualModules (for compiled Bun binary). */
-export async function getVirtualModules(): Promise<Record<string, object>> {
-	if (_virtualModules) return _virtualModules;
-	_virtualModulesPromise ??= loadVirtualModules().then(
-		(virtualModules) => {
-			_virtualModules = virtualModules;
-			return virtualModules;
-		},
-		(error: Error) => {
-			_virtualModulesPromise = null;
-			throw error;
-		},
-	);
-	return _virtualModulesPromise;
-}
 let _aliases: Record<string, string> | null = null;
 let _transpileCacheDir: string | null = null;
 
@@ -356,6 +274,41 @@ let extensionCacheCwd: string | undefined;
 let extensionCacheGeneration = 0;
 const extensionCache = new Map<string, ExtensionFactory>();
 
+// Installed builtin bundles are immutable within a running binary. Keep their
+// evaluated factories outside the generation-scoped editable-extension cache.
+const nativeBuiltinFactories = new Map<string, ExtensionFactory>();
+const nativeBuiltinLoads = new Map<string, Promise<ExtensionFactory | undefined>>();
+
+async function loadNativeBuiltinExtensionModule(
+	extensionPath: string,
+	cacheToken: ExtensionCacheToken | undefined,
+): Promise<ExtensionFactory | undefined> {
+	let factory = nativeBuiltinFactories.get(extensionPath);
+	if (!factory) {
+		let pending = nativeBuiltinLoads.get(extensionPath);
+		if (!pending) {
+			pending = (async () => {
+				await installHostModuleBridge();
+				const module = (await import(pathToFileURL(extensionPath).href)) as { default?: unknown };
+				if (typeof module.default !== "function") return undefined;
+				const loadedFactory = module.default as ExtensionFactory;
+				nativeBuiltinFactories.set(extensionPath, loadedFactory);
+				return loadedFactory;
+			})();
+			nativeBuiltinLoads.set(extensionPath, pending);
+		}
+		try {
+			factory = await pending;
+		} finally {
+			nativeBuiltinLoads.delete(extensionPath);
+		}
+	}
+	if (factory && isCurrentCacheToken(cacheToken)) {
+		extensionCache.set(extensionPath, factory);
+	}
+	return factory;
+}
+
 export interface ExtensionCacheToken {
 	cwd: string;
 	generation: number;
@@ -504,6 +457,7 @@ export const extensionLoaderTestHooks = {
 		importExtensionModule(extensionPath, cacheToken, true),
 	loadTransformedExtensionModule: (extensionPath: string, cacheToken?: ExtensionCacheToken) =>
 		loadTransformedExtensionModule(extensionPath, cacheToken),
+	loadNativeBuiltinExtensionModule,
 };
 
 /**
@@ -588,6 +542,11 @@ export async function loadExtensionModule(
 	extensionPath: string,
 	cacheToken?: ExtensionCacheToken,
 ): Promise<ExtensionFactory | undefined> {
+	const isSingleFileBuild = isBunBinary || isBundledBuild;
+	if (isSingleFileBuild && isNativeBuiltinExtensionPath(extensionPath)) {
+		return loadNativeBuiltinExtensionModule(extensionPath, cacheToken);
+	}
+
 	if (isCurrentCacheToken(cacheToken)) {
 		const cachedFactory = extensionCache.get(extensionPath);
 		if (cachedFactory) return cachedFactory;
@@ -598,7 +557,7 @@ export async function loadExtensionModule(
 	// package specifiers to files on disk: extensions must share the live
 	// module instances baked into the build, so virtualModules is used instead
 	// (which requires jiti's transformed-import path).
-	const isSingleFileBuild = isBunBinary || isBundledBuild;
+	// Every editable path retains the existing jiti/virtualModules behavior.
 	// Windows first-load fast path: native import() (jiti's default tryNative)
 	// skips per-launch transpilation of the extension module graph. Re-loads of
 	// the same path fall back to transformed imports for fresh evaluation.

--- a/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
+++ b/packages/coding-agent/src/core/extensions/loader-virtual-modules.ts
@@ -9,11 +9,11 @@ import { resolutionBaseUrl } from "../../utils/module-require.ts";
 import { resolvePath } from "../../utils/paths.ts";
 import { moduleDirFromMetaUrl } from "../../utils/split-launcher.ts";
 import { installHostModuleBridge } from "./host-module-bridge.ts";
-import { getVirtualModules, loadVirtualModules } from "./loader-host-modules.ts";
+import { getVirtualModules, loadVirtualModules } from "./loader-host-modules.js";
 import { isNativeBuiltinExtensionPath } from "./native-builtin-entries.ts";
 import type { ExtensionFactory } from "./types.ts";
 
-export { getVirtualModules } from "./loader-host-modules.ts";
+export { getVirtualModules } from "./loader-host-modules.js";
 
 const require = createRequire(import.meta.url);
 let _aliases: Record<string, string> | null = null;

--- a/packages/coding-agent/src/core/extensions/native-builtin-entries.ts
+++ b/packages/coding-agent/src/core/extensions/native-builtin-entries.ts
@@ -1,0 +1,28 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { INSTALLED_EXTENSION_ENTRIES } from "../builtin-install-layout.ts";
+import { getBuiltinPackageLocations } from "../builtin-packages.ts";
+
+let nativeBuiltinExtensionEntries: ReadonlySet<string> | undefined;
+
+/** Exact installed entry paths belonging to identity-verified Atomic builtin packages. */
+export function getNativeBuiltinExtensionEntries(): ReadonlySet<string> {
+	if (nativeBuiltinExtensionEntries) return nativeBuiltinExtensionEntries;
+
+	nativeBuiltinExtensionEntries = new Set(
+		getBuiltinPackageLocations().flatMap(({ distDirName, packageDir }) => {
+			const entryPath = resolve(packageDir, INSTALLED_EXTENSION_ENTRIES[distDirName]);
+			return existsSync(entryPath) ? [entryPath] : [];
+		}),
+	);
+	return nativeBuiltinExtensionEntries;
+}
+
+export function isNativeBuiltinExtensionPath(resolvedPath: string): boolean {
+	return getNativeBuiltinExtensionEntries().has(resolvedPath);
+}
+
+/** Reset memoized discovery after a test changes the simulated install layout. */
+export function resetNativeBuiltinExtensionEntriesForTest(): void {
+	nativeBuiltinExtensionEntries = undefined;
+}

--- a/packages/coding-agent/test/extensions-graph-manifest-reuse.test.ts
+++ b/packages/coding-agent/test/extensions-graph-manifest-reuse.test.ts
@@ -89,6 +89,20 @@ export default function () {
 		expect(second()).toBe("c-edited:b:a");
 	});
 
+	it("re-evaluates and observes new code after the entry file changes directly", async () => {
+		const { entry } = writeChainFixture();
+
+		const first = await loadGated(entry);
+		expect(first()).toBe("c:b:a");
+
+		fs.writeFileSync(entry, `export default function () { return "entry-edited"; }\n`);
+		const second = await loadGated(entry);
+
+		expect(state().evaluations).toBe(1);
+		expect(second).not.toBe(first);
+		expect(second()).toBe("entry-edited");
+	});
+
 	it("re-evaluates and extends the manifest after a new import joins the graph", async () => {
 		const { entry, chainC } = writeChainFixture();
 		const chainD = path.join(path.dirname(chainC), "chain-d.ts");

--- a/packages/coding-agent/test/extensions-host-module-bridge.test.ts
+++ b/packages/coding-agent/test/extensions-host-module-bridge.test.ts
@@ -53,6 +53,20 @@ describe("Bun host-module bridge", () => {
 		REAL_HOST_MODULES_TEST_TIMEOUT_MS,
 	);
 
+	it("contains a missing native binding without changing the successful module identity", async () => {
+		const { loaderHostModulesTestHooks } = await import("../src/core/extensions/loader-host-modules.ts");
+		const nativeExports = { marker: "live native exports" };
+
+		expect(loaderHostModulesTestHooks.loadOptionalAtomicNatives(() => nativeExports, "native-entry")).toBe(
+			nativeExports,
+		);
+		expect(
+			loaderHostModulesTestHooks.loadOptionalAtomicNatives(() => {
+				throw new Error("native binding unavailable");
+			}, "missing-native-entry"),
+		).toBeUndefined();
+	});
+
 	it("is inert outside single-file builds without touching Bun.plugin", async () => {
 		const plugin = vi.fn();
 		vi.stubGlobal("Bun", { plugin });

--- a/packages/coding-agent/test/native-builtin-entries.test.ts
+++ b/packages/coding-agent/test/native-builtin-entries.test.ts
@@ -1,8 +1,7 @@
-import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { afterEach, test } from "vitest";
+import { afterEach, expect, test } from "vitest";
 import {
 	BUILTIN_PACKAGE_DIR_NAMES,
 	INSTALLED_EXTENSION_ENTRIES,
@@ -56,7 +55,7 @@ test("trusts exactly the five identity-verified installed builtin entries", () =
 		resolve(packageDir, "builtin", dirName, INSTALLED_EXTENSION_ENTRIES[dirName]),
 	);
 
-	assert.deepEqual([...getNativeBuiltinExtensionEntries()], expected);
+	expect([...getNativeBuiltinExtensionEntries()]).toEqual(expected);
 });
 
 test("does not infer builtin trust from suffixes, filenames, manifests, or source entries", () => {
@@ -67,28 +66,28 @@ test("does not infer builtin trust from suffixes, filenames, manifests, or sourc
 	const sibling = join(workflowsDir, "sibling.mjs");
 	writeFileSync(sibling, "export default function register() {}\n");
 
-	assert.equal(isNativeBuiltinExtensionPath(arbitrary), false);
-	assert.equal(isNativeBuiltinExtensionPath(join(workflowsDir, "manifest-only.bundle.mjs")), false);
-	assert.equal(isNativeBuiltinExtensionPath(sibling), false);
-	assert.equal(isNativeBuiltinExtensionPath(join(workflowsDir, SOURCE_EXTENSION_ENTRIES.workflows)), false);
+	expect(isNativeBuiltinExtensionPath(arbitrary)).toBe(false);
+	expect(isNativeBuiltinExtensionPath(join(workflowsDir, "manifest-only.bundle.mjs"))).toBe(false);
+	expect(isNativeBuiltinExtensionPath(sibling)).toBe(false);
+	expect(isNativeBuiltinExtensionPath(join(workflowsDir, SOURCE_EXTENSION_ENTRIES.workflows))).toBe(false);
 });
 
 test("rejects an installed-looking entry when the package identity is not Atomic-owned", () => {
 	const packageDir = createInstall({ spoof: "workflows" });
 	const spoofedEntry = resolve(packageDir, "builtin", "workflows", INSTALLED_EXTENSION_ENTRIES.workflows);
 
-	assert.equal(isNativeBuiltinExtensionPath(spoofedEntry), false);
-	assert.equal(getNativeBuiltinExtensionEntries().size, 4);
+	expect(isNativeBuiltinExtensionPath(spoofedEntry)).toBe(false);
+	expect(getNativeBuiltinExtensionEntries().size).toBe(4);
 });
 
 test("does not retain installed builtin factories in the native cache under Node", async () => {
 	const packageDir = createInstall();
 	const entry = resolve(packageDir, "builtin", "workflows", INSTALLED_EXTENSION_ENTRIES.workflows);
 
-	assert.equal(isNativeBuiltinExtensionPath(entry), true);
+	expect(isNativeBuiltinExtensionPath(entry)).toBe(true);
 	const factory = await loadExtensionModule(entry);
-	assert.equal(typeof factory, "function");
+	expect(typeof factory).toBe("function");
 	// Under Node both .mjs routes converge behaviorally, so cache population is
 	// the faithful observable that the single-file-build guard remained inert.
-	assert.equal(extensionLoaderTestHooks.hasNativeBuiltinFactory(entry), false);
+	expect(extensionLoaderTestHooks.hasNativeBuiltinFactory(entry)).toBe(false);
 });

--- a/packages/coding-agent/test/native-builtin-entries.test.ts
+++ b/packages/coding-agent/test/native-builtin-entries.test.ts
@@ -8,6 +8,7 @@ import {
 	INSTALLED_EXTENSION_ENTRIES,
 	SOURCE_EXTENSION_ENTRIES,
 } from "../src/core/builtin-install-layout.ts";
+import { extensionLoaderTestHooks, loadExtensionModule } from "../src/core/extensions/loader-virtual-modules.ts";
 import {
 	getNativeBuiltinExtensionEntries,
 	isNativeBuiltinExtensionPath,
@@ -78,4 +79,16 @@ test("rejects an installed-looking entry when the package identity is not Atomic
 
 	assert.equal(isNativeBuiltinExtensionPath(spoofedEntry), false);
 	assert.equal(getNativeBuiltinExtensionEntries().size, 4);
+});
+
+test("does not retain installed builtin factories in the native cache under Node", async () => {
+	const packageDir = createInstall();
+	const entry = resolve(packageDir, "builtin", "workflows", INSTALLED_EXTENSION_ENTRIES.workflows);
+
+	assert.equal(isNativeBuiltinExtensionPath(entry), true);
+	const factory = await loadExtensionModule(entry);
+	assert.equal(typeof factory, "function");
+	// Under Node both .mjs routes converge behaviorally, so cache population is
+	// the faithful observable that the single-file-build guard remained inert.
+	assert.equal(extensionLoaderTestHooks.hasNativeBuiltinFactory(entry), false);
 });

--- a/packages/coding-agent/test/native-builtin-entries.test.ts
+++ b/packages/coding-agent/test/native-builtin-entries.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterEach, test } from "vitest";
+import {
+	BUILTIN_PACKAGE_DIR_NAMES,
+	INSTALLED_EXTENSION_ENTRIES,
+	SOURCE_EXTENSION_ENTRIES,
+} from "../src/core/builtin-install-layout.ts";
+import {
+	getNativeBuiltinExtensionEntries,
+	isNativeBuiltinExtensionPath,
+	resetNativeBuiltinExtensionEntriesForTest,
+} from "../src/core/extensions/native-builtin-entries.ts";
+
+const roots: string[] = [];
+const originalPackageDir = process.env.ATOMIC_PACKAGE_DIR;
+
+function createInstall(options: { spoof?: "workflows" } = {}): string {
+	const packageDir = mkdtempSync(join(tmpdir(), "atomic-native-builtins-"));
+	roots.push(packageDir);
+	for (const dirName of BUILTIN_PACKAGE_DIR_NAMES) {
+		const builtinDir = join(packageDir, "builtin", dirName);
+		const installedEntry = join(builtinDir, INSTALLED_EXTENSION_ENTRIES[dirName]);
+		mkdirSync(dirname(installedEntry), { recursive: true });
+		writeFileSync(
+			join(builtinDir, "package.json"),
+			JSON.stringify({
+				name: options.spoof === dirName ? "user-controlled-package" : `@bastani/${dirName}`,
+				atomic: { extensions: ["manifest-only.bundle.mjs"] },
+			}),
+		);
+		writeFileSync(installedEntry, "export default function register() {}\n");
+		writeFileSync(join(builtinDir, "manifest-only.bundle.mjs"), "export default function register() {}\n");
+		const sourceEntry = join(builtinDir, SOURCE_EXTENSION_ENTRIES[dirName]);
+		mkdirSync(dirname(sourceEntry), { recursive: true });
+		if (!existsSync(sourceEntry)) writeFileSync(sourceEntry, "export default function register() {}\n");
+	}
+	process.env.ATOMIC_PACKAGE_DIR = packageDir;
+	resetNativeBuiltinExtensionEntriesForTest();
+	return packageDir;
+}
+
+afterEach(() => {
+	if (originalPackageDir === undefined) delete process.env.ATOMIC_PACKAGE_DIR;
+	else process.env.ATOMIC_PACKAGE_DIR = originalPackageDir;
+	resetNativeBuiltinExtensionEntriesForTest();
+	while (roots.length > 0) rmSync(roots.pop()!, { recursive: true, force: true });
+});
+
+test("trusts exactly the five identity-verified installed builtin entries", () => {
+	const packageDir = createInstall();
+	const expected = BUILTIN_PACKAGE_DIR_NAMES.map((dirName) =>
+		resolve(packageDir, "builtin", dirName, INSTALLED_EXTENSION_ENTRIES[dirName]),
+	);
+
+	assert.deepEqual([...getNativeBuiltinExtensionEntries()], expected);
+});
+
+test("does not infer builtin trust from suffixes, filenames, manifests, or source entries", () => {
+	const packageDir = createInstall();
+	const arbitrary = join(packageDir, "arbitrary.mjs");
+	writeFileSync(arbitrary, "export default function register() {}\n");
+	const workflowsDir = join(packageDir, "builtin", "workflows");
+	const sibling = join(workflowsDir, "sibling.mjs");
+	writeFileSync(sibling, "export default function register() {}\n");
+
+	assert.equal(isNativeBuiltinExtensionPath(arbitrary), false);
+	assert.equal(isNativeBuiltinExtensionPath(join(workflowsDir, "manifest-only.bundle.mjs")), false);
+	assert.equal(isNativeBuiltinExtensionPath(sibling), false);
+	assert.equal(isNativeBuiltinExtensionPath(join(workflowsDir, SOURCE_EXTENSION_ENTRIES.workflows)), false);
+});
+
+test("rejects an installed-looking entry when the package identity is not Atomic-owned", () => {
+	const packageDir = createInstall({ spoof: "workflows" });
+	const spoofedEntry = resolve(packageDir, "builtin", "workflows", INSTALLED_EXTENSION_ENTRIES.workflows);
+
+	assert.equal(isNativeBuiltinExtensionPath(spoofedEntry), false);
+	assert.equal(getNativeBuiltinExtensionEntries().size, 4);
+});

--- a/research/evidence/native-builtin-loader/native-builtin-routing-validation.md
+++ b/research/evidence/native-builtin-loader/native-builtin-routing-validation.md
@@ -182,6 +182,52 @@ The exact CI-floor runtime demonstrated the version-specific mismatch:
 }
 ```
 
+The first fast invariant test asserted Node's `isBuiltin` API directly rather than the dependency-closure guard, so reverting the guard to the old `builtinModules` set could not make that test fail. Commit `d15b73fe21` extracts `isPermittedSpecifier`, routes both the artifact scan and the fast test through it, and pins prefix-only and ordinary builtins, rejected and registered third-party bare imports, and relative imports.
+
+Temporarily restoring the old `builtinModules` predicate in `isPermittedSpecifier` proved that the focused test is now coupled to the guard. The exact Node 22 red run was:
+
+```sh
+PATH=/tmp/node-v22.19.0-darwin-arm64/bin:$PATH node -v
+PATH=/tmp/node-v22.19.0-darwin-arm64/bin:$PATH npx vitest run --project ci test/ci/native-builtin-bundle-imports.test.ts -t "specifier permits Node builtins, registered host imports, and relative imports only"
+```
+
+```text
+v22.19.0
+
+ RUN  v4.1.10 /Users/tonystark/Documents/projects/atomic-native-builtin-loader
+
+ ❯ |ci| test/ci/native-builtin-bundle-imports.test.ts (2 tests | 1 failed | 1 skipped) 3ms
+   × specifier permits Node builtins, registered host imports, and relative imports only 2ms
+
+ FAIL  |ci| test/ci/native-builtin-bundle-imports.test.ts > specifier permits Node builtins, registered host imports, and relative imports only
+AssertionError: Expected values to be strictly equal:
+
+false !== true
+
+ ❯ test/ci/native-builtin-bundle-imports.test.ts:58:9
+     58|  assert.equal(isPermittedSpecifier("node:sqlite", emptyHostSpecifiers)…
+
+ Test Files  1 failed (1)
+      Tests  1 failed | 1 skipped (2)
+```
+
+After restoring `isBuiltin`, the same command passed under the same runtime:
+
+```sh
+PATH=/tmp/node-v22.19.0-darwin-arm64/bin:$PATH node -v
+PATH=/tmp/node-v22.19.0-darwin-arm64/bin:$PATH npx vitest run --project ci test/ci/native-builtin-bundle-imports.test.ts -t "specifier permits Node builtins, registered host imports, and relative imports only"
+```
+
+```text
+v22.19.0
+
+ RUN  v4.1.10 /Users/tonystark/Documents/projects/atomic-native-builtin-loader
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 1 skipped (2)
+   Duration  1.97s (transform 1.31s, setup 1.87s, import 9ms, tests 1ms, environment 0ms)
+```
+
 Final validation results for this repair round:
 
 - `npm run check`: passed Biome, both TypeScript checks, and shrinkwrap verification; Biome reported the existing informational `noUselessStringRaw` diagnostic in `test/ci/ci-workflow-contracts.test.ts`.

--- a/research/evidence/native-builtin-loader/native-builtin-routing-validation.md
+++ b/research/evidence/native-builtin-loader/native-builtin-routing-validation.md
@@ -12,6 +12,8 @@
 - Additional validation commits:
   - `ab4aa85f7989c3374f9e7adb9684e23be469b3a4` — `test(extensions): verify Node skips native builtin cache`
   - `docs(evidence): record native builtin routing validation` — the signed commit containing this document; its hash is reported by `git log` after creation because a commit cannot embed its own hash.
+  - `79e29a3f6a397117908ad01da3d5cca48b5a931d` — `fix(builtin): make native extension bundles self-contained`.
+  - `83a15f4fc51e876df60a7f7dd95ac7d1254bcf8b` — `test(ci): guard native builtin dependency closure`.
 
 ## Result table
 
@@ -19,7 +21,7 @@
 |---|---|---|
 | Trusted entry classification | **PASS** | The original focused run passed 4 files and 26 tests. After adding the Node cache guard regression, the same command passed 4 files and 27 tests. The tests cover exactly five identity-verified installed entries and reject arbitrary, sibling, manifest-only, source, and spoofed-package paths. |
 | Editable reload behavior | **PASS** | Focused graph-manifest tests observed both direct entry edits and transitive dependency edits. Editable TypeScript extensions remain on the jiti/content-hash path. |
-| Compiled production route | **PASS** | The CI boundary test passed after building a real external extension bundle, a bundled app sidecar, and a `--compile --bytecode` launcher, then executing that launcher. It checked exact live host export identity, bidirectional shared-object mutation, factory reuse across `clearExtensionCache()`, absence of a jiti source read, and absence of a jiti cache directory. |
+| Compiled production route | **PASS after regression repair** | The original fixture proved host identity but imported only bridge-registered packages and therefore missed unresolved third-party imports. The strengthened fixture bundles and executes `chalk`; a new contract inspects all five installed entries; and an extracted real release binary starts and reports commands/resources from all five builtin packages. |
 | Node/npm route | **PASS** | Under Node, the new focused test loads an identity-verified installed entry through the real loader and proves that the persistent native-builtin factory cache remains unpopulated. The full coding-agent, root unit, and root integration suites also passed under Node. |
 | Static checks | **PASS** | `npm run check` passed Biome, root `tsc --noEmit`, coding-agent tsgo build and typetests, and shrinkwrap verification. |
 
@@ -62,6 +64,61 @@ The test then executed the compiled launcher, which printed:
 compiled native-builtin production loader probe: OK
 ```
 
+### Regression discovered by the real release binary
+
+The first validation verdict was premature. Building and extracting the actual Darwin arm64 archive, then running `./atomic --help`, failed before showing help:
+
+```text
+error: Mandatory bundled Intercom is unavailable: Failed to load extension:
+Cannot find package 'chalk' imported from .../builtin/intercom/index.bundle.mjs
+```
+
+`copy-builtin-packages.ts` had built every installed entry with `packages: "external"`. The former jiti route resolved those bare dependencies from the shipped `node_modules`; native `import()` from a Bun compiled binary cannot resolve an external file's transitive bare imports. All five entries retained unregistered packages, so this was a startup-breaking regression rather than an isolated Intercom problem.
+
+The repair removes `packages: "external"` for installed extension entries and reachable workflow builtin bundles. Bun now embeds third-party JavaScript while preserving exact host identities as explicit externals. The explicit host set was completed for the registered `@bastani/pi-ai` entries and `proper-lockfile`.
+
+Two dependencies required deliberate handling:
+
+- `linkedom`'s Node entry probes the optional native `canvas` peer, whose missing `.node` build made Bun fail. The builtin-only build plugin resolves `linkedom` to its API-compatible `linkedom/worker` entry, which has no canvas dependency. The raw source import stays unchanged, so Node/npm and source-checkout behavior is untouched.
+- `@bastani/atomic-natives` is a genuine native binding and cannot be embedded. The installed bundles keep it external; the compiled host loads the shipped platform binding by its runtime package path and registers that exact live exports object through the host bridge.
+
+### Dependency-closure contract and strengthened boundary
+
+`test/ci/native-builtin-bundle-imports.test.ts` builds the installed package, parses every one of the five installed entry bundles, and rejects every bare import that is neither a Node builtin nor a real `getVirtualModules()` key. With the old `packages: "external"` setting restored temporarily, it failed with a list beginning:
+
+```text
+workflows: cross-spawn
+workflows: chalk
+workflows: highlight.js/lib/core.js
+```
+
+The compiled boundary fixture now imports and calls `chalk.green()`. With `chalk` temporarily externalized to reproduce the old bundle shape, the compiled executable failed with:
+
+```text
+Cannot find package 'chalk' imported from .../builtin/intercom/index.bundle.mjs
+```
+
+After bundling `chalk`, the fixture passed while its proper-lockfile, Atomic, and pi-ai host imports remained external and identity-shared.
+
+### Real archive end to end
+
+The final implementation was built with:
+
+```sh
+./scripts/build-binaries.sh --skip-deps --skip-install --skip-package-build \
+  --offline-model-data --platform darwin-arm64
+```
+
+The archive was extracted to `/tmp/atomic-e2e/atomic`. The checkout's `packages/coding-agent/dist/builtin` was temporarily hidden during execution so the compiled build-time `import.meta.url` could not select checkout artifacts instead of the extracted payload.
+
+`ATOMIC_AGENT_DIR=/tmp/atomic-e2e-agent ./atomic --help` exited 0 and began:
+
+```text
+atomic - AI coding assistant with read, bash, edit, write, find, search, ask_user_question, todo tools
+```
+
+An offline RPC `get_commands` request also exited 0. Its response identified builtin resources from the extracted payload for all five packages: `/workflow` and `/workflows` from workflows, subagent skills including `skill:subagent`, `/mcp` and `/mcp-auth` from MCP, `/websearch` and related commands from web-access, and `/intercom` plus `skill:intercom` from Intercom. Every `sourceInfo.path` was under `/private/tmp/atomic-e2e/atomic/builtin/...`; no checkout path or extension-load error appeared.
+
 ### Repository checks and suites
 
 ```sh
@@ -77,6 +134,10 @@ Observed results:
 - Coding-agent suite: 499 files passed, 4 files skipped; 4113 tests passed, 40 tests skipped.
 - Root unit suite: 723 files passed; 7265 tests passed, 23 tests skipped.
 - Root integration suite: 40 files passed; 506 tests passed.
+- Final focused loader run: 4 files passed; 27 tests passed.
+- Final compiled-boundary plus dependency-closure run: 2 files passed; 2 tests passed.
+
+During the repair validation, one full unit attempt had a single 32.5-second fixture-report timeout in `interactive-engine-inherited-discovery.test.ts` while all other 7,264 tests passed. That file immediately passed alone (2 tests), and the required full rerun then passed all 723 files and 7,265 tests. No product assertion failed.
 
 An initial root-unit invocation reported 4 failed tests because `packages/coding-agent/dist/builtin` did not exist: the coding-agent workspace build had not yet run. After:
 
@@ -154,11 +215,11 @@ Installed `.bundle.mjs` files in an npm installation are shipped artifacts, not 
 
 ## What this does not prove
 
-- The local compiled-boundary evidence covers only Darwin arm64 with Bun 1.4.0. Windows and Linux compiled behavior is covered by CI, not by a local run recorded here.
+- The local real-archive evidence covers only Darwin arm64 with Bun 1.4.0. Windows and Linux compiled behavior is covered by CI, not by a local run recorded here.
 - There is no robust behavioral discriminator between the two `.mjs` routes under vitest: its module runner resolves bare specifiers for either route, while Node's ESM cache makes edit/reload behavior converge. The Node boundary is therefore evidenced structurally by the inert production guard, the falsifiable persistent-cache-population invariant, and the green Node test suites.
 - Exact exported-object identity and mutation were tested. This does not claim that reassigning a host ESM binding after bridge registration becomes a live binding in the external bundle.
 - The validation proves routing and reload semantics; it does not claim a cross-platform startup-time measurement or quantify a production speedup.
 
 ## Verdict
 
-The tested implementation native-imports only exact installed entries of identity-verified Atomic builtin packages in Bun compiled or bundled single-file builds. Those fixed factories survive reload without jiti source reads, transforms, hashing, or graph-manifest work. The Node guard is load-bearing, source-checkout entries remain untrusted, and editable TypeScript extension graphs continue to re-evaluate after direct and transitive edits.
+The final tested implementation native-imports only exact installed entries of identity-verified Atomic builtin packages in Bun compiled or bundled single-file builds. Each installed entry is self-contained except for Node builtins and exact live host modules registered by the bridge, including the shared native control plane. A real extracted archive starts successfully and exposes resources from all five builtin packages. Those fixed factories survive reload without jiti source reads, transforms, hashing, or graph-manifest work. The Node guard is load-bearing, source-checkout entries remain untrusted, and editable TypeScript extension graphs continue to re-evaluate after direct and transitive edits.

--- a/research/evidence/native-builtin-loader/native-builtin-routing-validation.md
+++ b/research/evidence/native-builtin-loader/native-builtin-routing-validation.md
@@ -1,0 +1,164 @@
+# Native builtin routing validation
+
+## Environment
+
+- Bun: `1.4.0`
+- OS/architecture: `Darwin arm64` (`uname -sm` => `Darwin arm64`)
+- Repository branch: `perf/native-builtin-loader`
+- Implementation commits under test:
+  - `1e93c4a0d025566cc81a5689445e47fa84ac39fa` — `feat(extensions): native-load installed builtins`
+  - `c74aa5f5c0fabc943b7857bf8cf0954245d8f8c8` — `test(extensions): cover native builtin routing`
+  - `6d49ed2f66a70422ee9c2d5d0cf7ccc63bcc1914` — `docs(extensions): document native builtin reloads`
+- Additional validation commits:
+  - `ab4aa85f7989c3374f9e7adb9684e23be469b3a4` — `test(extensions): verify Node skips native builtin cache`
+  - `docs(evidence): record native builtin routing validation` — the signed commit containing this document; its hash is reported by `git log` after creation because a commit cannot embed its own hash.
+
+## Result table
+
+| Area | Result | Evidence |
+|---|---|---|
+| Trusted entry classification | **PASS** | The original focused run passed 4 files and 26 tests. After adding the Node cache guard regression, the same command passed 4 files and 27 tests. The tests cover exactly five identity-verified installed entries and reject arbitrary, sibling, manifest-only, source, and spoofed-package paths. |
+| Editable reload behavior | **PASS** | Focused graph-manifest tests observed both direct entry edits and transitive dependency edits. Editable TypeScript extensions remain on the jiti/content-hash path. |
+| Compiled production route | **PASS** | The CI boundary test passed after building a real external extension bundle, a bundled app sidecar, and a `--compile --bytecode` launcher, then executing that launcher. It checked exact live host export identity, bidirectional shared-object mutation, factory reuse across `clearExtensionCache()`, absence of a jiti source read, and absence of a jiti cache directory. |
+| Node/npm route | **PASS** | Under Node, the new focused test loads an identity-verified installed entry through the real loader and proves that the persistent native-builtin factory cache remains unpopulated. The full coding-agent, root unit, and root integration suites also passed under Node. |
+| Static checks | **PASS** | `npm run check` passed Biome, root `tsc --noEmit`, coding-agent tsgo build and typetests, and shrinkwrap verification. |
+
+## Commands and observed results
+
+### Focused loader tests
+
+```sh
+npx vitest --run --root packages/coding-agent \
+  test/native-builtin-entries.test.ts \
+  test/extensions-graph-manifest-reuse.test.ts \
+  test/extensions-loader-virtual-modules.test.ts \
+  test/extensions-host-module-bridge.test.ts
+```
+
+Before the Node cache guard regression was added, the result was 4 files passed and 26 tests passed. With the new regression, the result was 4 files passed and 27 tests passed.
+
+The new test alone also passed:
+
+```text
+Test Files  1 passed (1)
+     Tests  4 passed (4)
+```
+
+### Compiled boundary
+
+```sh
+npm run test:ci-contracts -- test/ci/extension-host-module-bridge-boundary.test.ts
+```
+
+Observed result: 1 file passed and 1 test passed. Verbose output showed three real Bun builds:
+
+1. An ESM extension bundle with its host imports externalized.
+2. The CJS application sidecar containing the production loader.
+3. A `--compile --bytecode` launcher.
+
+The test then executed the compiled launcher, which printed:
+
+```text
+compiled native-builtin production loader probe: OK
+```
+
+### Repository checks and suites
+
+```sh
+npm run check
+npm run test --workspace=@bastani/atomic
+npm run test:unit
+npm run test:integration
+```
+
+Observed results:
+
+- `npm run check`: passed, including Biome, `tsc --noEmit`, coding-agent tsgo build and typetests, and shrinkwrap verification.
+- Coding-agent suite: 499 files passed, 4 files skipped; 4113 tests passed, 40 tests skipped.
+- Root unit suite: 723 files passed; 7265 tests passed, 23 tests skipped.
+- Root integration suite: 40 files passed; 506 tests passed.
+
+An initial root-unit invocation reported 4 failed tests because `packages/coding-agent/dist/builtin` did not exist: the coding-agent workspace build had not yet run. After:
+
+```sh
+npm --workspace=@bastani/atomic run build
+```
+
+the affected focused tests passed (2 files, 47 tests), and the subsequent full unit run passed with the totals above. This was missing setup, not a loader regression.
+
+## Negative controls
+
+### Compiled builtin bypass
+
+The native branch was temporarily gated with `false &&`, then the compiled-boundary test was run. It failed with:
+
+```text
+AssertionError: jiti read builtin source
+```
+
+The source was restored before the passing run. This proves that the compiled test's jiti-bypass assertion is load-bearing rather than vacuous.
+
+### Node single-file guard
+
+The `isSingleFileBuild && ` term was temporarily removed from the production guard, leaving:
+
+```ts
+if (isNativeBuiltinExtensionPath(extensionPath)) {
+```
+
+Running the new focused test produced this exact failure output:
+
+```text
+ RUN  v4.1.10 /Users/tonystark/Documents/projects/atomic-native-builtin-loader/packages/coding-agent
+
+ ❯ |agent| test/native-builtin-entries.test.ts (4 tests | 1 failed) 19ms
+   × does not retain installed builtin factories in the native cache under Node 7ms
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  |agent| test/native-builtin-entries.test.ts > does not retain installed builtin factories in the native cache under Node
+AssertionError: Expected values to be strictly equal:
+
+true !== false
+
+
+- Expected
++ Received
+
+- false
++ true
+
+ ❯ test/native-builtin-entries.test.ts:96:9
+     94|  // Under Node both .mjs routes converge behaviorally, so cache popula…
+     95|  // the faithful observable that the single-file-build guard remained …
+     96|  assert.equal(extensionLoaderTestHooks.hasNativeBuiltinFactory(entry),…
+       |         ^
+     97| });
+     98|
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+ Test Files  1 failed (1)
+      Tests  1 failed | 3 passed (4)
+```
+
+The original guard was then restored. The same command passed 1 file and all 4 tests. This proves that the cache-population assertion detects removal of the Node/single-file boundary.
+
+## Pre-existing behavior, not a regression
+
+A separate diagnostic used an untrusted plain `.mjs` file in a temporary directory. `isNativeBuiltinExtensionPath()` returned `false`, so none of this slice's native-builtin routing could execute. The first load returned `"first"`; after rewriting the file and calling `clearExtensionCache()`, the second load still returned `"first"`. A `.ts` file in the same diagnostic returned `"first"` before its edit and `"edited"` afterward.
+
+That `.mjs` behavior comes from jiti's native-import route plus Node's ESM cache and predates this slice. It is not evidence that the persistent native-builtin cache leaked into Node. In this slice, the new production branch is guarded by `isSingleFileBuild &&`; with both `isBunBinary` and `isBundledBuild` false, the branch is inert and the remaining Node control flow is unchanged from the base commit.
+
+Installed `.bundle.mjs` files in an npm installation are shipped artifacts, not editable user source. Editable user, project, and package extensions and user workflows retain the jiti/content-hash behavior, including re-evaluation after direct or transitive TypeScript source edits.
+
+## What this does not prove
+
+- The local compiled-boundary evidence covers only Darwin arm64 with Bun 1.4.0. Windows and Linux compiled behavior is covered by CI, not by a local run recorded here.
+- There is no robust behavioral discriminator between the two `.mjs` routes under vitest: its module runner resolves bare specifiers for either route, while Node's ESM cache makes edit/reload behavior converge. The Node boundary is therefore evidenced structurally by the inert production guard, the falsifiable persistent-cache-population invariant, and the green Node test suites.
+- Exact exported-object identity and mutation were tested. This does not claim that reassigning a host ESM binding after bridge registration becomes a live binding in the external bundle.
+- The validation proves routing and reload semantics; it does not claim a cross-platform startup-time measurement or quantify a production speedup.
+
+## Verdict
+
+The tested implementation native-imports only exact installed entries of identity-verified Atomic builtin packages in Bun compiled or bundled single-file builds. Those fixed factories survive reload without jiti source reads, transforms, hashing, or graph-manifest work. The Node guard is load-bearing, source-checkout entries remain untrusted, and editable TypeScript extension graphs continue to re-evaluate after direct and transitive edits.

--- a/research/evidence/native-builtin-loader/native-builtin-routing-validation.md
+++ b/research/evidence/native-builtin-loader/native-builtin-routing-validation.md
@@ -14,6 +14,10 @@
   - `docs(evidence): record native builtin routing validation` — the signed commit containing this document; its hash is reported by `git log` after creation because a commit cannot embed its own hash.
   - `79e29a3f6a397117908ad01da3d5cca48b5a931d` — `fix(builtin): make native extension bundles self-contained`.
   - `83a15f4fc51e876df60a7f7dd95ac7d1254bcf8b` — `test(ci): guard native builtin dependency closure`.
+  - `286031a89e` — `fix(extensions): contain missing native binding`.
+  - `3ba9519efe` — `fix(builtin): preserve MCP xdg-open fallback`.
+  - `627f11a083` — `test(ci): make native builtin guards hermetic`.
+  - `cc64ca9fa9` — `docs(extensions): clarify reload state reuse`.
 
 ## Result table
 
@@ -111,13 +115,23 @@ The final implementation was built with:
 
 The archive was extracted to `/tmp/atomic-e2e/atomic`. The checkout's `packages/coding-agent/dist/builtin` was temporarily hidden during execution so the compiled build-time `import.meta.url` could not select checkout artifacts instead of the extracted payload.
 
-`ATOMIC_AGENT_DIR=/tmp/atomic-e2e-agent ./atomic --help` exited 0 and began:
+The earlier run recorded here used `ATOMIC_AGENT_DIR`, which Atomic does not read. It therefore used the caller's default agent directory; the run proved startup and builtin discovery, but it did **not** prove agent-directory isolation. `./atomic --help` still exited 0 and began:
 
 ```text
 atomic - AI coding assistant with read, bash, edit, write, find, search, ask_user_question, todo tools
 ```
 
 An offline RPC `get_commands` request also exited 0. Its response identified builtin resources from the extracted payload for all five packages: `/workflow` and `/workflows` from workflows, subagent skills including `skill:subagent`, `/mcp` and `/mcp-auth` from MCP, `/websearch` and related commands from web-access, and `/intercom` plus `skill:intercom` from Intercom. Every `sourceInfo.path` was under `/private/tmp/atomic-e2e/atomic/builtin/...`; no checkout path or extension-load error appeared.
+
+After the review repair, the archive was rebuilt and extracted to `/tmp/atomic-review-e2e/atomic`, with the checkout's `dist/builtin` again hidden. Both commands used the real `ATOMIC_CODING_AGENT_DIR=/tmp/atomic-review-agent` override. `./atomic --help` and the offline RPC request exited 0. RPC returned 28 commands and included `workflow`, `workflows`, `skill:subagent`, `mcp`, `mcp-auth`, `websearch`, `intercom`, and `skill:intercom`. The extracted `builtin/mcp/xdg-open` existed with mode `0755`.
+
+### Review-round repairs
+
+- The compiled boundary fixture now sets `ATOMIC_CODING_AGENT_DIR`, so its jiti-cache check is hermetic and inspects the directory the product actually uses. For the liveness control, the native route was temporarily disabled, the read poison was neutralized, and the fixture exited after the jiti load. The outer assertion then failed specifically with `AssertionError: native builtin created jiti cache` and `true !== false`. The production route passed after restoration.
+- Loading `@bastani/atomic-natives` is contained. A successful require returns the exact same exports object; a failed require omits only that virtual-module registration. Removing the containment made the focused test fail with `Error: native binding unavailable` at `loadOptionalAtomicNatives`. The in-place `npm run build:binary --workspace=@bastani/atomic` artifact, which does not stage the native package under `dist/node_modules`, now runs `dist/atomic --help` successfully with exit 0.
+- The bundled MCP extension keeps `open` embedded but copies its vendored `xdg-open` beside `index.bundle.mjs` and preserves executable mode. Omitting the copy made the closure test fail with `ENOENT .../dist/builtin/mcp/xdg-open`.
+- The dependency-closure contract now checks all five installed entries, the workflow SDK bundle, and every emitted workflow builtin entry and split chunk. Restoring `packages: "external"` still failed with unregistered imports beginning `cross-spawn`, `chalk`, and `highlight.js`. Injecting a control import into a generated chunk failed with `workflows/builtin/chunk-0x6e303p.js: review-control-unregistered`.
+- The extension documentation now states the retained-factory behavior accurately: an unchanged editable graph can reuse module state in Bun single-file builds; an edit anywhere in the graph forces re-evaluation. Fixed installed builtins always reuse their factories across reloads.
 
 ### Repository checks and suites
 
@@ -130,11 +144,12 @@ npm run test:integration
 
 Observed results:
 
-- `npm run check`: passed, including Biome, `tsc --noEmit`, coding-agent tsgo build and typetests, and shrinkwrap verification.
-- Coding-agent suite: 499 files passed, 4 files skipped; 4113 tests passed, 40 tests skipped.
+- `npm run check`: passed, including Biome, `tsc --noEmit`, coding-agent tsgo build and typetests, and shrinkwrap verification. Biome reported one pre-existing informational `noUselessStringRaw` diagnostic outside this change.
+- Coding-agent suite: 499 files passed, 4 files skipped; 4115 tests passed, 40 tests skipped.
 - Root unit suite: 723 files passed; 7265 tests passed, 23 tests skipped.
 - Root integration suite: 40 files passed; 506 tests passed.
-- Final focused loader run: 4 files passed; 27 tests passed.
+- Full CI-contract suite: 15 files passed; 76 tests passed.
+- Final focused host-module run: 1 file passed; 5 tests passed.
 - Final compiled-boundary plus dependency-closure run: 2 files passed; 2 tests passed.
 
 During the repair validation, one full unit attempt had a single 32.5-second fixture-report timeout in `interactive-engine-inherited-discovery.test.ts` while all other 7,264 tests passed. That file immediately passed alone (2 tests), and the required full rerun then passed all 723 files and 7,265 tests. No product assertion failed.

--- a/research/evidence/native-builtin-loader/native-builtin-routing-validation.md
+++ b/research/evidence/native-builtin-loader/native-builtin-routing-validation.md
@@ -162,6 +162,32 @@ npm --workspace=@bastani/atomic run build
 
 the affected focused tests passed (2 files, 47 tests), and the subsequent full unit run passed with the totals above. This was missing setup, not a loader regression.
 
+### PR #2774 review repairs
+
+- Greptile identified that `packages/coding-agent/test/native-builtin-entries.test.ts` used `node:assert/strict` instead of the package suite's Vitest `expect` convention. Commit `7e2bff55bc` converts only that package test while preserving its four test names, assertion meanings, and cache-population explanation.
+- The dependency-closure test derived its builtin set from `builtinModules`. Node 22 omits prefix-only modules such as `node:sqlite` from that list even though the runtime supports them. Commit `6762a79250` uses `isBuiltin` as the authoritative predicate and adds a fast invariant test that accepts `node:sqlite` and `node:fs` while rejecting the third-party `acorn` specifier.
+
+The exact CI-floor runtime demonstrated the version-specific mismatch:
+
+```sh
+/tmp/node-v22.19.0-darwin-arm64/bin/node -e 'const { builtinModules, isBuiltin } = require("node:module"); console.log({ builtinModulesHasNodeSqlite: builtinModules.includes("node:sqlite"), isBuiltinNodeSqlite: isBuiltin("node:sqlite"), isBuiltinNodeFs: isBuiltin("node:fs"), isBuiltinAcorn: isBuiltin("acorn") });'
+```
+
+```text
+{
+  builtinModulesHasNodeSqlite: false,
+  isBuiltinNodeSqlite: true,
+  isBuiltinNodeFs: true,
+  isBuiltinAcorn: false
+}
+```
+
+Final validation results for this repair round:
+
+- `npm run check`: passed Biome, both TypeScript checks, and shrinkwrap verification; Biome reported the existing informational `noUselessStringRaw` diagnostic in `test/ci/ci-workflow-contracts.test.ts`.
+- `npm run test --workspace=@bastani/atomic -- native-builtin-entries`: 1 file passed and 4 tests passed.
+- `npm run test:ci-contracts`: 15 files passed and 77 tests passed.
+
 ## Negative controls
 
 ### Compiled builtin bypass

--- a/test/ci/extension-host-module-bridge-boundary.test.ts
+++ b/test/ci/extension-host-module-bridge-boundary.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { cpSync, mkdtempSync, readdirSync, readFileSync } from "node:fs";
+import { cpSync, existsSync, mkdtempSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "vitest";
@@ -26,14 +26,18 @@ function formatCommand(command: readonly string[]): string {
 }
 
 test(
-	"compiled launcher exposes exact live host modules to an external ESM bundle",
+	"compiled production loader natively imports a trusted builtin with exact live host modules",
 	() => {
 		const fixture = mkdtempSync(join(root, ".tmp-host-module-bridge-boundary."));
 		const runtimeDir = join(fixture, "runtime");
 		const executablePath = join(runtimeDir, process.platform === "win32" ? "atomic.exe" : "atomic");
 		const appPath = join(runtimeDir, "app.js");
-		const extensionPath = join(fixture, "extension.mjs");
-		makeDirectorySync(runtimeDir, { recursive: true });
+		const extensionPath = join(runtimeDir, "builtin", "intercom", "index.bundle.mjs");
+		makeDirectorySync(join(runtimeDir, "builtin", "intercom"), { recursive: true });
+		writeTextSync(
+			join(runtimeDir, "builtin", "intercom", "package.json"),
+			JSON.stringify({ name: "@bastani/intercom" }),
+		);
 
 		try {
 			writeTextSync(
@@ -42,53 +46,66 @@ test(
 					'import { createEventBus } from "@bastani/atomic";\n' +
 					'import { StringEnum as bastaniStringEnum } from "@bastani/pi-ai";\n' +
 					'import { StringEnum as earendilStringEnum } from "@earendil-works/pi-ai";\n' +
-					"export const importedDefault = lockfile;\n" +
-					"export const importedNamed = lock;\n" +
-					"export const importedCreateEventBus = createEventBus;\n" +
-					"export const aliasesShareExport = Object.is(bastaniStringEnum, earendilStringEnum);\n" +
-					"export const namedType = typeof lock;\n" +
-					'export function readHostMutation(): string { return (lockfile as { bridgeMarker?: string }).bridgeMarker ?? ""; }\n' +
-					'export function readAtomicHostMutation(): string { return (createEventBus as { bridgeMarker?: string }).bridgeMarker ?? ""; }\n' +
-					'export function mutateNamed(): void { (lock as { bridgeMarker?: string }).bridgeMarker = "external-mutated"; }\n' +
-					'export function mutateAtomicNamed(): void { (createEventBus as { bridgeMarker?: string }).bridgeMarker = "external-mutated"; }\n',
+					"const importedDefault = lockfile;\n" +
+					"const importedNamed = lock;\n" +
+					"const importedCreateEventBus = createEventBus;\n" +
+					"const aliasesShareExport = Object.is(bastaniStringEnum, earendilStringEnum);\n" +
+					"const namedType = typeof lock;\n" +
+					'function readHostMutation(): string { return (lockfile as { bridgeMarker?: string }).bridgeMarker ?? ""; }\n' +
+					'function readAtomicHostMutation(): string { return (createEventBus as { bridgeMarker?: string }).bridgeMarker ?? ""; }\n' +
+					'function mutateNamed(): void { (lock as { bridgeMarker?: string }).bridgeMarker = "external-mutated"; }\n' +
+					'function mutateAtomicNamed(): void { (createEventBus as { bridgeMarker?: string }).bridgeMarker = "external-mutated"; }\n' +
+					"function register(): void {}\n" +
+					"Object.assign(register, { importedDefault, importedNamed, importedCreateEventBus, aliasesShareExport, namedType, readHostMutation, readAtomicHostMutation, mutateNamed, mutateAtomicNamed });\n" +
+					"export default register;\n",
 			);
 			writeTextSync(
 				join(fixture, "app-entry.ts"),
-				`import { installHostModuleBridge } from ${JSON.stringify(join(root, "packages/coding-agent/src/core/extensions/host-module-bridge.ts"))};\n` +
-					`import { getVirtualModules } from ${JSON.stringify(join(root, "packages/coding-agent/src/core/extensions/loader-virtual-modules.ts"))};\n` +
+				`import { clearExtensionCache, loadExtensionModule } from ${JSON.stringify(join(root, "packages/coding-agent/src/core/extensions/loader-virtual-modules.ts"))};\n` +
+					`import { isNativeBuiltinExtensionPath } from ${JSON.stringify(join(root, "packages/coding-agent/src/core/extensions/native-builtin-entries.ts"))};\n` +
+					'import { createRequire } from "node:module";\n' +
+					`import { getVirtualModules } from ${JSON.stringify(join(root, "packages/coding-agent/src/core/extensions/loader-host-modules.ts"))};\n` +
 					"void (async () => {\n" +
 					'  const extensionPath = process.argv[2];\n  if (!extensionPath) throw new Error("missing extension path");\n' +
-					"  const firstInstall = await installHostModuleBridge();\n" +
-					"  const secondInstall = await installHostModuleBridge();\n" +
-					'  if (!firstInstall.installed || secondInstall !== firstInstall || !firstInstall.specifiers.includes("proper-lockfile")) throw new Error("host bridge did not install exactly once");\n' +
+					'  if (!isNativeBuiltinExtensionPath(extensionPath)) throw new Error("installed builtin entry was not trusted");\n' +
+					'  const fs = createRequire(import.meta.url)("node:fs") as { readFileSync: (...args: any[]) => any };\n' +
+					"  const originalReadFileSync = fs.readFileSync;\n" +
+					'  fs.readFileSync = (target, ...args) => { if (String(target) === extensionPath) throw new Error("jiti read builtin source"); return originalReadFileSync(target, ...args); };\n' +
+					"  let first;\n" +
+					"  try { first = await loadExtensionModule(extensionPath); } finally { fs.readFileSync = originalReadFileSync; }\n" +
+					"  first = first as typeof Function & { importedDefault: object; importedNamed: object; importedCreateEventBus: object; aliasesShareExport: boolean; namedType: string; readHostMutation(): string; readAtomicHostMutation(): string; mutateNamed(): void; mutateAtomicNamed(): void };\n" +
+					'  if (typeof first !== "function") throw new Error("production loader did not return the builtin factory");\n' +
+					"  clearExtensionCache();\n" +
+					"  const second = await loadExtensionModule(extensionPath);\n" +
+					'  if (!Object.is(first, second)) throw new Error("native builtin factory was re-evaluated on reload");\n' +
 					"  const modules = await getVirtualModules();\n" +
 					'  const host = modules["proper-lockfile"] as { default: { bridgeMarker?: string }; lock: { bridgeMarker?: string } };\n' +
 					'  const atomicHost = modules["@bastani/atomic"] as { createEventBus: { bridgeMarker?: string } };\n' +
-					"  const extension = await import(extensionPath);\n" +
-					'  if (extension.namedType !== "function") throw new Error("proper-lockfile named export missing");\n' +
-					'  if (!Object.is(extension.importedDefault, host.default)) throw new Error("proper-lockfile default export identity changed");\n' +
-					'  if (!Object.is(extension.importedNamed, host.lock)) throw new Error("proper-lockfile named export identity changed");\n' +
-					'  if (!Object.is(extension.importedCreateEventBus, atomicHost.createEventBus)) throw new Error("@bastani/atomic named export identity changed");\n' +
-					'  if (!extension.aliasesShareExport) throw new Error("pi-ai aliases duplicated host state");\n' +
+					'  if (first.namedType !== "function") throw new Error("proper-lockfile named export missing");\n' +
+					'  if (!Object.is(first.importedDefault, host.default)) throw new Error("proper-lockfile default export identity changed");\n' +
+					'  if (!Object.is(first.importedNamed, host.lock)) throw new Error("proper-lockfile named export identity changed");\n' +
+					'  if (!Object.is(first.importedCreateEventBus, atomicHost.createEventBus)) throw new Error("@bastani/atomic named export identity changed");\n' +
+					'  if (!first.aliasesShareExport) throw new Error("pi-ai aliases duplicated host state");\n' +
 					'  host.default.bridgeMarker = "host-mutated";\n' +
-					'  if (extension.readHostMutation() !== "host-mutated") throw new Error("proper-lockfile host mutation was not shared");\n' +
+					'  if (first.readHostMutation() !== "host-mutated") throw new Error("proper-lockfile host mutation was not shared");\n' +
 					'  atomicHost.createEventBus.bridgeMarker = "host-mutated";\n' +
-					'  if (extension.readAtomicHostMutation() !== "host-mutated") throw new Error("@bastani/atomic host mutation was not shared");\n' +
-					"  extension.mutateNamed();\n" +
+					'  if (first.readAtomicHostMutation() !== "host-mutated") throw new Error("@bastani/atomic host mutation was not shared");\n' +
+					"  first.mutateNamed();\n" +
 					'  if (host.lock.bridgeMarker !== "external-mutated") throw new Error("proper-lockfile extension mutation was not shared");\n' +
-					"  extension.mutateAtomicNamed();\n" +
+					"  first.mutateAtomicNamed();\n" +
 					'  if (atomicHost.createEventBus.bridgeMarker !== "external-mutated") throw new Error("@bastani/atomic extension mutation was not shared");\n' +
 					"  delete host.default.bridgeMarker;\n" +
 					"  delete host.lock.bridgeMarker;\n" +
 					"  delete atomicHost.createEventBus.bridgeMarker;\n" +
-					'  console.log("compiled host-module bridge probe: OK");\n' +
+					'  console.log("compiled native-builtin production loader probe: OK");\n' +
 					"})().catch((error) => { console.error(error instanceof Error ? error.message : String(error)); process.exit(1); });\n",
 			);
 			writeTextSync(
 				join(fixture, "split-loader.ts"),
-				'process.env.ATOMIC_CODING_AGENT = "true";\n' +
-					'import { dirname, join } from "node:path";\n' +
+				'import { dirname, join } from "node:path";\n' +
 					'import { pathToFileURL } from "node:url";\n' +
+					'process.env.ATOMIC_AGENT_DIR = join(dirname(process.execPath), "agent");\n' +
+					'process.env.ATOMIC_CODING_AGENT = "true";\n' +
 					'void import(pathToFileURL(join(dirname(process.execPath), "app.js")).href);\n',
 			);
 
@@ -170,7 +187,12 @@ test(
 			console.log(`startup: ${formatCommand(startupCommand)}`);
 			const startup = spawnSyncCollect(startupCommand, { cwd: fixture });
 			assert.equal(startup.exitCode, 0, startup.stderr.toString());
-			assert.equal(startup.stdout.toString().trim(), "compiled host-module bridge probe: OK");
+			assert.equal(startup.stdout.toString().trim(), "compiled native-builtin production loader probe: OK");
+			assert.equal(
+				existsSync(join(runtimeDir, "agent", "cache", "jiti")),
+				false,
+				"native builtin created jiti cache",
+			);
 		} finally {
 			removeTempDirectory(fixture);
 		}

--- a/test/ci/extension-host-module-bridge-boundary.test.ts
+++ b/test/ci/extension-host-module-bridge-boundary.test.ts
@@ -107,7 +107,7 @@ test(
 				join(fixture, "split-loader.ts"),
 				'import { dirname, join } from "node:path";\n' +
 					'import { pathToFileURL } from "node:url";\n' +
-					'process.env.ATOMIC_AGENT_DIR = join(dirname(process.execPath), "agent");\n' +
+					'process.env.ATOMIC_CODING_AGENT_DIR = join(dirname(process.execPath), "agent");\n' +
 					'process.env.ATOMIC_CODING_AGENT = "true";\n' +
 					'void import(pathToFileURL(join(dirname(process.execPath), "app.js")).href);\n',
 			);

--- a/test/ci/extension-host-module-bridge-boundary.test.ts
+++ b/test/ci/extension-host-module-bridge-boundary.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../helpers/runtime.js";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
-/** Two real Bun builds plus execution across the compiled launcher/sidecar boundary. */
+/** Three real Bun builds plus execution across the compiled launcher/sidecar boundary. */
 const COMPILED_HOST_MODULE_BRIDGE_TIMEOUT_MS = 120_000;
 
 function sha256(path: string): string {
@@ -46,17 +46,19 @@ test(
 					'import { createEventBus } from "@bastani/atomic";\n' +
 					'import { StringEnum as bastaniStringEnum } from "@bastani/pi-ai";\n' +
 					'import { StringEnum as earendilStringEnum } from "@earendil-works/pi-ai";\n' +
+					'import chalk from "chalk";\n' +
 					"const importedDefault = lockfile;\n" +
 					"const importedNamed = lock;\n" +
 					"const importedCreateEventBus = createEventBus;\n" +
 					"const aliasesShareExport = Object.is(bastaniStringEnum, earendilStringEnum);\n" +
 					"const namedType = typeof lock;\n" +
+					'const styledThirdPartyValue = chalk.green("third-party-bundled");\n' +
 					'function readHostMutation(): string { return (lockfile as { bridgeMarker?: string }).bridgeMarker ?? ""; }\n' +
 					'function readAtomicHostMutation(): string { return (createEventBus as { bridgeMarker?: string }).bridgeMarker ?? ""; }\n' +
 					'function mutateNamed(): void { (lock as { bridgeMarker?: string }).bridgeMarker = "external-mutated"; }\n' +
 					'function mutateAtomicNamed(): void { (createEventBus as { bridgeMarker?: string }).bridgeMarker = "external-mutated"; }\n' +
 					"function register(): void {}\n" +
-					"Object.assign(register, { importedDefault, importedNamed, importedCreateEventBus, aliasesShareExport, namedType, readHostMutation, readAtomicHostMutation, mutateNamed, mutateAtomicNamed });\n" +
+					"Object.assign(register, { importedDefault, importedNamed, importedCreateEventBus, aliasesShareExport, namedType, styledThirdPartyValue, readHostMutation, readAtomicHostMutation, mutateNamed, mutateAtomicNamed });\n" +
 					"export default register;\n",
 			);
 			writeTextSync(
@@ -73,7 +75,7 @@ test(
 					'  fs.readFileSync = (target, ...args) => { if (String(target) === extensionPath) throw new Error("jiti read builtin source"); return originalReadFileSync(target, ...args); };\n' +
 					"  let first;\n" +
 					"  try { first = await loadExtensionModule(extensionPath); } finally { fs.readFileSync = originalReadFileSync; }\n" +
-					"  first = first as typeof Function & { importedDefault: object; importedNamed: object; importedCreateEventBus: object; aliasesShareExport: boolean; namedType: string; readHostMutation(): string; readAtomicHostMutation(): string; mutateNamed(): void; mutateAtomicNamed(): void };\n" +
+					"  first = first as typeof Function & { importedDefault: object; importedNamed: object; importedCreateEventBus: object; aliasesShareExport: boolean; namedType: string; styledThirdPartyValue: string; readHostMutation(): string; readAtomicHostMutation(): string; mutateNamed(): void; mutateAtomicNamed(): void };\n" +
 					'  if (typeof first !== "function") throw new Error("production loader did not return the builtin factory");\n' +
 					"  clearExtensionCache();\n" +
 					"  const second = await loadExtensionModule(extensionPath);\n" +
@@ -86,6 +88,7 @@ test(
 					'  if (!Object.is(first.importedNamed, host.lock)) throw new Error("proper-lockfile named export identity changed");\n' +
 					'  if (!Object.is(first.importedCreateEventBus, atomicHost.createEventBus)) throw new Error("@bastani/atomic named export identity changed");\n' +
 					'  if (!first.aliasesShareExport) throw new Error("pi-ai aliases duplicated host state");\n' +
+					'  if (first.styledThirdPartyValue !== "third-party-bundled") throw new Error("bundled third-party dependency did not execute");\n' +
 					'  host.default.bridgeMarker = "host-mutated";\n' +
 					'  if (first.readHostMutation() !== "host-mutated") throw new Error("proper-lockfile host mutation was not shared");\n' +
 					'  atomicHost.createEventBus.bridgeMarker = "host-mutated";\n' +
@@ -128,6 +131,7 @@ test(
 			assert.match(readFileSync(extensionPath, "utf8"), /from\s+["']@bastani\/atomic["']/);
 			assert.match(readFileSync(extensionPath, "utf8"), /from\s+["']@bastani\/pi-ai["']/);
 			assert.match(readFileSync(extensionPath, "utf8"), /from\s+["']@earendil-works\/pi-ai["']/);
+			assert.doesNotMatch(readFileSync(extensionPath, "utf8"), /from\s+["']chalk["']/);
 
 			const nativeFiles = readdirSync(join(root, "packages/natives/native")).filter((name) =>
 				name.endsWith(".node"),

--- a/test/ci/native-builtin-bundle-imports.test.ts
+++ b/test/ci/native-builtin-bundle-imports.test.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { builtinModules } from "node:module";
-import { join } from "node:path";
+import { extname, join, relative } from "node:path";
 import { parse } from "acorn";
 import { simple } from "acorn-walk";
 import { test } from "vitest";
-import { INSTALLED_EXTENSION_ENTRIES } from "../../packages/coding-agent/src/core/builtin-install-layout.js";
+import {
+	INSTALLED_EXTENSION_ENTRIES,
+	WORKFLOWS_SDK_BUNDLE_ENTRY,
+} from "../../packages/coding-agent/src/core/builtin-install-layout.js";
 import { getVirtualModules } from "../../packages/coding-agent/src/core/extensions/loader-host-modules.js";
 import { moduleDir, spawnSyncCollect } from "../helpers/runtime.js";
 
@@ -34,24 +37,40 @@ function collectImportSpecifiers(source: string): Set<string> {
 	return specifiers;
 }
 
+function listJavaScriptArtifacts(rootDir: string): string[] {
+	return readdirSync(rootDir, { withFileTypes: true }).flatMap((entry) => {
+		const path = join(rootDir, entry.name);
+		if (entry.isDirectory()) return listJavaScriptArtifacts(path);
+		return [".js", ".mjs"].includes(extname(entry.name)) ? [path] : [];
+	});
+}
+
 test(
-	"installed builtin entry bundles retain only node builtins and registered host imports",
+	"installed builtin bundles retain only node builtins and registered host imports",
 	async () => {
 		const build = spawnSyncCollect(["npm", "run", "build", "--workspace=@bastani/atomic"], { cwd: root });
 		assert.equal(build.exitCode, 0, `${build.stdout.toString()}\n${build.stderr.toString()}`);
 
 		const hostSpecifiers = new Set(Object.keys(await getVirtualModules()));
 		const unexpected: string[] = [];
+		const builtinRoot = join(root, "packages/coding-agent/dist/builtin");
+		const emittedArtifacts = [
+			...Object.entries(INSTALLED_EXTENSION_ENTRIES).map(([dirName, entry]) => join(builtinRoot, dirName, entry)),
+			join(builtinRoot, "workflows", WORKFLOWS_SDK_BUNDLE_ENTRY),
+			...listJavaScriptArtifacts(join(builtinRoot, "workflows", "builtin")),
+		];
 
-		for (const [dirName, relativeEntry] of Object.entries(INSTALLED_EXTENSION_ENTRIES)) {
-			const entryPath = join(root, "packages/coding-agent/dist/builtin", dirName, relativeEntry);
-			const source = readFileSync(entryPath, "utf8");
+		for (const artifactPath of emittedArtifacts) {
+			const source = readFileSync(artifactPath, "utf8");
 			for (const specifier of collectImportSpecifiers(source)) {
 				if (isBareSpecifier(specifier) && !nodeBuiltinSpecifiers.has(specifier) && !hostSpecifiers.has(specifier)) {
-					unexpected.push(`${dirName}: ${specifier}`);
+					unexpected.push(`${relative(builtinRoot, artifactPath)}: ${specifier}`);
 				}
 			}
 		}
+
+		const installedXdgOpen = join(builtinRoot, "mcp", "xdg-open");
+		assert.notEqual(statSync(installedXdgOpen).mode & 0o111, 0, "installed MCP xdg-open fallback is not executable");
 
 		assert.deepEqual(unexpected, []);
 	},

--- a/test/ci/native-builtin-bundle-imports.test.ts
+++ b/test/ci/native-builtin-bundle-imports.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { builtinModules } from "node:module";
+import { isBuiltin } from "node:module";
 import { extname, join, relative } from "node:path";
 import { parse } from "acorn";
 import { simple } from "acorn-walk";
@@ -14,7 +14,6 @@ import { moduleDir, spawnSyncCollect } from "../helpers/runtime.js";
 
 const root = join(moduleDir(import.meta.url), "../..");
 const BUILTIN_BUNDLE_BUILD_TIMEOUT_MS = 120_000;
-const nodeBuiltinSpecifiers = new Set(builtinModules.flatMap((specifier) => [specifier, `node:${specifier}`]));
 
 function isBareSpecifier(specifier: string): boolean {
 	return !specifier.startsWith(".") && !specifier.startsWith("/") && !specifier.startsWith("file:");
@@ -45,6 +44,12 @@ function listJavaScriptArtifacts(rootDir: string): string[] {
 	});
 }
 
+test("Node builtin detection accepts prefix-only builtins without accepting third-party packages", () => {
+	assert.equal(isBuiltin("node:sqlite"), true);
+	assert.equal(isBuiltin("node:fs"), true);
+	assert.equal(isBuiltin("acorn"), false);
+});
+
 test(
 	"installed builtin bundles retain only node builtins and registered host imports",
 	async () => {
@@ -63,7 +68,9 @@ test(
 		for (const artifactPath of emittedArtifacts) {
 			const source = readFileSync(artifactPath, "utf8");
 			for (const specifier of collectImportSpecifiers(source)) {
-				if (isBareSpecifier(specifier) && !nodeBuiltinSpecifiers.has(specifier) && !hostSpecifiers.has(specifier)) {
+				// `builtinModules` omits prefix-only builtins such as `node:sqlite` on Node 22;
+				// `isBuiltin` recognizes them on every supported Node version.
+				if (isBareSpecifier(specifier) && !isBuiltin(specifier) && !hostSpecifiers.has(specifier)) {
 					unexpected.push(`${relative(builtinRoot, artifactPath)}: ${specifier}`);
 				}
 			}

--- a/test/ci/native-builtin-bundle-imports.test.ts
+++ b/test/ci/native-builtin-bundle-imports.test.ts
@@ -19,6 +19,13 @@ function isBareSpecifier(specifier: string): boolean {
 	return !specifier.startsWith(".") && !specifier.startsWith("/") && !specifier.startsWith("file:");
 }
 
+function isPermittedSpecifier(specifier: string, hostSpecifiers: ReadonlySet<string>): boolean {
+	if (!isBareSpecifier(specifier)) return true;
+	// `builtinModules` omits prefix-only builtins such as `node:sqlite` on Node 22;
+	// `isBuiltin` recognizes them on every supported Node version.
+	return isBuiltin(specifier) || hostSpecifiers.has(specifier);
+}
+
 function collectImportSpecifiers(source: string): Set<string> {
 	const specifiers = new Set<string>();
 	const program = parse(source, { ecmaVersion: "latest", sourceType: "module" });
@@ -44,10 +51,15 @@ function listJavaScriptArtifacts(rootDir: string): string[] {
 	});
 }
 
-test("Node builtin detection accepts prefix-only builtins without accepting third-party packages", () => {
-	assert.equal(isBuiltin("node:sqlite"), true);
-	assert.equal(isBuiltin("node:fs"), true);
-	assert.equal(isBuiltin("acorn"), false);
+test("specifier permits Node builtins, registered host imports, and relative imports only", () => {
+	const emptyHostSpecifiers = new Set<string>();
+
+	assert.equal(isPermittedSpecifier("node:sqlite", emptyHostSpecifiers), true);
+	assert.equal(isPermittedSpecifier("node:fs", emptyHostSpecifiers), true);
+	assert.equal(isPermittedSpecifier("fs", emptyHostSpecifiers), true);
+	assert.equal(isPermittedSpecifier("acorn", emptyHostSpecifiers), false);
+	assert.equal(isPermittedSpecifier("acorn", new Set(["acorn"])), true);
+	assert.equal(isPermittedSpecifier("./thing.js", emptyHostSpecifiers), true);
 });
 
 test(
@@ -68,9 +80,7 @@ test(
 		for (const artifactPath of emittedArtifacts) {
 			const source = readFileSync(artifactPath, "utf8");
 			for (const specifier of collectImportSpecifiers(source)) {
-				// `builtinModules` omits prefix-only builtins such as `node:sqlite` on Node 22;
-				// `isBuiltin` recognizes them on every supported Node version.
-				if (isBareSpecifier(specifier) && !isBuiltin(specifier) && !hostSpecifiers.has(specifier)) {
+				if (!isPermittedSpecifier(specifier, hostSpecifiers)) {
 					unexpected.push(`${relative(builtinRoot, artifactPath)}: ${specifier}`);
 				}
 			}

--- a/test/ci/native-builtin-bundle-imports.test.ts
+++ b/test/ci/native-builtin-bundle-imports.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { builtinModules } from "node:module";
+import { join } from "node:path";
+import { parse } from "acorn";
+import { simple } from "acorn-walk";
+import { test } from "vitest";
+import { INSTALLED_EXTENSION_ENTRIES } from "../../packages/coding-agent/src/core/builtin-install-layout.js";
+import { getVirtualModules } from "../../packages/coding-agent/src/core/extensions/loader-host-modules.js";
+import { moduleDir, spawnSyncCollect } from "../helpers/runtime.js";
+
+const root = join(moduleDir(import.meta.url), "../..");
+const BUILTIN_BUNDLE_BUILD_TIMEOUT_MS = 120_000;
+const nodeBuiltinSpecifiers = new Set(builtinModules.flatMap((specifier) => [specifier, `node:${specifier}`]));
+
+function isBareSpecifier(specifier: string): boolean {
+	return !specifier.startsWith(".") && !specifier.startsWith("/") && !specifier.startsWith("file:");
+}
+
+function collectImportSpecifiers(source: string): Set<string> {
+	const specifiers = new Set<string>();
+	const program = parse(source, { ecmaVersion: "latest", sourceType: "module" });
+	const addLiteral = (value: string | number | bigint | boolean | RegExp | null | undefined): void => {
+		if (typeof value === "string") specifiers.add(value);
+	};
+	simple(program, {
+		ImportDeclaration: (node) => addLiteral(node.source.value),
+		ExportNamedDeclaration: (node) => addLiteral(node.source?.value),
+		ExportAllDeclaration: (node) => addLiteral(node.source.value),
+		ImportExpression: (node) => {
+			if (node.source.type === "Literal") addLiteral(node.source.value);
+		},
+	});
+	return specifiers;
+}
+
+test(
+	"installed builtin entry bundles retain only node builtins and registered host imports",
+	async () => {
+		const build = spawnSyncCollect(["npm", "run", "build", "--workspace=@bastani/atomic"], { cwd: root });
+		assert.equal(build.exitCode, 0, `${build.stdout.toString()}\n${build.stderr.toString()}`);
+
+		const hostSpecifiers = new Set(Object.keys(await getVirtualModules()));
+		const unexpected: string[] = [];
+
+		for (const [dirName, relativeEntry] of Object.entries(INSTALLED_EXTENSION_ENTRIES)) {
+			const entryPath = join(root, "packages/coding-agent/dist/builtin", dirName, relativeEntry);
+			const source = readFileSync(entryPath, "utf8");
+			for (const specifier of collectImportSpecifiers(source)) {
+				if (isBareSpecifier(specifier) && !nodeBuiltinSpecifiers.has(specifier) && !hostSpecifiers.has(specifier)) {
+					unexpected.push(`${dirName}: ${specifier}`);
+				}
+			}
+		}
+
+		assert.deepEqual(unexpected, []);
+	},
+	BUILTIN_BUNDLE_BUILD_TIMEOUT_MS,
+);


### PR DESCRIPTION
## Summary

- identify exactly the five Atomic-owned installed builtin extension entries and native-import them in Bun single-file builds
- retain jiti, content-hash invalidation, graph manifests, and direct/transitive edit reloads for editable extensions and workflows
- reuse fixed builtin factories across reload generations without jiti source reads, hashing, transforms, or cache writes
- make installed builtin bundles self-contained except for Node builtins and registered live host modules
- preserve the MCP `xdg-open` fallback and contain missing optional native-binding failures
- add hermetic compiled-boundary, trust-classification, reload, dependency-closure, and Node-route regressions
- document the behavior and update the Unreleased changelog

## Validation

- `npm run check`
- coding-agent suite: 4,113 passed / 40 skipped
- root unit suite: 7,265 passed / 23 skipped
- root integration suite: 506 passed
- compiled boundary: external extension bundle + production app sidecar + Bun `--compile --bytecode` launcher
- real Darwin release archive startup and interactive workflow/MCP surfaces
- negative controls for native-route bypass, Node guard, jiti cache creation, and unresolved builtin imports
- independently reviewed and repaired through two Goal review rounds

## Stack

1. [#2773](https://github.com/bastani-inc/atomic/pull/2773): host-module bridge and compiled-boundary proof
2. **This PR:** trusted native builtin routing and release-artifact hardening

The stack is based on `perf/windows-startup` ([#2771](https://github.com/bastani-inc/atomic/pull/2771)).






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update native-loads verified installed builtin extensions in Bun single-file builds while retaining content-based reload behavior for editable extensions. The compiled launcher boundary, installed-bundle packaging, and direct and transitive editable-extension reload checks passed.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised bundled-extension and editable-reload paths.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the extension-host-module-bridge-boundary test for the CI project; it exited 0 with 1 test file passed (1 test).
- Ran the native-builtin-entries and extensions-graph-manifest-reuse tests under packages/coding-agent; the run exited 0 with 2 test files passed and 12 tests total.
- Ran the native-builtin-bundle-imports test; it exited 0 with 1 test file passed and 2 tests.
- These three test runs collectively validate the compiled native-builtin boundary, the installed bundle packaging output, and the editable direct and transitive dependency invalidation, and they completed without failures.
- Note that Bun 1.3.14 was used on the host, while the repo requires Bun \>= 1.4.0, which is a compatibility caveat rather than a defect.

<a href="https://app.greptile.com/trex/runs/21517477/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(extensions): align host module impor..."](https://github.com/bastani-inc/atomic/commit/5700ce22b705c40943d20a8c66f1a632a050a5f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58428383)</sub>

<!-- /greptile_comment -->