### PR TITLE
docs(changelog): prepare 0.9.18-alpha.1 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.18-alpha.1] - 2026-08-30
+
 ### Changed
 
 - Interactive startup now paints the themed identity and focused editor before isolated-engine binding completes, while first submissions wait for the complete optional resource set. Escape cancels a submission still blocked on readiness, and `/reload` can retry after an extension failure without restarting Atomic. Failed transactional candidates do not publish host-managed settings, providers, tools, resources, event subscriptions, or system-prompt state. Compiled builds syntax-minify the shared application sidecar without identifier minification and now use Bun bytecode launchers on Windows x64 and ARM64, matching Linux and macOS. No measured Windows speedup is claimed yet.


### PR DESCRIPTION
## Summary

Prepares the `0.9.18-alpha.1` prerelease notes by moving the accumulated coding-agent `[Unreleased]` entries into a dated release section. This changelog-only PR must merge before the release tag is cut.

## Changes

- Records the isolated startup readiness and transactional reload work, plus Bun bytecode launchers for compiled Windows builds.
- Records native imports and factory reuse for the five fixed builtin extension bundles in compiled and bundled builds.
- Records the restored startup resource listing and removes the `/atomic` guide command from the documented interface.

## Scope

The diff contains only `packages/coding-agent/CHANGELOG.md`, with two added lines and no deletions. All eight package manifests, workspace lock entries, Cargo metadata, and generated native version checks remain at `0.0.0`. The target version appears nowhere outside the prepared changelog.

`main` stays versionless. After this PR merges, `scripts/cut-release.ts` will stamp `0.9.18-alpha.1` only on the detached Release commit. Pushing that tag starts `publish.yml`; this PR does not merge, tag, publish, or dispatch publication.

## Validation

- `bun run vitest --run --project unit test/unit/build-release-notes.test.ts test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/bump-version-script.test.ts` (35 tests passed)
- `bun run scripts/build-release-notes.ts 0.9.18-alpha.1`
- Bun-based versionless invariant check across package manifests, `package-lock.json`, Cargo metadata, and `packages/natives/native/index.js`
- Changelog-only path check and `git diff --check`
- Pre-commit `npm run check` passed with hooks enabled

Assistant-model: GPT-5.6 Sol

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790750009&installation_model_id=10562&pr_number=2780&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2780&signature=d4cef7d620e3801130f13274035a578fb1fc2fb875a67fac4d4578daf0978b48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepares the coding-agent changelog for `0.9.18-alpha.1` by placing the accumulated release notes under a dated version heading and leaving `[Unreleased]` empty for future work.

Release-note generation produced the expected two changed entries, one fixed entry, and one removed entry. The output remained bounded to `0.9.18-alpha.1`, excluding `0.9.17`, and the focused changelog and release-note parser tests passed.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the version boundary and generated release-note content behave as intended.

The release-note builder was exercised against both the prior and updated changelog, with explicit assertions for an empty Unreleased section, intended entries, and exclusion of the preceding release. Focused parser coverage also passed.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the parent changelog against the change by running the release-note boundary harness for 0.9.18-alpha.1, which showed the parent changelog lacked the 0.9.18-alpha.1 heading and produced two Changed entries, one Fixed entry, and one Removed entry.
- Ran unit tests for the release-note tooling and changelog parser; both suites passed with 19 of 19 tests green, confirming compatibility.
- After applying the change, running bun run scripts/build-release-notes.ts 0.9.18-alpha.1 emitted exactly two Changed, one Fixed, and one Removed, and the harness confirmed no \[Unreleased\] content and no leakage of 0.9.17.
- Parser coverage remained green across the evaluation.

<a href="https://app.greptile.com/trex/runs/21553114/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.18-alpha.1 ..."](https://github.com/bastani-inc/atomic/commit/9bd825d3019a5ac77525b6874d83941400151f4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58531243)</sub>

<!-- /greptile_comment -->