### PR TITLE
fix(deps): clear four npm security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4487,9 +4487,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5764,9 +5764,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -8126,9 +8126,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -1455,9 +1455,9 @@
 			}
 		},
 		"node_modules/@xmldom/xmldom": {
-			"version": "0.8.13",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-			"integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+			"version": "0.8.15",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+			"integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -2198,9 +2198,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+			"integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
 			"license": "BSD-3-Clause",
 			"funding": [
 				{
@@ -3791,9 +3791,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.15.3",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+			"integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"es-define-property": "^1.0.1",


### PR DESCRIPTION
Clears the four open Dependabot alerts on `main` by moving three transitive
packages to their patched versions and regenerating both lockfiles.

- fast-uri 3.1.5 -> 3.1.7, clearing GHSA-5jgf-p345-68v8 (CVE-2026-75931,
  alert #36) and GHSA-fph4-wmhf-6fwf (CVE-2026-75899, alert #37), and also
  the later 3.1.7 advisories GHSA-qw65-cvwx-89v3 and GHSA-58mr-gqgx-xq4g.
  It arrives through ajv@8.20.0 and stays on 3.x because ajv declares
  fast-uri ^3.0.1, which 4.x does not satisfy.
- qs 6.15.3 -> 6.16.0, clearing GHSA-x5fp-wj9c-mxmx (CVE-2026-82562,
  alert #38). It arrives through @modelcontextprotocol/sdk, express@5.2.1,
  and body-parser.
- @xmldom/xmldom 0.8.13 -> 0.8.15, clearing GHSA-6gmq-8vp8-gcm6
  (CVE-2026-83610, alert #39). It arrives through markit-ai and
  mammoth@1.12.0 and stays on 0.8.x because mammoth declares ^0.8.6.

No `package.json` override was required: npm selected all three patched
versions through the existing declared ranges, so the diff is exactly
`package-lock.json` and `packages/coding-agent/npm-shrinkwrap.json`, 18
insertions and 18 deletions, every line a `version`/`resolved`/`integrity`
triple. The existing overrides (protobufjs, brace-expansion, semver, and
the rest) are untouched, no manifest moves off the `0.0.0` placeholder,
and there is no changelog entry because no shipped API or behavior
changed — matching #2117, which was also lockfile-only.

This supersedes Dependabot PR #2823, which proposes the same fast-uri
3.1.5 -> 3.1.7 bump but leaves qs and @xmldom/xmldom vulnerable and does
not regenerate the coding-agent shrinkwrap. #2823 is left open and
untouched here; close it once this merges.

Verification, all run in a clean checkout of this branch:

- `npm audit` reports 0 vulnerabilities.
- `npm ls --all fast-uri qs @xmldom/xmldom` exits 0 and resolves
  `ajv -> fast-uri@3.1.7`, `body-parser -> qs@6.16.0`, and
  `mammoth -> @xmldom/xmldom@0.8.15`. A full-key scan of both lockfiles
  finds exactly one copy of each package, with no nested duplicate left
  at a vulnerable version.
- Each lockfile `integrity` hash is byte-identical to
  `npm view <spec> dist.integrity`, so the entries are authentic registry
  metadata rather than hand-edited.
- `npm run check:shrinkwrap` reports the shrinkwrap up to date, and
  `npm run check` (biome plus both typecheck passes) exits 0.
- `npm run test:ci-contracts` passes 82 tests; `npm run test:unit` passes
  7445 tests across 735 files.
- End to end through the shipped path: a real `.docx` converted through
  `packages/coding-agent/dist/utils/markit.js`, which routes markit-ai ->
  mammoth -> @xmldom/xmldom@0.8.15, preserves table structure, cell text,
  and surrounding paragraphs. The compiled CLI boots on the new lockfile.

Alerts #36 through #39 close on GitHub once this lands on `main`; the
local audit and the per-alert first-patched-version comparison are the
strongest pre-merge signal available.

Assistant-model: Claude Opus 5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791046559&installation_model_id=10562&pr_number=2827&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2827&signature=ef889b7ef11fb2b8465dc50ddd9a18eb20c7cc8de1c7245ec3ea21193264185c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates the root lockfile and coding-agent shrinkwrap to patched transitive releases of `@xmldom/xmldom`, `fast-uri`, and `qs`. The installed dependency tree resolved the intended versions, the coding-agent shrinkwrap was current and included in the publish dry run, and the affected Markit document-conversion test passed. No defects were found.

<h3>Confidence Score: 5/5</h3>

The lockfile and published shrinkwrap changes are safe to merge based on successful dependency, packaging, and document-conversion checks.

No review findings remain after confirming the updated dependency resolutions, validating shrinkwrap synchronization, checking the publish package contents, and exercising the affected conversion path.

**Files Needing Attention:** None. `package-lock.json` and `packages/coding-agent/npm-shrinkwrap.json` were validated without requiring changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The uploaded focused lockfile validation script was executed and exited successfully.
- Dependency resolutions before and after the upgrade were compared, shrinkwrap was checked, the package contents were inspected, and the Markit document-conversion test ran and passed.
- The root Vitest discovery initially did not find the workspace test due to root config scoping, so the exact test was rerun from the coding-agent package and it passed.
- Git confirmed that neither changed lockfile was modified by validation.

<a href="https://app.greptile.com/trex/runs/22328793/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deps): clear four npm security advis..."](https://github.com/bastani-inc/atomic/commit/46f068140dd013610d98cee5dc687403b51e4a52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60038032)</sub>

<!-- /greptile_comment -->