### PR TITLE
fix(workflows): recognize tool-only workflow nodes

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Heartbeat, workflow-tool, and builtin stage guidance now directs shared scope and acceptance-criteria amendments through one authoritative path broadcast rather than enumerating known stages, and teaches path discovery, globs, sticky delivery, and live-only asks.
 
+### Fixed
+
+- Tool-only workflows no longer emit a `ZERO_STAGES` discovery warning. The static scan now recognizes `ctx.tool()` as tracked graph work without advertising tool nodes as future chat-stage targets.
+
 ## [0.9.18-alpha.3] - 2026-09-01
 
 ### Added

--- a/packages/workflows/src/extension/discovery.ts
+++ b/packages/workflows/src/extension/discovery.ts
@@ -189,9 +189,9 @@ function validateConfig(config: unknown): string | null {
 }
 
 /**
- * D10 lint: a definition whose static scan yields zero possible stages logs a
- * warning. Scan failures never surface here (the scan reports its own
- * warnings and never blocks).
+ * D10 lint: a definition whose static scan finds neither possible stages nor
+ * another tracked node call logs a warning. Scan failures never surface here
+ * (the scan reports its own warnings and never blocks).
  */
 function zeroStageLintDiagnostic(
 	def: WorkflowDefinition,
@@ -199,17 +199,17 @@ function zeroStageLintDiagnostic(
 ): DiscoveryDiagnostic | undefined {
 	const entryPath = filePath ?? resolveBuiltinDefinitionSource(def.normalizedName);
 	if (entryPath === undefined) return undefined;
-	let stages: readonly string[];
+	let scan: ReturnType<typeof scanPossibleStagesFromSource>;
 	try {
-		stages = scanPossibleStagesFromSource(entryPath).stages;
+		scan = scanPossibleStagesFromSource(entryPath);
 	} catch {
 		return undefined;
 	}
-	if (stages.length > 0) return undefined;
+	if (scan.hasTrackedNodes || scan.stages.length > 0) return undefined;
 	return {
 		level: "warn",
 		code: "ZERO_STAGES",
-		message: `workflow "${def.name}" yielded zero possible stages: no ctx.stage/ctx.task/ctx.chain/ctx.parallel/ctx.workflow call sites were found by the static scan`,
+		message: `workflow "${def.name}" yielded zero possible stages: no ctx.stage/ctx.task/ctx.chain/ctx.parallel/ctx.workflow/ctx.tool call sites were found by the static scan`,
 		source: filePath ?? def.normalizedName,
 	};
 }

--- a/packages/workflows/src/shared/possible-stages.ts
+++ b/packages/workflows/src/shared/possible-stages.ts
@@ -13,6 +13,8 @@
  *     definition's own stages under that boundary segment, following the child
  *     through relative imports and the builtin export barrel
  *     (`@bastani/atomic/workflows/builtin` / `@bastani/workflows/builtin`).
+ *   - `<ctx>.tool(name, args, fn)` marks the definition as having tracked work
+ *     without advertising a chat-stage target.
  *
  * `<ctx>` is whatever identifier the run callback binds (`ctx`,
  * `workflowCtx`, …) plus local rebindings seeded from it; calls may be awaited
@@ -49,7 +51,7 @@ const BUILTIN_BARREL_SPECIFIERS: ReadonlySet<string> = new Set([
 /** Prefix of `.../builtin/<name>` subpath specifiers. */
 const BUILTIN_SUBPATH_PREFIXES = ["@bastani/atomic/workflows/builtin/", "@bastani/workflows/builtin/"];
 
-const STAGE_METHODS: ReadonlySet<string> = new Set(["stage", "task", "chain", "parallel", "workflow"]);
+const TRACKED_NODE_METHODS: ReadonlySet<string> = new Set(["stage", "task", "chain", "parallel", "workflow", "tool"]);
 
 export interface PossibleStagesScanOptions {
 	/**
@@ -63,6 +65,8 @@ export interface PossibleStagesScanOptions {
 export interface PossibleStagesScanResult {
 	/** Sorted, de-duplicated possible stage target paths (literals, globs, nested paths). */
 	readonly stages: readonly string[];
+	/** Whether the source contains any call site that can create a tracked graph node. */
+	readonly hasTrackedNodes: boolean;
 	/** Non-fatal scan warnings in deterministic traversal order. */
 	readonly warnings: readonly string[];
 }
@@ -85,6 +89,7 @@ export function scanPossibleStagesFromSource(
 	const scanner = new PossibleStagesScanner(maxDepth);
 	scanner.scanSubtree(resolve(entrySourcePath), "", 0, [resolve(entrySourcePath)]);
 	return {
+		hasTrackedNodes: scanner.hasTrackedNodes,
 		stages: [...scanner.stages].sort(),
 		warnings: scanner.warnings,
 	};
@@ -799,6 +804,7 @@ function collectDefinitionName(
 
 class PossibleStagesScanner {
 	readonly stages = new Set<string>();
+	hasTrackedNodes = false;
 	readonly warnings: string[] = [];
 	private readonly maxDepth: number;
 	private readonly units = new Map<string, FileUnit | undefined>();
@@ -898,6 +904,8 @@ class PossibleStagesScanner {
 		depth: number,
 		ancestorStack: readonly string[],
 	): void {
+		this.hasTrackedNodes = true;
+		if (call.method === "tool") return;
 		if (call.method === "workflow") {
 			this.handleWorkflowCall(call, unit, path, boundaryPrefix, depth, ancestorStack);
 			return;
@@ -1140,7 +1148,7 @@ function joinBoundary(prefix: string, segment: string): string {
 }
 
 interface CtxCall {
-	readonly method: "stage" | "task" | "chain" | "parallel" | "workflow";
+	readonly method: "stage" | "task" | "chain" | "parallel" | "workflow" | "tool";
 	/** Index of the `(` token opening the argument list. */
 	readonly argsOpen: number;
 }
@@ -1152,7 +1160,7 @@ function matchCtxCall(tokens: readonly Token[], index: number, ctxLike: Readonly
 	const dot = tokens[index + 1];
 	if (dot?.kind === "punct" && (dot.value === "." || dot.value === "?.")) {
 		const method = tokens[index + 2];
-		if (method?.kind === "ident" && STAGE_METHODS.has(method.value) && ctxLike.has(head.value)) {
+		if (method?.kind === "ident" && TRACKED_NODE_METHODS.has(method.value) && ctxLike.has(head.value)) {
 			return ctxCallAt(tokens, index + 2, method.value as CtxCall["method"]);
 		}
 	}
@@ -1168,7 +1176,7 @@ function matchCtxCall(tokens: readonly Token[], index: number, ctxLike: Readonly
 			secondDot?.kind === "punct" &&
 			(secondDot.value === "." || secondDot.value === "?.") &&
 			method?.kind === "ident" &&
-			STAGE_METHODS.has(method.value)
+			TRACKED_NODE_METHODS.has(method.value)
 		) {
 			return ctxCallAt(tokens, index + 4, method.value as CtxCall["method"]);
 		}

--- a/test/unit/workflow-possible-stages-persistence.test.ts
+++ b/test/unit/workflow-possible-stages-persistence.test.ts
@@ -280,6 +280,7 @@ describe("possible-stages discovery lint (D10)", () => {
 	test("a definition yielding zero stages logs a ZERO_STAGES warning", async () => {
 		writeWorkflow("lint-empty.ts", "\t\t\treturn {};");
 		writeWorkflow("lint-busy.ts", '\t\t\tawait ctx.stage("real-stage");\n\t\t\treturn {};');
+		writeWorkflow("lint-tool.ts", '\t\t\tawait ctx.tool("durable-check", {}, async () => "ok");\n\t\t\treturn {};');
 		const result = await discoverWorkflows({
 			cwd: TEST_DIR,
 			homeDir: join(TEST_DIR, "home"),
@@ -291,6 +292,7 @@ describe("possible-stages discovery lint (D10)", () => {
 		assert.match(zeroStages[0]?.message ?? "", /lint-empty/);
 		assert.equal(result.registry.has("lint-empty"), true, "the lint never blocks registration");
 		assert.equal(result.registry.has("lint-busy"), true);
+		assert.equal(result.registry.has("lint-tool"), true, "ctx.tool creates a tracked workflow node");
 	});
 });
 

--- a/test/unit/workflow-possible-stages-scan.test.ts
+++ b/test/unit/workflow-possible-stages-scan.test.ts
@@ -178,6 +178,22 @@ describe("possible-stage scan — D2 name patterns", () => {
 		assert.deepEqual(result.stages, ["discovery", "rebound"]);
 	});
 
+	test("ctx.tool marks tracked work without advertising a chat-stage target", () => {
+		const result = scanFile(
+			"tool-only.ts",
+			`
+				export default workflow({
+					name: "tool-only",
+					run: async (ctx) => {
+						await ctx.tool("durable-check", {}, async () => "ok");
+					},
+				});
+			`,
+		);
+		assert.deepEqual(result.stages, []);
+		assert.equal(result.hasTrackedNodes, true);
+	});
+
 	test("calls inside strings and comments are ignored", () => {
 		const result = scanFile(
 			"noise.ts",


### PR DESCRIPTION
## Summary

Stop `ZERO_STAGES` discovery warnings for workflows whose tracked graph work consists entirely of durable `ctx.tool()` nodes.

## Changes

- recognize `ctx.tool()` as a tracked-node call during the possible-stage scan
- keep tool names out of future chat-stage routing targets
- add scanner and discovery regression coverage
- document the user-visible fix in the workflows changelog

## Validation

- `npm run check`
- `npx vitest --run --project unit test/unit/workflow-possible-stages-persistence.test.ts test/unit/workflow-possible-stages-scan.test.ts` (46 passed)
- `npm --workspace=@bastani/atomic run build`
- `npm run test:unit` (7,418 passed, 23 skipped)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790966334&installation_model_id=10562&pr_number=2817&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2817&signature=e2287a81915bda44930863b555a16676138b0ba69c1cf80a23a4cfee50089184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change teaches workflow discovery that tool calls represent graph work, preventing false empty-workflow warnings for tool-only workflows. A focused runtime reproduction found that the same recognition also accepts an unrelated nested object named `ctx`, allowing its `tool()` call to hide an otherwise empty workflow from the warning.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until context-call matching no longer treats locally shadowed identifiers as workflow contexts.

There is one verified non-security P2 finding; the score is therefore 4 under the required scoring table.

**Files Needing Attention:** packages/workflows/src/shared/possible-stages.ts needs scope-aware context recognition, with regression coverage for a nested non-workflow `ctx.tool()` call.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused shadowed ctx scanner reproduction script to reproduce the P2 context scenario and generate a proof of work.
- Compared the Baseline empty workflow output with the Shadowed local ctx.tool output to identify differences relevant to the P2 finding.
- Linked the produced proof to the posted P2 finding and the related review comment to confirm alignment.

<a href="https://app.greptile.com/trex/runs/22117144/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/workflows/src/shared/possible-stages.ts:1163
**Shadowed tool calls suppress lint**

`matchCtxCall` recognizes calls solely from a file-wide set of context-like identifier names. A nested scope can therefore shadow the workflow context with an unrelated `ctx` object, and its `ctx.tool()` call is still considered tracked work. Because `handleCtxCall` sets `hasTrackedNodes` before returning for `tool`, a workflow with no actual graph nodes no longer receives the empty-workflow warning. Make context recognition scope-aware, or exclude locally shadowed context names, and cover this nested `ctx.tool()` case in discovery tests.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): recognize tool-only work..."](https://github.com/bastani-inc/atomic/commit/3ca242a5350d95663f0652515488c39bc9d4342e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59632222)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->