### PR TITLE
docs(models): refresh DeepSWE snapshot to the August 26 leaderboard

### DIFF
--- a/packages/coding-agent/docs/models/artificial-analysis-index.md
+++ b/packages/coding-agent/docs/models/artificial-analysis-index.md
@@ -8,7 +8,7 @@ description: "The external benchmarks that inform Atomic model selection — Art
 Atomic's model-selection docs are keyed to two live external benchmark sources rather than a hand-maintained table of scores. This page lists each benchmark, what it measures, and **when to reference it** for a given workflow role — so the docs stay useful as new models ship without a manual rewrite every time.
 
 <Warning>
-No single benchmark is the source of truth. Use these as inputs and validate against Atomic's own workflow evals — public suites test different task distributions than real engineering loops. When Atomic's numbers disagree with a public index, Atomic's evals win. **Last reviewed: 2026-08-21.**
+No single benchmark is the source of truth. Use these as inputs and validate against Atomic's own workflow evals — public suites test different task distributions than real engineering loops. When Atomic's numbers disagree with a public index, Atomic's evals win. The DeepSWE snapshot used by the linked model-selection pages was updated August 26, 2026. **Last reviewed: 2026-09-01.**
 </Warning>
 
 ## The two sources at a glance
@@ -22,6 +22,7 @@ No single benchmark is the source of truth. Use these as inputs and validate aga
 
 DeepSWE is the closest public proxy for what Atomic actually does. Tasks are written from scratch (not scraped from PRs), so no model has seen the solutions; solutions require substantially more code than SWE-bench-style suites; and verifiers test behavior rather than implementation.
 
+- **Current snapshot:** DeepSWE v1.1, 113 tasks across 91 repositories and 5 languages, updated August 26, 2026. The site reports 26 measured models and displays 19 leaderboard rows.
 - **Metric:** `pass@1`, plus average cost per task, output tokens, and agent steps.
 - **When to reference:** default weighting for debugger, worker, and any code-writing role. This is the table that drives [Model Selection](/models/model-selection) and [Pareto Efficiency](/models/pareto-efficiency).
 - **Watch:** cost and step count, not just score — a model that passes but takes 268 steps (e.g. sonnet-5) is a poor worker even at a good pass rate.

--- a/packages/coding-agent/docs/models/model-selection.md
+++ b/packages/coding-agent/docs/models/model-selection.md
@@ -14,7 +14,7 @@ This page gives workflow authors and runtime policy code a practical way to answ
 It is a **static reference**. It does not change runtime model routing — routing is configured elsewhere. Treat these recommendations as a starting point and validate against your own workflow evals.
 
 <Note>
-The table below is a snapshot of the [DeepSWE](https://deepswe.datacurve.ai/) leaderboard (v1.1, highest published thinking level per model), a long-horizon coding-agent benchmark reporting `pass@1` and average dollars per task. Benchmarks and pricing drift and new models ship constantly, so **treat the live leaderboards as authoritative** and refresh this page from them rather than hand-maintaining scores. See [Benchmark sources & when to reference each](/models/artificial-analysis-index). **Last compiled: 2026-08-21.**
+The table below is a snapshot of the [DeepSWE](https://deepswe.datacurve.ai/) leaderboard (v1.1, highest published thinking level per model), a long-horizon coding-agent benchmark reporting `pass@1` and average dollars per task. The source reports 113 tasks and was updated August 26, 2026. Benchmarks and pricing drift and new models ship constantly, so **treat the live leaderboards as authoritative** and refresh this page from them rather than hand-maintaining scores. See [Benchmark sources & when to reference each](/models/artificial-analysis-index). **Last compiled: 2026-09-01.**
 </Note>
 
 ## Benchmark levels are measurement settings
@@ -30,38 +30,39 @@ reports the ambiguity. Use `--provider <provider> --model <id>` or `--model <pro
 
 ## Recommendation chart
 
-The current highest-effort-config Pareto frontier is **claude-opus-5** (accuracy ceiling), **gpt-5.6-sol**, **glm-5.3**, **gpt-5.6-luna**, **deepseek-v4-pro**, and **deepseek-v4-flash**. Everything else is dominated on DeepSWE cost and accuracy and earns a place only through role fit or provider diversity. For the frontier reasoning, see [Pareto Efficiency](/models/pareto-efficiency).
+The current highest-effort-config Pareto frontier is **claude-opus-5** (accuracy ceiling), **gpt-5.6-sol**, **glm-5.3**, **gpt-5.6-luna**, and **glm-5.3-flash** (cheapest point). Everything else displayed on the live DeepSWE leaderboard is dominated on cost and accuracy and earns a place only through role fit or provider diversity. For the frontier reasoning, see [Pareto Efficiency](/models/pareto-efficiency).
 
 | Model [benchmark measurement level] | pass@1 | $/task | Verdict | Use it for |
 | --- | --- | --- | --- | --- |
 | claude-opus-5 [max] | 74% | $11.84 | Accuracy ceiling / frontier | Final approval and the hardest debugging when one more point can justify the cost |
-| gpt-5.6-sol [max] | 73% | $8.39 | Frontier | High-cost judgment gates; nearly the top score at lower cost than Opus 5 |
-| gpt-5.6-terra [max] | 70% | $3.96 | Off the live board | Last published measurement (July pricing); no longer displayed on the live leaderboard as of the August 20 refresh — re-verify against the source before relying on it |
+| gpt-5.6-sol [max] | 73% | $6.46 | Frontier | High-cost judgment gates; nearly the top score for about half the task cost of Opus 5 |
+| gpt-5.6-terra [max] | 70% | $3.96 | Historical — off the live board | Last published measurement; not displayed on the August 26 leaderboard, so re-verify before relying on it |
 | claude-fable-5 [max] | 70% | $21.63 | Drop | Sol matches or beats its score for much less |
-| glm-5.3 [max] | 69% | $3.99 | Frontier — open-weights value | Best open-weights cost/accuracy point; matches Kimi K3's rounded score for less |
+| glm-5.3 [max] | 69% | $3.99 | Frontier — open-weights value | Best open-weights mid-tier cost/accuracy point; matches Kimi K3's rounded score for less |
 | kimi-k3 [max] | 69% | $4.65 | Dominated | GLM-5.3 matches its rounded score for $0.66 less; Moonshot-family diversity only |
 | gpt-5.6-luna [max] | 67% | $0.61 | Frontier — best general value | Research, orchestration, workers, and code simplification |
 | gpt-5.5 [xhigh] | 67% | $7.23 | Superseded | Luna matches its score for less than one tenth of the task cost |
 | grok-4.6 [xhigh] | 67% | $5.50 | Provider fallback | xAI diversity; Luna has the same rounded score at lower DeepSWE task cost |
 | gemini-3.7-flash [high] | 65% | $2.18 | Provider fallback | Strong Google-family result, but Luna is cheaper and more accurate |
-| deepseek-v4-pro [max] | 63% | $0.24 | Frontier (budget) | Low-cost work where its 155-step average remains acceptable |
+| glm-5.3-flash [max] | 63% | $0.24 | Frontier — cheapest | Budget worker loops that can accept lower accuracy and 123 average steps |
+| deepseek-v4-pro [max] | 63% | $1.67 | Dominated / provider fallback | DeepSeek diversity only; GLM-5.3 Flash has a higher unrounded score, fewer steps, and about one seventh of the cost |
 | claude-opus-4.8 [max] | 59% | $13.22 | Fallback only | Anthropic diversity and long-context behavior, not cost efficiency |
-| qwen3.8-max [xhigh] | 57% | $3.73 | Provider fallback | Qwen diversity only; DeepSeek Pro and Luna dominate it |
-| muse-spark-1.2 [xhigh] | 55% | $3.70 | Drop | DeepSeek Pro is cheaper and more accurate |
+| qwen3.8-max [xhigh] | 57% | $3.73 | Provider fallback | Qwen diversity only; GLM-5.3 Flash and Luna dominate it |
+| muse-spark-1.2 [xhigh] | 55% | $3.70 | Drop | GLM-5.3 Flash is cheaper and more accurate |
 | claude-sonnet-5 [max] | 54% | $26.40 | Drop everywhere | Highest task cost and 268 average steps for a mid-table score |
-| grok-4.5 [high] | 54% | $2.42 | Superseded | Grok 4.6 adds 13 points; cheaper frontier models still dominate both generations |
-| deepseek-v4-flash [max] | 53% | $0.10 | Frontier (cheapest) | Very cheap mechanical loops that can tolerate lower accuracy and 153 average steps |
-| muse-spark-1.1 [xhigh] | 53% | $2.36 | Superseded | Replaced by Muse Spark 1.2 and dominated by DeepSeek Pro |
-| gpt-5.4 [xhigh] | 52% | $5.65 | Superseded | Luna is cheaper and 15 points more accurate |
+| grok-4.5 [high] | 54% | $2.42 | Historical — off the live board | Last published measurement; superseded by Grok 4.6 and dominated by current frontier models |
+| deepseek-v4-flash [max] | 53% | $0.46 | Dominated / provider fallback | DeepSeek diversity only; GLM-5.3 Flash is ten points more accurate for about half the cost |
+| muse-spark-1.1 [xhigh] | 53% | $2.36 | Historical — off the live board | Last published measurement; replaced by Muse Spark 1.2 and dominated by current frontier models |
+| gpt-5.4 [xhigh] | 52% | $5.65 | Historical — off the live board | Last published measurement; Luna is cheaper and 15 points more accurate |
 | gemini-3.6-flash [high] | 47% | $2.21 | Drop from reasoning | Superseded by Gemini 3.7 Flash |
 | glm-5.2 [max] | 44% | $3.92 | Superseded | Measured predecessor only; do not relabel this as GLM-5.3 |
 | gemini-3.5-flash [high] | 36% | $3.45 | Drop from reasoning | Retain only where a low-effort retrieval role has separate evidence |
-| kimi-k2.7-code [low] | 31% | $2.19 | Superseded | Kimi K3 is the current family fallback |
-| claude-sonnet-4.6 [high] | 30% | $5.52 | Drop everywhere | Removed from all chains |
-| gemini-3.1-pro [high] | 12% | $2.14 | Drop everywhere | Removed from all chains |
+| kimi-k2.7-code | 31% | $2.82 | Historical — off the live board | Last published measurement had no effort level; Kimi K3 is the current family fallback |
+| claude-sonnet-4.6 [high] | 30% | $5.52 | Historical — off the live board | Last published measurement; removed from all chains |
+| gemini-3.1-pro-preview [high] | 12% | $2.14 | Historical — off the live board | Last published measurement; removed from all chains |
 
 <Note>
-DeepSWE values above use the v1.1 results and reporting corrections published through August 20, 2026; `pass@1` is rounded as on the live leaderboard and confidence intervals are omitted here. The highest published thinking level is a measurement choice, not a production default. GPT-5.6 Terra's July measurement no longer appears on the live board, so its row keeps the last published values. See the live page for intervals, output tokens, steps, lower-effort configurations, and later corrections.
+DeepSWE values above use the v1.1 results displayed on the August 26, 2026 leaderboard, including the August 21 pricing corrections for GPT-5.6 Sol and DeepSeek V4. Sol's cost reflects OpenAI's promotional input and output price cut through at least November 21, 2026. DeepSWE uses DeepSeek's peak rates; its off-peak rates are half as much. `pass@1` is rounded as on the live leaderboard and confidence intervals are omitted here. The highest published thinking level is a measurement choice, not a production default. Seven historical configurations are retained with their last published values because they are no longer displayed: GPT-5.6 Terra, Grok 4.5, Muse Spark 1.1, GPT-5.4, Kimi K2.7 Code, Claude Sonnet 4.6, and Gemini 3.1 Pro Preview. See the live page for intervals, output tokens, steps, lower-effort configurations, and later corrections.
 </Note>
 
 ## Role-based thinking effort
@@ -82,10 +83,10 @@ Reserve `max` for a high-cost-of-error role or an explicit user request. An expl
 Pick by the cost of being wrong in each role, not by raw accuracy. Match the role to the benchmark that best measures it (see [Benchmark sources](/models/artificial-analysis-index)).
 
 - **Reviewer / judgment gates** — use `max` when the reviewer makes a security, identity, adversarial, or final-approval decision whose wrong verdict discards an entire loop. `claude-opus-5` is the DeepSWE accuracy ceiling; `gpt-5.6-sol` is the lower-cost near-peer. Use another family when decorrelated errors matter.
-- **Codebase mapping / planner** — start at `high` for repository mapping, lifecycle analysis, compatibility, and plans. `gpt-5.6-sol` is the strongest top-tier value at its measured `max` configuration, and `glm-5.3` carries the open-weights mid tier; raise production effort to `max` only when the plan gates a high-cost loop or the user asks for it.
+- **Codebase mapping / planner** — start at `high` for repository mapping, lifecycle analysis, compatibility, and plans. `gpt-5.6-sol` is the strongest top-tier value at its measured `max` configuration, and `glm-5.3` holds the open-weights mid tier; raise production effort to `max` only when the plan gates a high-cost loop or the user asks for it.
 - **Debugger / triage / repair** — start at `high`; deep reasoning pays off when root-causing or repairing is costly. Weight DeepSWE and Terminal-Bench together rather than treating either as a complete measure.
 - **Research / synthesis** — use `high` for demanding research and evidence reconciliation; use `medium` for routine synthesis when the evidence is already strong. `gpt-5.6-luna` remains the workhorse. Benchmark to weight: AA-LCR and AA-Omniscience.
-- **Orchestrator / worker / cheap loops** — Luna offers the best broad cost/accuracy balance. DeepSeek V4 Pro and Flash occupy the budget frontier but take 155 and 153 steps on average; use them only when that longer path fits. Use another family when provider diversity matters.
+- **Orchestrator / worker / cheap loops** — Luna offers the best broad cost/accuracy balance. GLM-5.3 Flash is the cheapest live frontier point at 63% for $0.24 with 123 average steps. DeepSeek V4 Pro and Flash are provider-diversity options, not budget-frontier choices.
 - **User-impact review / final reporting** — use `medium` for impact summaries and reports that preserve the evidence needed by the user. Do not spend `max` here unless the user explicitly requests it or the role has become a high-cost-of-error approval.
 - **Design** — a quality-first, unbenchmarked domain; keep a top-tier model (`gpt-5.6-sol` or `claude-fable-5`) when the design decision has high failure cost, and choose effort by the review or approval role rather than by the benchmark row.
 - **Interactive coding sessions** — use `high` for complex, multi-step coding and `medium` for routine edits; reserve `max` for a high-cost-of-error judgment or an explicit user request.

--- a/packages/coding-agent/docs/models/pareto-efficiency.md
+++ b/packages/coding-agent/docs/models/pareto-efficiency.md
@@ -5,58 +5,65 @@ description: "Cost-vs-accuracy frontier for model selection: which models domina
 
 # Pareto Efficiency
 
-A model is **Pareto-efficient** (on the frontier) if no other model is both cheaper and more accurate. Everything not on the frontier is **dominated** — some other option matches or beats it on accuracy for less money — and should be avoided unless it earns a slot through a specific role fit or provider diversity.
+A model is **Pareto-efficient** (on the frontier) if no other model is both cheaper and more accurate. Everything not on the frontier is **dominated**: some other option matches or beats it on accuracy for less money. Avoid a dominated model unless it earns a slot through a specific role fit or provider diversity.
 
 The axes here are `pass@1` (accuracy) and `average dollars per task` (cost), taken from the [DeepSWE](https://deepswe.datacurve.ai/) coding-agent leaderboard. For the full table and role guidance, see [Model Selection](/models/model-selection).
 
 <Note>
-Figures are a snapshot of DeepSWE v1.1 using the highest published thinking level per model and reporting corrections through August 20, 2026. The frontier moves whenever a model, run, or price changes — DeepSWE publishes a live cost-vs-score scatter, so **read the frontier off the live chart** rather than trusting a static list. **Last compiled: 2026-08-21.**
+Figures are a snapshot of DeepSWE v1.1 using the highest published thinking level for each of the 19 models displayed on the August 26, 2026 leaderboard. They include the August 21 pricing corrections for GPT-5.6 Sol and DeepSeek V4. DeepSWE publishes a live cost-vs-score scatter, so **read the frontier off the live chart** rather than trusting a static list. **Last compiled: 2026-09-01.**
 </Note>
 
 ## The frontier
 
-Six highest-effort model configurations currently sit on the frontier, from the cheapest measured task cost to the accuracy ceiling:
+Five displayed highest-effort model configurations sit on the frontier, from the cheapest measured task cost to the accuracy ceiling:
 
-- **deepseek-v4-flash [max]** — 53% for $0.10. The cheapest point, with lower accuracy and 153 average steps.
-- **deepseek-v4-pro [max]** — 63% for $0.24. A large accuracy gain for another $0.14 per task, with 155 average steps.
-- **gpt-5.6-luna [max]** — 67% for $0.61. The best broad value on the board.
-- **glm-5.3 [max]** — 69% for $3.99. The open-weights mid-tier point; matches Kimi K3's rounded score for less.
-- **gpt-5.6-sol [max]** — 73% for $8.39. The lower-cost near-peer to the accuracy leader.
-- **claude-opus-5 [max]** — 74% for $11.84. The current accuracy ceiling.
+- **glm-5.3-flash [max]**: 63% for $0.24 with 123 average steps. This is the cheapest point.
+- **gpt-5.6-luna [max]**: 67% for $0.61. This is the best broad value on the board.
+- **glm-5.3 [max]**: 69% for $3.99 with 124 average steps. This is the open-weights mid-tier point and matches Kimi K3's rounded score for less.
+- **gpt-5.6-sol [max]**: 73% for $6.46 with 61 average steps. This is the lower-cost near-peer to the accuracy leader.
+- **claude-opus-5 [max]**: 74% for $11.84 with 99 average steps. This is the current accuracy ceiling.
 
-## What changed — the frontier moved
+## What changed
 
-The August 20 refresh reshuffled the middle of the frontier:
+The August 26 snapshot moves the budget end of the frontier and lowers the cost of its upper end:
 
-- **GLM-5.3 [max]** is now measured — 69% for $3.99 with 124 average steps — and takes the mid-tier frontier slot.
-- **GPT-5.6 Terra [max]** no longer appears on the live board; its July measurement (70% for $3.96) is retained in [Model Selection](/models/model-selection) as history, not a current frontier point.
-- **Kimi K3 [max]** is now strictly dominated: GLM-5.3 matches its rounded score for $0.66 less per task.
+- **GLM-5.3 Flash [max]** now appears at 63% for $0.24 with 123 average steps. It replaces both DeepSeek V4 configurations on the budget frontier.
+- **DeepSeek V4 Pro [max]** now costs $1.67 per task after DeepSeek's August 16 price change. GLM-5.3 Flash has a higher unrounded score (63.4% versus 62.8%), costs about one seventh as much, and averages 32 fewer steps.
+- **DeepSeek V4 Flash [max]** now costs $0.46 per task. GLM-5.3 Flash is ten rounded points more accurate and costs about half as much.
+- **GPT-5.6 Sol [max]** now costs $6.46 per task after OpenAI's August 20 promotional price cut, down from $8.39 in the previous snapshot. The reduced input and output rates run through at least November 21, 2026.
 
-## Dominated models — and why
+DeepSWE's August 21, 2026 changelog says these DeepSeek costs use peak rates and off-peak rates are half as much. DeepSeek V4 Pro remains dominated at either rate. At the off-peak rate, DeepSeek V4 Flash costs about $0.23, marginally less than GLM-5.3 Flash's $0.24, but remains ten rounded points less accurate; these pages report the frontier from DeepSWE's published peak-rate costs.
 
-- **claude-fable-5 [max]** — Sol is more accurate and much cheaper; GLM-5.3 comes within a point for less than one fifth of the task cost.
-- **kimi-k3 [max]** — GLM-5.3 matches its rounded score and is $0.66 cheaper; Kimi remains useful for Moonshot-family diversity.
-- **gpt-5.5 [xhigh]** and **grok-4.6 [xhigh]** — Luna matches their rounded 67% for $0.61.
-- **gemini-3.7-flash [high]** — Luna is two points more accurate and less than one third of its task cost.
-- **grok-4.5 [high]**, **muse-spark-1.1 [xhigh]**, **muse-spark-1.2 [xhigh]**, and **gpt-5.4 [xhigh]** — the new DeepSeek and GPT-5.6 points dominate these former budget choices.
-- **claude-opus-4.8 [max]** and **claude-sonnet-5 [max]** — dominated on both cost and accuracy.
-- **qwen3.8-max [xhigh]**, **gemini-3.6-flash [high]**, **gemini-3.5-flash [high]**, **glm-5.2 [max]**, **kimi-k2.7-code [low]**, **claude-sonnet-4.6 [high]**, and **gemini-3.1-pro [high]** — each has a cheaper, more accurate measured alternative.
+## Dominated models and why
+
+- **deepseek-v4-pro [max]**: GLM-5.3 Flash has a higher unrounded score, costs $1.43 less, and averages 123 steps instead of 155.
+- **deepseek-v4-flash [max]**: GLM-5.3 Flash is ten rounded points more accurate and costs $0.22 less.
+- **claude-fable-5 [max]**: Sol is more accurate and much cheaper; GLM-5.3 comes within a point for less than one fifth of the task cost.
+- **kimi-k3 [max]**: GLM-5.3 matches its rounded score and is $0.66 cheaper; Kimi remains useful for Moonshot-family diversity.
+- **gpt-5.5 [xhigh]** and **grok-4.6 [xhigh]**: Luna matches their rounded 67% for $0.61.
+- **gemini-3.7-flash [high]**: Luna is two points more accurate and costs less than one third as much.
+- **muse-spark-1.2 [xhigh]**: GLM-5.3 Flash is eight points more accurate and costs $3.46 less.
+- **claude-opus-4.8 [max]** and **claude-sonnet-5 [max]**: each is dominated on both cost and accuracy.
+- **qwen3.8-max [xhigh]**, **gemini-3.6-flash [high]**, **gemini-3.5-flash [high]**, and **glm-5.2 [max]**: each has a cheaper, more accurate displayed alternative.
+
+Seven measured configurations are no longer displayed on the live leaderboard and are excluded from this current frontier calculation. [Model Selection](/models/model-selection) keeps their last published values as clearly labeled history: GPT-5.6 Terra, Grok 4.5, Muse Spark 1.1, GPT-5.4, Kimi K2.7 Code, Claude Sonnet 4.6, and Gemini 3.1 Pro Preview.
 
 ## Diversity and role-fit exceptions
 
 Efficiency is not the only axis. A dominated model can still earn a slot when it decorrelates errors or fills a niche:
 
-- **grok-4.6** — retained as the operational xAI and OpenRouter provider-diversity fallback.
-- **glm-5.2 [max]** — kept only as a measured predecessor; its results are never relabeled as GLM-5.3, which is now measured directly on the frontier.
-- **kimi-k3** — retained as a Moonshot-family provider-diversity option despite GLM-5.3's strict DeepSWE dominance.
-- **claude-opus-4.8 [max]** — retained where Anthropic diversity or its long-context behavior has separate value.
-- **claude-fable-5** — kept where Anthropic-family behavior is specifically wanted, such as the quality-first, unbenchmarked design chain.
-- **Unmeasured models** — a family without current DeepSWE or Artificial Analysis coverage may remain an operational default, but should not inherit a predecessor's score.
+- **deepseek-v4-pro** and **deepseek-v4-flash** remain DeepSeek provider-diversity options, not budget-frontier choices.
+- **grok-4.6** remains the operational xAI and OpenRouter provider-diversity fallback.
+- **glm-5.2 [max]** remains only as a measured predecessor; its results are never relabeled as GLM-5.3 or GLM-5.3 Flash.
+- **kimi-k3** remains a Moonshot-family provider-diversity option despite GLM-5.3's strict DeepSWE dominance.
+- **claude-opus-4.8 [max]** remains useful where Anthropic diversity or its long-context behavior has separate value.
+- **claude-fable-5** remains useful where Anthropic-family behavior is specifically wanted, such as the quality-first, unbenchmarked design chain.
+- **Unmeasured models** may remain operational defaults when a family lacks current DeepSWE or Artificial Analysis coverage, but they should not inherit a predecessor's score.
 
 ## How to use this
 
 1. Default to a frontier model for the role's accuracy needs (see [Model Selection](/models/model-selection)).
-2. Only reach for a dominated model when you have an explicit reason — provider diversity, a long-context or token-price niche, or an unbenchmarked domain like design.
+2. Only reach for a dominated model when you have an explicit reason, such as provider diversity, a long-context or token-price niche, or an unbenchmarked domain like design.
 3. Re-read the frontier off the [DeepSWE live chart](https://deepswe.datacurve.ai/) when prices or benchmarks change, and update the timestamp on these pages.
 
 ## Related


### PR DESCRIPTION
## Summary

The three model-reference pages were compiled against the August 21, 2026 DeepSWE snapshot. The live board has moved since: it now reports 113 tasks generated August 26, 2026, and the August 21 changelog carries pricing corrections that invalidate the budget end of the frontier the docs recommend from.

This refresh recompiles the pages from the live source. The recommendation chart gains GLM-5.3 Flash, four costs are corrected, the Pareto frontier is recomputed rather than carried forward, and every "DeepSeek is the budget choice" recommendation is replaced, because the repricing made both DeepSeek configurations strictly dominated.

Docs only. No runtime code, no test, no changelog entry.

## What changed

**The frontier shrank from six members to five, and swapped its cheap end.** Recomputed by a dominance sweep over the 19 configurations the live board displays, at the highest published effort per model:

| | pass@1 | $/task | steps |
| --- | --- | --- | --- |
| glm-5.3-flash `[max]` | 63% | $0.24 | 123 |
| gpt-5.6-luna `[max]` | 67% | $0.61 | — |
| glm-5.3 `[max]` | 69% | $3.99 | 124 |
| gpt-5.6-sol `[max]` | 73% | $6.46 | 61 |
| claude-opus-5 `[max]` | 74% | $11.84 | 99 |

Fourteen displayed configurations are dominated. Both DeepSeek entries left the frontier.

**DeepSeek lost the budget frontier outright.** After DeepSeek's August 16 price change, `deepseek-v4-pro` went $0.24 → $1.67 and `deepseek-v4-flash` went $0.10 → $0.46. GLM-5.3 Flash now beats Pro on unrounded score (63.4% vs 62.8%), on cost (about one seventh), and on steps (123 vs 155); it beats Flash by ten rounded points at about half the cost. The scenario guidance, both table verdicts, and the `qwen3.8-max` / `muse-spark-1.2` comparators were rewritten accordingly. DeepSeek is retained as provider diversity, which is what it now is.

**GPT-5.6 Sol repriced $8.39 → $6.46** after OpenAI's August 20 promotional cut, which runs through at least November 21, 2026. The Opus 5 comparison changed from "lower cost" to "about half the task cost".

**Seven models are off the live board, not one.** The site measures 26 models and displays 19. The docs previously flagged only `gpt-5.6-terra`; `grok-4.5`, `muse-spark-1.1`, `gpt-5.4`, `kimi-k2.7-code`, `claude-sonnet-4.6`, and `gemini-3.1-pro-preview` are equally undisplayed. All seven now carry the verdict `Historical — off the live board` plus a "last published measurement" qualifier, and both pages enumerate the same seven in the same order, so a historical row cannot be read as a live result.

**Two pre-existing errors fixed along the way**, both found while diffing rows against the source rather than briefed in advance:

- `kimi-k2.7-code` was recorded as `[low]` / $2.19. The source shows no effort level and $2.82; the $2.19 was `claude-sonnet-5 [low]`'s cost.
- `gemini-3.1-pro` is `gemini-3-1-pro-preview` on the source. The row now uses the real ID.

**Snapshot dates aligned** across all three pages: source updated August 26, 2026; last compiled/reviewed 2026-09-01. `artificial-analysis-index.md` gains an explicit snapshot line (v1.1, 113 tasks, 91 repositories, 5 languages, 26 measured, 19 displayed).

## Verification

Figures were not copied from the rendered table. The live page embeds a structured payload behind the 19 rendered rows — 63 effort configurations across 26 models, `generated_at 2026-08-26T07:38:24Z`, `n_tasks_in_set 113` — and every row, cost, step count, and prose arithmetic claim was checked against it. Three reviewers independently re-fetched the source, re-parsed the payload, and re-ran the dominance sweep under both rounded and unrounded `pass@1`; all four derivations returned the same five-member, fourteen-dominated frontier.

Repository checks, run at `8824854`:

- `vitest --run --project unit test/unit/execution-routing-guidance.test.ts` — 42/42 passed, exit 0.
- `packages/coding-agent$ bun run docs:check` — passed, 38 Markdown/MDX files, 38 docs pages, exit 0.

**Honest limits on that green.** The vitest suite is a no-regression guard, not evidence for this diff: it reads `model-selection.md` at two assertion sites covering the role/effort table, the "Reserve `max`" block, and two forbidden substrings, and it constrains none of the 57 changed lines. `pareto-efficiency.md` and `artificial-analysis-index.md` have no test coverage at all. The load-bearing evidence is the source re-derivation above. Adding figure-asserting tests would hard-code a live leaderboard that these pages explicitly tell readers to re-read from source, so none were added. Mintlify page rendering is unverified — no `mint`/`mintlify` CLI is installed — and `docs:check` is the applicable substitute.

`biome check` on the changed paths exits 1 with "these paths were provided but ignored" and processes zero files. Biome's configuration excludes Markdown; this is not a lint failure.

## Two disclosures

**Off-peak DeepSeek pricing.** An earlier draft of this branch closed the dominance argument with "both configurations remain dominated when the calculation uses the peak-rate costs that DeepSWE publishes", which is circular and implies the result survives the choice of rate. It does not. DeepSWE's changelog states off-peak is half, so `deepseek-v4-flash` runs about $0.23 off-peak against GLM-5.3 Flash's $0.24 — marginally cheaper. The text now states the real sensitivity: Pro is dominated at either rate, Flash is marginally cheaper off-peak but ten rounded points less accurate, and these pages report DeepSWE's published peak-rate frontier.

**Terra and the displayed-19 scope.** `gpt-5.6-terra` is not stale data; it sits in the current August 26 payload at 69.62% / $3.96, and if it were displayed it would strictly dominate `glm-5.3` ($3.96 < $3.99, 69.62% > 68.96%). So "glm-5.3 is on the frontier" holds under the displayed-19 scope, which `pareto-efficiency.md` states twice on the page that makes the claim. Preserving Terra as labeled history matches what `main` already did.

## Changelog

None, deliberately. `AGENTS.md` scopes `packages/*/CHANGELOG.md` to shipped package behavior; this is a docs-only reference refresh. No `issues.md` remains.

## Scope

Three files under `packages/coding-agent/docs/models/`, +57/-48. No code, test, config, or CI file touched. Prepared in an isolated worktree on `docs/deepswe-aug-2026` based on `origin/main` at `7279ce2fc0`; the primary checkout was not modified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790847659&installation_model_id=10562&pr_number=2798&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2798&signature=f07a30b46b8adc38970209d0354e0848342b544de5946dfe70da0fe58d30b573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change refreshes the DeepSWE v1.1 model-selection reference to the August 26, 2026 snapshot. It updates displayed leaderboard metadata, normalized pricing, the five-model cost/accuracy frontier, historical model labels, and role guidance. The live DeepSWE artifact and deployed display-price rules confirmed the documented 19 displayed models, frontier values, and DeepSeek comparisons. Documentation link, navigation, rendering, and frontmatter checks also passed for all three edited pages.

<h3>Confidence Score: 5/5</h3>

The documentation refresh is suitable to merge: its external benchmark statements and documentation rendering behavior were exercised successfully.

No independent defects remain in the final findings. The benchmark claims were checked against the live DeepSWE data and deployed client-side price normalization, including a raw-data negative control, while documentation validation passed before and after the edit.

**Files Needing Attention:** No files need further attention. The checked pages are packages/coding-agent/docs/models/artificial-analysis-index.md, model-selection.md, and pareto-efficiency.md.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the DeepSWE leaderboard by applying the client’s price revisions and selecting displayed models, confirming 19 models and five frontier points: GLM-5.3 Flash, GPT-5.6 Luna, GLM-5.3, GPT-5.6 Sol, and Claude Opus 5, with both DeepSeek V4 configurations dominated.
- Validated the repository documentation rendering and navigation checks, confirming the pages render correctly before and after the edit.
- Verified the frontier-point data and costs show the five normalized frontier points (GLM-5.3 Flash, GPT-5.6 Luna, GLM-5.3, GPT-5.6 Sol, Claude Opus 5) with their respective costs, and noted that the raw-source data would disagree without normalization because the deployed client revises prices before display.
- Documented that the PR scope includes three files and captured the exact commands, working directory, and exit codes used to run the validation checks.

<a href="https://app.greptile.com/trex/runs/21783953/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(models): refresh DeepSWE snapshot t..."](https://github.com/bastani-inc/atomic/commit/882485428aff4edc4ae182201c6cde0c60b0ca5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58982479)</sub>

<!-- /greptile_comment -->