### PR TITLE
docs(changelog): prepare 0.9.18-alpha.4 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.18-alpha.4] - 2026-09-01
+
+### Changed
+
+- The bundled model-selection reference documentation now tracks the August 26, 2026 DeepSWE v1.1 snapshot across the model-selection, Pareto-efficiency, and benchmark-source pages. Displayed pricing is corrected for GPT-5.6 Sol ($8.39 to $6.46 after OpenAI's promotional cut), DeepSeek V4 Pro ($1.67), and DeepSeek V4 Flash ($0.46). The recomputed Pareto frontier adds GLM-5.3 Flash as its cheapest point, moves both DeepSeek V4 configurations to provider-diversity options, and retains seven configurations no longer displayed on the live leaderboard as clearly labeled history. These static reference changes do not alter runtime routing or model defaults ([#2798](https://github.com/bastani-inc/atomic/pull/2798)).
+
 ## [0.9.18-alpha.2] - 2026-08-31
 
 ### Fixed


### PR DESCRIPTION
## Summary

Prepare the coding-agent release notes for the `0.9.18-alpha.4` prerelease. Coding-agent's `Unreleased` section was empty — the alpha.3 preparation only touched `packages/intercom` and `packages/workflows` — so this section is authored fresh from the merged `#2798` diff rather than promoted. This changelog-only PR must merge before the release tag is cut.

## Changes

- Add a dated `## [0.9.18-alpha.4] - 2026-09-01` section directly beneath `Unreleased` in `packages/coding-agent/CHANGELOG.md`.
- Record the bundled model-selection reference refresh from [#2798](https://github.com/bastani-inc/atomic/pull/2798): the August 26, 2026 DeepSWE v1.1 snapshot across the model-selection, Pareto-efficiency, and benchmark-source pages; corrected displayed pricing for GPT-5.6 Sol ($8.39 → $6.46), DeepSeek V4 Pro ($1.67), and DeepSeek V4 Flash ($0.46); and the recomputed Pareto frontier that adds GLM-5.3 Flash as its cheapest point, moves both DeepSeek V4 configurations to provider-diversity options, and keeps seven configurations no longer on the live leaderboard as clearly labeled history.
- The entry states explicitly that these are static reference changes and do not alter runtime routing or model defaults. No runtime behavior claim is made.

## Scope

`#2797` is deliberately absent: its pier/deep-swe submodule sync is repository infrastructure, which `AGENTS.md` excludes from package changelogs.

The diff contains only `packages/coding-agent/CHANGELOG.md`, with six added lines and no deletions. All eight package manifests, `package-lock.json` workspace entries, the `@bastani/atomic-natives` pin, `packages/natives/native/index.js` version checks, and the Cargo manifest/lock remain at `0.0.0`. No already-released changelog section is modified.

`main` stays versionless. After this PR merges, `scripts/cut-release.ts` may stamp `0.9.18-alpha.4` only on the detached Release commit. Pushing that tag starts `publish.yml`; this PR does not merge, tag, publish, dispatch, or rerun publication.

## Validation

- `npx vitest --run --project unit test/unit/build-release-notes.test.ts test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/bump-version-script.test.ts` (4 files, 35 tests passed)
- `bun run scripts/build-release-notes.ts 0.9.18-alpha.4` (exit 0, emits the intended documentation note)
- Versionless-invariant sweep across package manifests, `package-lock.json`, the natives pin, `packages/natives/native/index.js`, `Cargo.toml`, and `Cargo.lock` — all `0.0.0`
- Parsed the edited file through `packages/coding-agent/src/utils/changelog.ts`: `0.9.18-alpha.4` parses first with the bullet intact
- `git diff --check` clean; `packages/coding-agent/CHANGELOG.md` is the only path changed from `main`
- Pre-commit repository checks passed with hooks enabled

Assistant-model: Claude Opus 5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790873146&installation_model_id=10562&pr_number=2801&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2801&signature=fb523b2f2d52b913b8bb82f8df879d0c9e1764ae3bd98d747ce22c38326e2336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the `0.9.18-alpha.4` coding-agent release notes for the DeepSWE v1.1 model-reference refresh, including corrected displayed pricing, the recomputed Pareto frontier, and clearly labeled historical configurations. A generated-release-notes failure was disproved: the release-note generator emits one correctly dated and bounded alpha.4 Changed entry, without including alpha.2 content.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the documentation-only release entry is correctly discovered and rendered by the release-note generator.

The focused generator check compared the parent and current changelog states, confirmed the new heading and date, verified that the entry appears exactly once, and confirmed the section stops before the prior alpha.2 release.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The alpha.4 release-notes validation script was executed in /home/user/repo and completed successfully, discovering the alpha.4 entry exactly once with heading ## \[0.9.18-alpha.4\] - 2026-09-01 and cutoffToAlpha2=true, while the parent state contained no alpha.4 entry.

<a href="https://app.greptile.com/trex/runs/21853807/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.18-alpha.4 ..."](https://github.com/bastani-inc/atomic/commit/7f4d7dbc39c12bf34e57dff36635b10198a613ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59118487)</sub>

<!-- /greptile_comment -->