### PR TITLE
docs(changelog): prepare 0.9.18-alpha.5 release notes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
+## [0.9.18-alpha.5] - 2026-09-01
+
 ### Added
 
 - Added first-class Claude Fable 5.1 (`claude-fable-5-1`) support to the generated catalogs, for the providers Atomic has a matching runtime integration for. Each entry carries the model's 1,000,000-token context window, 128,000-token maximum output, and that provider's own pricing, including the reduced $0.25 per million cache read (a quarter of Claude Fable 5's rate) and the US-only inference premium on the Amazon Bedrock `us.` profile. Adaptive thinking is always on, `off` is denied, and exactly the five efforts Anthropic publishes — `low`, `medium`, `high`, `xhigh`, `max` — are selectable, with the `high` default preserved. Provider catalogs move independently of releases, so the exact mirror set tracks them rather than being fixed here; a provider "latest" alias may also route to Fable 5.1 without naming it.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.18-alpha.5] - 2026-09-01
+
 ### Added
 
 - Documented the Zed integrated-terminal `keymap.json` bindings that make Zed emit the Kitty-protocol sequences Atomic reads for `Shift+Enter` and friends ([#8828](https://github.com/earendil-works/pi/pull/8828)).

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.18-alpha.5] - 2026-09-01
+
 ### Fixed
 
 - A failed background reconnect no longer strands a live Intercom session. The next attempt is now scheduled after reconnect ownership is released, so a session whose broker restarts recovers on its own with bounded backoff instead of staying invisible until the next explicit Intercom call. A failing explicit `intercom` or overlay connection now leaves the same background retry behind rather than cancelling the one already scheduled, and a connection attempt that fails before it suspends can no longer park a settled promise in the reconnect slot and block every later attempt.


### PR DESCRIPTION
## Summary

Prepare the AI, coding-agent, and Intercom release notes for the `0.9.18-alpha.5` prerelease. This changelog-only PR promotes the accumulated `Unreleased` entries into dated release sections and must merge before the release tag is cut.

## Changes

- Record Claude Fable 5.1 catalogs and compatibility, preserved-thinking and fallback handling, PDF input, sampling and forced-tool safeguards, OAuth compatibility, and related billing fixes.
- Record the bundled coding-agent model, selector, session-fork, extension-cwd, custom-provider, terminal, and documentation updates included since alpha.4.
- Record the Intercom reconnect recovery fixes for ordinary sessions and workflow-stage routing after broker churn.

## Scope

The diff contains only `packages/ai/CHANGELOG.md`, `packages/coding-agent/CHANGELOG.md`, and `packages/intercom/CHANGELOG.md`, with six added lines and no deletions. All eight package manifests, direct `package-lock.json` workspace entries, first-party dependency pins, Cargo workspace/lock metadata, generated native version checks, and optional version badges remain at `0.0.0`. The target version appears nowhere outside the three prepared changelogs, and no already-released changelog section is modified.

`main` stays versionless. After this PR merges, `scripts/cut-release.ts` may stamp `0.9.18-alpha.5` only on the detached Release commit. Pushing that tag starts `publish.yml`; this PR does not merge, tag, publish, dispatch, or rerun publication.

## Validation

- `bun run vitest --run --project unit test/unit/build-release-notes.test.ts test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/bump-version-script.test.ts` (4 files, 35 tests passed)
- `bun run scripts/build-release-notes.ts 0.9.18-alpha.5` (49-line merged release-notes body generated from all three prepared packages)
- Bun-based versionless-invariant validation across all eight package manifests, direct lockfile workspace entries, first-party pins, Cargo workspace inheritance and lock entry, generated native checks, and optional package README badges
- Changelog-only path check, target-version scope check, and `git diff --check`
- Pre-commit repository checks passed with hooks enabled

Assistant-model: GPT-5.6 Sol

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790905200&installation_model_id=10562&pr_number=2810&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2810&signature=a78cc2e51076a57e51064555b9724fedc3b5fea0da75a53e5fa3e01e4fc9d2ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change publishes the accumulated AI, coding-agent, and Intercom notes under `0.9.18-alpha.5`.

A release-notes failure caused by missing versioned changelog sections was disproved: generation succeeds at the updated revision, includes the promoted entries from all three packages, and preserves canonical Added, Changed, and Fixed groupings. The focused changelog, release-note, package-metadata, and version-bump checks passed, along with whitespace validation.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the versioned changelog sections generate complete release notes and preserve release metadata invariants.

No defects remain. Generation was compared before and after the release-note promotion, and focused validation confirmed the published version is discoverable and correctly merged across all affected packages.

**Files Needing Attention:** None. The changed changelogs in `packages/ai`, `packages/coding-agent`, and `packages/intercom` were covered by release-note and metadata validation.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to generate release notes against the base revision's archived changelogs and failed due to no package documenting 0.9.18-alpha.5.
- After changelog promotion, T-Rex generated release notes against the updated revision and obtained merged notes including the promoted AI, coding-agent, and Intercom content.
- T-Rex validated that the merged release notes contain three canonical headings and representative content for the promoted sources.
- T-Rex ran focused validation checks for release-note, changelog, package-metadata, version-bump, and whitespace; all 35 tests passed.

<a href="https://app.greptile.com/trex/runs/21959644/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.18-alpha.5 ..."](https://github.com/bastani-inc/atomic/commit/3f83de7916f6a0cb32f5cf5b2395e154ba56246b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59320411)</sub>

<!-- /greptile_comment -->