### PR TITLE
docs(changelog): prepare 0.9.18-alpha.2 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.18-alpha.2] - 2026-08-31
+
+### Fixed
+
+- Fixed the `0.9.18-alpha.1` Windows x64 and ARM64 release archives crashing before startup because Bun 1.4.0 bytecode launchers were cross-compiled on Linux. Tagged releases now build both Windows archives on a Windows host, smoke-test the x64 archive, and stage both architectures into the release payload ([#2781](https://github.com/bastani-inc/atomic/pull/2781)).
+
 ## [0.9.18-alpha.1] - 2026-08-30
 
 ### Changed


### PR DESCRIPTION
## Summary

Prepares the `0.9.18-alpha.2` prerelease notes with the Windows release-archive fix merged in #2781. This changelog-only PR must merge before the release tag is cut.

## Changes

- Records why the `0.9.18-alpha.1` Windows x64 and ARM64 archives crashed before startup.
- Records that tagged Windows archives now build on a Windows host, with the x64 archive smoke-tested before both architectures enter the release payload.

## Scope

The diff contains only `packages/coding-agent/CHANGELOG.md`, with six added lines and no deletions. All eight package manifests, workspace lock entries, Cargo metadata, and generated native version checks remain at `0.0.0`. The target version appears nowhere outside the prepared changelog.

`main` stays versionless. After this PR merges, `scripts/cut-release.ts` will stamp `0.9.18-alpha.2` only on the detached Release commit. Pushing that tag starts `publish.yml`; this PR does not merge, tag, publish, dispatch, or rerun publication.

## Validation

- `bun run vitest --run --project unit test/unit/build-release-notes.test.ts test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/bump-version-script.test.ts` (35 tests passed)
- `bun run scripts/build-release-notes.ts 0.9.18-alpha.2`
- Bun-based versionless invariant check across package manifests, `package-lock.json`, Cargo metadata, and `packages/natives/native/index.js`
- Changelog-only path check, target-version scope check, and `git diff --check`
- Pre-commit `npm run check` passed with hooks enabled

Assistant-model: GPT-5.6 Sol

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790783299&installation_model_id=10562&pr_number=2782&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2782&signature=360e97d4430eea91758e1c6d6303bc48aa99383a6b5f4f6e73b980b4cf95ec42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prepares the `0.9.18-alpha.2` coding-agent release notes for the Windows archive startup fix. The release-note generator and its section parser recognized the new heading, rendered the complete `Fixed` entry, and stopped at the following release heading as intended. The potential release-note formatting failure was disproved by executing the generator and parser against this version.

### T-Rex validation blocked
The focused Vitest release-note suite could not initialize because the local `@bastani/pi-ai/compat` package is missing. The directly exercised generator and parser checks completed successfully.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the changed release-note section is accepted and rendered correctly by the release-note generator.

No defects remain. Direct execution confirmed the new prerelease heading produces one complete `Fixed` entry with no unexpected preamble or spillover into adjacent versions.

**Files Needing Attention:** No files need attention. `packages/coding-agent/CHANGELOG.md` was the only changed file.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The release-note generator was run against the parent changelog snapshot and failed for 0.9.18-alpha.2 because that prerelease version was not yet documented.
- At HEAD, bun run scripts/build-release-notes.ts 0.9.18-alpha.2 completed with exit code 0 and rendered the complete entry under Fixed.
- Directly parsed the changed changelog with extractVersionSection; it recognized 0.9.18-alpha.2, produced no unexpected preamble, and returned a single Fixed entry containing the expected release-note text.
- Attempted the focused Vitest release-note suite but test initialization blocked due to a missing local @bastani/pi-ai/compat package.

<a href="https://app.greptile.com/trex/runs/21621171/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.18-alpha.2 ..."](https://github.com/bastani-inc/atomic/commit/a6d0301c2ff01ccb6cabc1d874a71e9d781c8f2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58668138)</sub>

<!-- /greptile_comment -->