### PR TITLE
docs(changelog): prepare 0.9.18-alpha.3 release notes

### DIFF
--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.18-alpha.3] - 2026-09-01
+
 ### Fixed
 
 - Recoverable Intercom disconnects during lazy initialization no longer print a misleading error and stack trace in the interactive UI; later calls still retry initialization.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.18-alpha.3] - 2026-09-01
+
 ### Added
 
 - Workflow status text, interactive list/detail views, and the persistent `BACKGROUND` panel now identify materialized pending stages by display name and canonical stage ID, show exact Intercom targets only when pre-start delivery is available, and distinguish unavailable pending delivery truthfully.


### PR DESCRIPTION
## Summary

Prepare the intercom and workflows release notes for the `0.9.18-alpha.3` prerelease. This changelog-only PR must merge before the release tag is cut.

## Changes

- Record the Intercom lazy-initialization and isolated workflow-control fixes.
- Record the workflow pending-stage status fixes and extension-hook authoring guidance.
- Move the accumulated entries from `Unreleased` into dated `0.9.18-alpha.3` sections.

## Scope

The diff contains only `packages/intercom/CHANGELOG.md` and `packages/workflows/CHANGELOG.md`, with four added lines and no deletions. All eight package manifests, workspace lock entries, Cargo metadata, and generated native version checks remain at `0.0.0`. The target version appears nowhere outside the two prepared changelogs.

`main` stays versionless. After this PR merges, `scripts/cut-release.ts` may stamp `0.9.18-alpha.3` only on the detached Release commit. Pushing that tag starts `publish.yml`; this PR does not merge, tag, publish, dispatch, or rerun publication.

## Validation

- `bun run vitest --run --project unit test/unit/build-release-notes.test.ts test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/bump-version-script.test.ts` (35 tests passed)
- `bun run scripts/build-release-notes.ts 0.9.18-alpha.3`
- Bun-based versionless invariant check across package manifests, `package-lock.json`, Cargo metadata, and `packages/natives/native/index.js`
- Changelog-only path check, target-version scope check, and `git diff --check`
- Pre-commit repository checks passed with hooks enabled

Assistant-model: GPT-5.6 Sol

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790842420&installation_model_id=10562&pr_number=2796&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2796&signature=dfd4f2f761be800be33defdc9c3094428719d39bebd77f92877fadb1ff1088d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds dated `0.9.18-alpha.3` release notes for Intercom and Workflows.

The release-note generator successfully produced merged notes containing both package entries, and the focused release-note generator tests passed.

The potential concern that these new changelog sections would not be publishable is disproved: release-note generation completed successfully and included the documented Intercom and Workflows changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the documented prerelease version generates publishable merged release notes for both affected packages.

Direct release-note generation and the focused generator test suite completed successfully, with no defects found.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the release-note generator against the prior changelog snapshot, and it exited 1 because the version was undocumented.
- T-Rex then ran the release-note generator on HEAD and it exited 0, emitting Intercom and Workflows entries under the Added, Changed, and Fixed sections.
- The focused release-note generator unit-test suite passed all seven tests without modifying tracked files.
- In a before/after validation, the before run exited with a missing-version error, the after run exited 0 and emitted the same sections, and the focused tests passed.

<a href="https://app.greptile.com/trex/runs/21773164/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.18-alpha.3 ..."](https://github.com/bastani-inc/atomic/commit/5663d96f673251ace77bfd42123b74f4ea381d15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58960465)</sub>

<!-- /greptile_comment -->