### PR TITLE
fix(coding-agent): use musl managed-tool builds on Linux

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fixed the `write` tool reporting UTF-16 code-unit counts as byte counts by removing the misleading count. Every write confirmation now reads `Successfully wrote to <path>` ([#8979](https://github.com/earendil-works/pi/issues/8979)).
 - Fixed the `write` tool mistaking user-authored lines beginning with `Successfully wrote to` for copied tool confirmation text and silently discarding them. A copied confirmation is now recognized only when it names the complete path the write was asked for, its resolved or cwd-relative form, or the copied snapshot's own path, so prose that merely shares a prefix or a basename is written through unchanged.
 - Restricted synthetic fast aliases and first-party Codex routing identity to the explicit OpenAI/OpenAI Codex model route, suppressed aliases over native extension transports, and prevented Copilot from restoring an advertised fast ID without its base catalog model.
+- Fixed Linux managed-tool downloads to use statically linked musl archives for fd and ripgrep on both x64 and ARM64 ([#9070](https://github.com/earendil-works/pi/pull/9070) by [@charlesisworkinghard](https://github.com/charlesisworkinghard)).
 
 ## [0.9.18-alpha.5] - 2026-09-01
 

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -39,7 +39,7 @@ const TOOLS: Record<string, ToolConfig> = {
 				return `fd-v${version}-${archStr}-apple-darwin.tar.gz`;
 			} else if (plat === "linux") {
 				const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
-				return `fd-v${version}-${archStr}-unknown-linux-gnu.tar.gz`;
+				return `fd-v${version}-${archStr}-unknown-linux-musl.tar.gz`;
 			} else if (plat === "win32") {
 				const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
 				return `fd-v${version}-${archStr}-pc-windows-msvc.zip`;
@@ -57,10 +57,8 @@ const TOOLS: Record<string, ToolConfig> = {
 				const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
 				return `ripgrep-${version}-${archStr}-apple-darwin.tar.gz`;
 			} else if (plat === "linux") {
-				if (architecture === "arm64") {
-					return `ripgrep-${version}-aarch64-unknown-linux-gnu.tar.gz`;
-				}
-				return `ripgrep-${version}-x86_64-unknown-linux-musl.tar.gz`;
+				const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
+				return `ripgrep-${version}-${archStr}-unknown-linux-musl.tar.gz`;
 			} else if (plat === "win32") {
 				const archStr = architecture === "arm64" ? "aarch64" : "x86_64";
 				return `ripgrep-${version}-${archStr}-pc-windows-msvc.zip`;

--- a/packages/coding-agent/test/tools-manager.test.ts
+++ b/packages/coding-agent/test/tools-manager.test.ts
@@ -6,8 +6,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ENV_AGENT_DIR, ENV_OFFLINE } from "../src/config.ts";
 
 const mocks = vi.hoisted(() => ({
+	arch: vi.fn<typeof import("node:os").arch>(),
+	platform: vi.fn<typeof import("node:os").platform>(),
 	spawnSync: vi.fn<(command: string, args?: readonly string[]) => SpawnSyncReturns<Buffer>>(),
 }));
+
+vi.mock("os", async () => {
+	const actual = await vi.importActual<typeof import("os")>("os");
+	return { ...actual, arch: mocks.arch, platform: mocks.platform };
+});
 
 vi.mock("child_process", async () => {
 	const actual = await vi.importActual<typeof import("child_process")>("child_process");
@@ -23,6 +30,10 @@ describe("managed tool downloads", () => {
 		vi.stubEnv(ENV_AGENT_DIR, join(tempDir, "agent"));
 		vi.stubEnv(ENV_OFFLINE, "");
 		vi.stubEnv("PI_OFFLINE", "");
+		mocks.arch.mockReset();
+		mocks.arch.mockReturnValue(process.arch);
+		mocks.platform.mockReset();
+		mocks.platform.mockReturnValue(process.platform);
 		mocks.spawnSync.mockReset();
 		mocks.spawnSync.mockReturnValue({ error: new Error("not found") } as SpawnSyncReturns<Buffer>);
 		vi.resetModules();
@@ -70,6 +81,31 @@ describe("managed tool downloads", () => {
 		expect(archiveAttempts).toBe(3);
 		expect(fetchMock.mock.calls.filter(([input]) => String(input) === releaseUrl)).toHaveLength(1);
 		expect(fetchMock.mock.calls.filter(([input]) => String(input).startsWith(archiveUrlPrefix))).toHaveLength(3);
+	});
+
+	it.each([
+		["fd", "x64", "fd-v10.2.0-x86_64-unknown-linux-musl.tar.gz"],
+		["fd", "arm64", "fd-v10.2.0-aarch64-unknown-linux-musl.tar.gz"],
+		["rg", "x64", "ripgrep-15.2.0-x86_64-unknown-linux-musl.tar.gz"],
+		["rg", "arm64", "ripgrep-15.2.0-aarch64-unknown-linux-musl.tar.gz"],
+	] as const)("downloads the %s %s musl archive on Linux", async (tool, architecture, assetName) => {
+		mocks.platform.mockReturnValue("linux");
+		mocks.arch.mockReturnValue(architecture);
+		const repo = tool === "fd" ? "sharkdp/fd" : "BurntSushi/ripgrep";
+		const version = tool === "fd" ? "10.2.0" : "15.2.0";
+		const tagPrefix = tool === "fd" ? "v" : "";
+		const releaseUrl = `https://api.github.com/repos/${repo}/releases/latest`;
+		const archiveUrl = `https://github.com/${repo}/releases/download/${tagPrefix}${version}/${assetName}`;
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+			if (String(input) === releaseUrl) {
+				return Response.json({ tag_name: `${tagPrefix}${version}` });
+			}
+			return new Response("download unavailable", { status: 404 });
+		});
+
+		await expect(ensureTool(tool)).resolves.toBeUndefined();
+
+		expect(fetchMock.mock.calls.some(([input]) => String(input) === archiveUrl)).toBe(true);
 	});
 
 	it("reports an offline skip through onStatus and never writes to the console", async () => {


### PR DESCRIPTION
## Summary

Linux fd/rg downloads now use statically linked musl archives on both x64 and ARM64, matching upstream pi `6aedd106` / [#9070](https://github.com/earendil-works/pi/pull/9070).

## Changes

- `fd` Linux assets: `unknown-linux-gnu` → `unknown-linux-musl`
- `ripgrep` Linux ARM64: drop the gnu special case; both arches use `unknown-linux-musl`
- Tests cover all four Linux tool/arch archive URLs

## Notes

This is the same managed-tool URL change already included in #2830. Landed separately so it can merge without waiting on the rest of that sync.

Assistant-model: Grok 4.6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791071583&installation_model_id=10562&pr_number=2831&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2831&signature=9e45b83bd7aeaf3d92805a38316a1122ff65512198f459853b6cd996acd97b8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary
- Updates Linux managed-tool downloads so fd and ripgrep use statically linked musl release archives on x64 and ARM64.
- Adds coverage for all four Linux tool and architecture combinations and documents the behavior change.

## Merge safety
Safe to merge. The changed download paths request the expected musl archive names for each supported Linux architecture.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the Linux fd and ripgrep download selections were exercised for x64 and ARM64 and requested the expected archives.

No actionable issues were found in the changed behavior.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The linux-managed-tool-archive-url-command.sh script was executed to drive the URL retrieval flow for Linux x64 and ARM64.
- The focused-suite before-state log and the observed-URL after-state log were reviewed to verify the URL retrieval workflow completed.
- The tool-manager code path that uses fd and ripgrep to select musl archives on Linux was identified in the referenced source files.
- The evidence notes that there was no confirmed issue and marks the security flag as false.

<a href="https://app.greptile.com/trex/runs/22417948/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(coding-agent): use musl managed-tool..."](https://github.com/bastani-inc/atomic/commit/03cdcf3f91ed8497fa9567d857abf3168e2b41c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60216911)</sub>

<!-- /greptile_comment -->