### PR TITLE
feat(settings): expose keybinding configuration

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an informational **Keybindings** row to `/settings` that shows the active agent directory's `keybindings.json` path and points to `/hotkeys`, the complete Keybindings documentation, and `/reload` without changing any shortcuts or editor behavior ([#2629](https://github.com/bastani-inc/atomic/issues/2629)).
+
 ## [0.9.18-alpha.5] - 2026-09-01
 
 ### Added

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -9,6 +9,10 @@ Atomic uses JSON settings files with project settings overriding global settings
 
 Edit directly or use `/settings` for common options. To save startup model defaults interactively, use `/model` and press Ctrl+S on the desired model; to save the startup thinking level, use `/thinking` and press Ctrl+S. Atomic also reads legacy `~/.pi/agent/settings.json` and `.pi/settings.json` as compatibility fallbacks, with `.atomic` paths taking precedence.
 
+## Keybindings
+
+`/settings` shows the active agent directory's `keybindings.json` path in its informational **Keybindings** row. This reflects custom agent directories and Windows paths instead of assuming `~/.atomic/agent/keybindings.json`. Edit that file and run `/reload` to apply the changes. `/hotkeys` shows common active and extension shortcuts; see [Keybindings](/keybindings) for the complete reference and configuration format.
+
 ## Project Trust
 
 On interactive startup, Atomic asks before trusting a project folder that contains trust-gated project inputs and has no saved decision for the folder or a parent folder in `~/.atomic/agent/trust.json`. Trusting a project allows Atomic to load project-local `.atomic/settings.json` and `.atomic` resources, legacy `.pi/settings.json` and `.pi` resources, project-local context files, install missing project packages, and execute project extensions.

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -50,7 +50,7 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | `/scoped-models` | Enable/disable models for CTRL+P cycling |
 | `/fast` | Configure fast mode for chat and workflow stages when supported OpenAI or GitHub Copilot models are available |
 | `/workflow` | List/run workflows; manage runs (connect/inspect/pause/interrupt/quit/resume); reload workflow resources |
-| `/settings` | Theme, message delivery, transport, and other preferences |
+| `/settings` | Keybinding configuration, theme, message delivery, transport, and other preferences |
 | `/resume` | Pick from previous sessions |
 | `/new` | Start a new session |
 | `/name <name>` | Set session display name |
@@ -63,7 +63,7 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | `/export [file]` | Export session to HTML |
 | `/share` | Upload as private GitHub gist with shareable HTML link |
 | `/reload` | Reload keybindings, extensions, skills, prompts, and context files |
-| `/hotkeys` | Show all keyboard shortcuts |
+| `/hotkeys` | Show common active and extension shortcuts; see [Keybindings](/keybindings) for the complete reference |
 | `/changelog` | Display version history |
 | `/exit` | Exit Atomic |
 | `/quit` | Quit Atomic |

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector-items.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector-items.ts
@@ -139,6 +139,13 @@ export function buildSettingsItems(config: SettingsConfig, callbacks: SettingsCa
 
 	const items: SettingItem[] = [
 		{
+			id: "keybindings",
+			label: "Keybindings",
+			description:
+				"Edit this file, then run /reload. /hotkeys shows common active and extension shortcuts; the Keybindings documentation is the complete reference.",
+			currentValue: config.keybindingsPath,
+		},
+		{
 			id: "autocompact",
 			label: "Auto-compact",
 			description: "Automatically compact context when it gets too large",

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector-types.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector-types.ts
@@ -14,6 +14,7 @@ export type DoubleEscapeAction = "fork" | "tree" | "none";
 export type TreeFilterMode = "default" | "no-tools" | "user-only" | "labeled-only" | "all";
 
 export interface SettingsConfig {
+	keybindingsPath: string;
 	autoCompact: boolean;
 	showImages: boolean;
 	imageWidthCells: number;

--- a/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { InteractiveModeBase } from "./interactive-mode-base.ts";
 import {
 	type Component,
@@ -81,6 +82,7 @@ InteractiveModeBase.prototype.showSettingsSelector = function (this: Interactive
 	this.showSelector((done) => {
 		const component = new SettingsSelectorComponent(
 			{
+				keybindingsPath: join(this.runtimeHost.services.agentDir, "keybindings.json"),
 				autoCompact: this.session.autoCompactionEnabled,
 				showImages: this.settingsManager.getShowImages(),
 				imageWidthCells: this.settingsManager.getImageWidthCells(),

--- a/packages/coding-agent/test/interactive-selectors-tui-mode.test.ts
+++ b/packages/coding-agent/test/interactive-selectors-tui-mode.test.ts
@@ -39,6 +39,7 @@ class SelectorTerminal implements Terminal {
 
 function openSettingsSelector() {
 	const settingsManager = SettingsManager.inMemory({});
+	const agentDir = "C:\\Users\\dev\\custom-atomic-agent";
 	let selector: SettingsSelectorComponent | undefined;
 	const renderer = createInteractiveTui({
 		showHardwareCursor: false,
@@ -47,7 +48,7 @@ function openSettingsSelector() {
 	});
 	const mode = Object.assign(Object.create(InteractiveMode.prototype), {
 		runtimeHost: {
-			services: { agentDir: "/tmp" },
+			services: { agentDir },
 			session: {
 				settingsManager,
 				autoCompactionEnabled: true,
@@ -78,7 +79,7 @@ function openSettingsSelector() {
 
 	mode.showSettingsSelector();
 	if (!selector) throw new Error("settings selector was not created");
-	return { mode, selector };
+	return { agentDir, mode, selector };
 }
 
 beforeEach(() => {
@@ -104,5 +105,17 @@ test("settings selector keeps fullscreen scrollbar available", () => {
 	const rendered = stripTerminalSequences(selector.getSettingsList().render(120).join("\n"));
 
 	expect(rendered).toMatch(/Fullscreen scrollbar\s+auto/);
+	mode.ui.stop();
+});
+
+test("/settings renders keybinding guidance for the active agent directory", () => {
+	const { agentDir, mode, selector } = openSettingsSelector();
+	const rendered = stripTerminalSequences(selector.getSettingsList().render(160).join("\n"));
+
+	expect(rendered).toContain("Keybindings");
+	expect(rendered).toContain(`${agentDir}\\keybindings.json`);
+	expect(rendered).toContain("/reload");
+	expect(rendered).toContain("/hotkeys shows common active and extension shortcuts");
+	expect(rendered).toContain("Keybindings documentation is the complete reference");
 	mode.ui.stop();
 });

--- a/packages/coding-agent/test/pi-0.84.2-fullscreen-exit-output.test.ts
+++ b/packages/coding-agent/test/pi-0.84.2-fullscreen-exit-output.test.ts
@@ -20,6 +20,7 @@ const EXIT_ALT_SCREEN = "\x1b[?1049l";
 
 function createSettingsConfig(): SettingsConfig {
 	return {
+		keybindingsPath: "/tmp/custom-agent/keybindings.json",
 		autoCompact: true,
 		showImages: true,
 		imageWidthCells: 60,

--- a/packages/coding-agent/test/settings-per-model-thinking.test.ts
+++ b/packages/coding-agent/test/settings-per-model-thinking.test.ts
@@ -11,6 +11,7 @@ beforeAll(() => {
 
 function settingsConfig(overrides: Partial<SettingsConfig> = {}): SettingsConfig {
 	return {
+		keybindingsPath: "/tmp/custom-agent/keybindings.json",
 		autoCompact: true,
 		showImages: false,
 		imageWidthCells: 60,

--- a/packages/coding-agent/test/settings-selector-tui-mode.test.ts
+++ b/packages/coding-agent/test/settings-selector-tui-mode.test.ts
@@ -6,6 +6,7 @@ import type { SettingsCallbacks, SettingsConfig } from "../src/modes/interactive
 
 function createSettingsConfig(): SettingsConfig {
 	return {
+		keybindingsPath: "/tmp/custom-agent/keybindings.json",
 		autoCompact: true,
 		showImages: true,
 		imageWidthCells: 60,

--- a/packages/coding-agent/test/settings-selector.test.ts
+++ b/packages/coding-agent/test/settings-selector.test.ts
@@ -14,6 +14,7 @@ beforeAll(() => {
 
 function settingsConfig(overrides: Partial<SettingsConfig> = {}): SettingsConfig {
 	return {
+		keybindingsPath: "/tmp/custom-agent/keybindings.json",
 		autoCompact: true,
 		showImages: false,
 		imageWidthCells: 60,

--- a/test/unit/pi-parity-group-5.test.ts
+++ b/test/unit/pi-parity-group-5.test.ts
@@ -146,6 +146,7 @@ describe("Group 5 parity", () => {
 	test("settings place output padding before autocomplete and expose cache notices", () => {
 		const items = buildSettingsItems(
 			{
+				keybindingsPath: "/tmp/custom-agent/keybindings.json",
 				autoCompact: true,
 				showImages: true,
 				imageWidthCells: 60,


### PR DESCRIPTION
## Summary

- add one informational **Keybindings** row to `/settings`
- show the active agent directory's `keybindings.json` path, including custom directories and Windows paths
- point users to `/reload`, `/hotkeys`, and the complete Keybindings documentation
- leave all defaults and editor behavior unchanged
- update settings docs, command docs, and the Unreleased changelog

## Tests

- `npm run test --workspace=@bastani/atomic -- test/interactive-selectors-tui-mode.test.ts test/settings-selector-tui-mode.test.ts test/settings-selector.test.ts test/settings-per-model-thinking.test.ts test/pi-0.84.2-fullscreen-exit-output.test.ts` (20 passed)
- `npm run typecheck`
- `npx biome check --error-on-warnings <touched TypeScript files>`
- `npm audit` (0 vulnerabilities)

Closes #2629

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790935147&installation_model_id=10562&pr_number=2814&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2814&signature=cf554e96121f76104f9f9b6d0cf8ddece8460bd88e98e638cbd031c57278372d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=59439016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

No blocking failure remains.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Windows separator breaks Linux test** <a href="https://github.com/bastani-inc/atomic/pull/2814#discussion_r3912985786">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/coding-agent/test/interactive-selectors-tui-mode.test.ts:undefined-116
The selector builds this path with `path.join(agentDir, "keybindings.json")`, which appends `/keybindings.json` when the suite runs on Linux-even when `agentDir` itself looks like a Windows path. This assertion hard-codes `\keybindings.json`, so the focused Linux test fails. Build the expected path with `path.join(agentDir, "keybindings.json")` or assert the directory and filename separately.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

The settings screen now shows the active agent’s `keybindings.json` location and explains how to reload changes and find shortcut documentation.

The previously reported Windows separator failure in `packages/coding-agent/test/interactive-selectors-tui-mode.test.ts` is no longer present. A Linux rendering run with a Windows-looking agent directory confirmed that both the displayed value and the test expectation use the platform-aware `path.join` result, and the focused settings test passed.

<sub>Reviews (2) · Last reviewed commit: ["Merge remote-tracking branch &#39;upstream/m..."](https://github.com/bastani-inc/atomic/commit/dc5de277a0027211e14074e3bfb3e9fa379c82d3)</sub>

<!-- /greptile_comment -->