### PR TITLE
fix(intercom): suppress recoverable init disconnect noise

### DIFF
--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Fixed
+
+- Recoverable Intercom disconnects during lazy initialization no longer print a misleading error and stack trace in the interactive UI; later calls still retry initialization.
+
 ## [0.9.17] - 2026-08-29
 
 Cumulative release of the `0.9.17-alpha.1` prerelease. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease section below.

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -120,6 +120,10 @@ function renderHeavyToolResult(loadedHeavy: CapturedHeavy | null, name: string, 
 	if (renderer) return renderer(...args);
 	return renderIntercomToolResult(name, args);
 }
+function isRecoverableHeavyInitializationDisconnect(error: unknown): boolean {
+	return error instanceof Error && error.message === "Client disconnected";
+}
+
 export default function intercom(pi: ExtensionAPI, options: LightweightIntercomOptions = {}) {
   const inheritedDelegatedSessionName = readSubagentEnv("INTERCOM_SESSION_NAME");
   let heavyAttempt: HeavyAttempt | null = null;
@@ -252,8 +256,10 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 			() => undefined,
 			(error: unknown) => {
 				if (heavyAttempt?.promise === promise) heavyAttempt = null;
-				const message = error instanceof Error ? error.message : String(error);
-				console.error(`Intercom heavy initialization failed; a later call will retry: ${message}`, error);
+				if (!isRecoverableHeavyInitializationDisconnect(error)) {
+					const message = error instanceof Error ? error.message : String(error);
+					console.error(`Intercom heavy initialization failed; a later call will retry: ${message}`, error);
+				}
 			},
 		);
 		return promise;

--- a/test/unit/intercom-heavy-init-diagnostics.test.ts
+++ b/test/unit/intercom-heavy-init-diagnostics.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import type { ExtensionAPI, ToolDefinition } from "@bastani/atomic";
+import { Type } from "typebox";
+import { afterEach, beforeEach, describe, test } from "vitest";
+import intercom from "../../packages/intercom/index.js";
+
+type HeavyModule = { default: (pi: ExtensionAPI) => void | Promise<void> };
+type ConsoleErrorCall = [message?: unknown, ...optionalParams: unknown[]];
+type ImportResult = { error: unknown } | { module: HeavyModule };
+
+const originalConsoleError = console.error;
+let consoleErrorCalls: ConsoleErrorCall[] = [];
+
+beforeEach(() => {
+	consoleErrorCalls = [];
+	console.error = (...args: ConsoleErrorCall) => {
+		consoleErrorCalls.push(args);
+	};
+});
+
+afterEach(() => {
+	console.error = originalConsoleError;
+});
+
+function fixture(importResults: ImportResult[]) {
+	const tools = new Map<string, ToolDefinition>();
+	let imports = 0;
+	const pi = {
+		on() {},
+		registerTool(tool: ToolDefinition) {
+			tools.set(tool.name, tool);
+		},
+		registerCommand() {},
+		registerShortcut() {},
+		events: { on() {} },
+	};
+	intercom(pi as never, {
+		async importHeavy() {
+			const result = importResults[imports++];
+			assert.ok(result, "each heavy initialization attempt needs a fixture result");
+			if ("error" in result) throw result.error;
+			return result.module;
+		},
+	});
+	const ctx = { hasUI: true };
+	return {
+		get imports() {
+			return imports;
+		},
+		executeIntercom() {
+			const tool = tools.get("intercom");
+			assert.ok(tool, "intercom tool should be registered");
+			return tool.execute("tool-call", { action: "list" }, new AbortController().signal, undefined, ctx as never);
+		},
+	};
+}
+
+function successfulHeavyModule(): HeavyModule {
+	return {
+		default(heavyPi) {
+			heavyPi.registerTool({
+				name: "intercom",
+				label: "Intercom",
+				description: "test intercom",
+				parameters: Type.Object({}),
+				async execute() {
+					return { content: [{ type: "text", text: "connected" }], details: {} };
+				},
+			});
+		},
+	};
+}
+
+describe("Intercom lazy heavy-initialization diagnostics", () => {
+	test("keeps a recoverable client disconnect out of console output while rejecting the caller", async () => {
+		const disconnectError = new Error("Client disconnected");
+		const current = fixture([{ error: disconnectError }]);
+
+		await assert.rejects(current.executeIntercom(), disconnectError);
+		await Promise.resolve();
+
+		assert.deepEqual(consoleErrorCalls, []);
+	});
+
+	test("retries successfully after a silent recoverable client disconnect", async () => {
+		const disconnectError = new Error("Client disconnected");
+		const current = fixture([{ error: disconnectError }, { module: successfulHeavyModule() }]);
+
+		await assert.rejects(current.executeIntercom(), disconnectError);
+		const result = await current.executeIntercom();
+		await Promise.resolve();
+
+		assert.equal(current.imports, 2);
+		assert.deepEqual(result, { content: [{ type: "text", text: "connected" }], details: {} });
+		assert.deepEqual(consoleErrorCalls, []);
+	});
+
+	test("diagnoses a non-recoverable heavy-module import failure", async () => {
+		const importError = new Error("Cannot import Intercom heavy module");
+		const current = fixture([{ error: importError }]);
+
+		await assert.rejects(current.executeIntercom(), importError);
+		await Promise.resolve();
+
+		assert.deepEqual(consoleErrorCalls, [
+			[
+				"Intercom heavy initialization failed; a later call will retry: Cannot import Intercom heavy module",
+				importError,
+			],
+		]);
+	});
+
+	test("keeps neighboring client failures actionable", async () => {
+		const disconnectingError = new Error("Client disconnecting");
+		const current = fixture([{ error: disconnectingError }]);
+
+		await assert.rejects(current.executeIntercom(), disconnectingError);
+		await Promise.resolve();
+
+		assert.deepEqual(consoleErrorCalls, [
+			["Intercom heavy initialization failed; a later call will retry: Client disconnecting", disconnectingError],
+		]);
+	});
+
+	test("keeps ambiguous and non-Error failures actionable", async () => {
+		const failures: unknown[] = [
+			new Error("Configuration failed after Client disconnected unexpectedly"),
+			"Client disconnected",
+			{ reason: "Client disconnected" },
+			undefined,
+		];
+
+		for (const failure of failures) {
+			const current = fixture([{ error: failure }]);
+			await assert.rejects(current.executeIntercom());
+			await Promise.resolve();
+		}
+
+		assert.deepEqual(
+			consoleErrorCalls.map(([message, error]) => [message, error]),
+			failures.map((failure) => [
+				`Intercom heavy initialization failed; a later call will retry: ${failure instanceof Error ? failure.message : String(failure)}`,
+				failure,
+			]),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

An Intercom session that lost its broker connection during lazy heavy initialization printed a full error banner and stack trace into the interactive TUI:

```
Intercom heavy initialization failed; a later call will retry: Client disconnected Error: Client disconnected ...
```

The condition it reported was already self-healing. The rejection handler clears `heavyAttempt`, so the very next call re-enters `loadHeavy` and initialization succeeds — the message told users about a failure the code had already arranged to recover from, in the loudest way available. This suppresses the console output for that one recoverable condition and leaves every other initialization failure exactly as diagnostic as it was.

## Changes

**Suppression (`packages/intercom/index.ts`, +8/−2)**

- add `isRecoverableHeavyInitializationDisconnect(error)`, which is true only for `error instanceof Error && error.message === "Client disconnected"`
- guard the existing `console.error` in the heavy-initialization rejection handler with it

The classification is deliberately narrow: exact message identity on a real `Error`, not a substring scan. An import error whose text merely embeds the phrase, a non-`Error` throw of the string `"Client disconnected"`, an object with a matching `.message`, and the neighboring `"Client disconnecting"` all stay loud. When the error is ambiguous, it stays visible.

What did not change:

- `heavyAttempt = null` still runs before the guard, so the retry path is untouched
- the promise still rejects to its caller with the identical error object, so a persistent disconnect still surfaces as a real tool error through `lazy-tool-execution.ts`
- no file under `packages/intercom/broker/` is touched; broker and client failure semantics are unchanged
- the three other `console.error` sites in `index.ts` are unchanged; nothing is broadly silenced

**Tests (`test/unit/intercom-heavy-init-diagnostics.test.ts`, new, 147 lines)**

Five public-behavior tests driving the real exported `intercom()` extension through its registered `intercom` tool, via the pre-existing `importHeavy` seam:

1. a recoverable disconnect produces `consoleErrorCalls` deep-equal to `[]` while still rejecting the caller with the same error object
2. the next call retries — asserts `imports === 2` and a successful heavy result
3. a non-recoverable import failure still logs the exact banner string and the original error
4. `Client disconnecting` still logs
5. a substring-embedded configuration error, a bare string throw, an object throw, and `undefined` all still log

Tests 1 and 2 go red on the parent commit and green here; tests 3–5 pass in both directions, which is correct for behavior this change must not alter.

**Changelog (`packages/intercom/CHANGELOG.md`, +4)**

One entry under `### Fixed` in the existing `## [Unreleased]` section. No released section modified.

No documentation change. `packages/coding-agent/docs/intercom.md:122,126` describe lazy heavy initialization but never document this banner, so both passages remain accurate.

## Validation

- `npx vitest --run --project unit test/unit/intercom-heavy-init-diagnostics.test.ts` — 5/5 passed
- red check: reverted `index.ts` to the parent commit and re-ran — `2 failed | 3 passed`, then restored
- `npx vitest --run --project unit` — full unit suite green, 0 failed, 23 skipped
- `npm run check` — biome, `tsc --noEmit`, coding-agent `tsgo`, shrinkwrap check, all clean
- tmux end-to-end against the built CLI: bundled Intercom lazy-loads and `intercom status` responds with no banner; killing an isolated live broker and issuing the next TUI call reconnects through a replacement broker with no banner; three timed first-call broker-kill races (0.05 / 0.15 / 0.35 s) stayed user-clean

**Known coverage gap, stated rather than papered over.** The exact heavy-init rejection branch was not reachable from a standalone CLI session at runtime. In an ordinary session, heavy init registers the tool and connects later inside tool execution via `ensureConnected("tool")`; the top-level lazy rejection needs a workflow-stage session carrying `pendingStageDelivery`, whose replayed `session_start` calls `ensureConnected("startup")`, plus a broker close inside that narrow window. The non-recoverable contrast was likewise unreachable, since `--no-extensions` retains mandatory bundled Intercom. Both paths are covered by the durable unit tests above; closing the runtime gap would need a deterministic broker-close hook, which is new test infrastructure and out of scope here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790805225&installation_model_id=10562&pr_number=2792&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2792&signature=b20e59aef3c74afb76560ef3730f0515e903b56dba3e86a84157d70c755475bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update removes the misleading Intercom initialization error banner for the exact recoverable `Error("Client disconnected")` case. Extension-level execution confirmed that the triggering call still rejects, later calls retry initialization, concurrent calls share initialization work, lifecycle resets clear the cached attempt, and other errors remain visible. The focused Intercom diagnostic tests pass. No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised lazy-initialization and retry flows.

The exact recoverable-disconnect path was compared before and after the change, and the updated behavior preserved rejection, retry, concurrent initialization, lifecycle reset, and diagnostics for other failures.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The pre-PR end-to-end validation failed with a client-disconnect diagnostic, reproducing the noise targeted by PR #2792.
- After applying the PR, the end-to-end validation passed, with the disconnect becoming silent while rejections, retries, concurrency, and reset are exercised.
- A focused PR test run completed with five passing tests, validating the targeted regression area.
- I authored the executable validation source that drives the before/after proof, providing the runtime harness used in the validation.
- I authored the Vitest configuration that enables standalone validation without altering repository source.

<a href="https://app.greptile.com/trex/runs/21693696/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(intercom): suppress recoverable init..."](https://github.com/bastani-inc/atomic/commit/d3910c0818bb39cb5444b23b90511140e20b1f67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58811505)</sub>

<!-- /greptile_comment -->