### PR TITLE
feat(ai): add compact assistant-message frames

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,6 +13,7 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 - Added Anthropic per-turn effort persistence, deterministic historical effort markers, and signed-thinking mismatch recovery for supported Claude models across Anthropic Messages transports, including OpenRouter.
 - Added `compat.vllmPriority` to the OpenAI Completions compatibility options. When set, it is sent as the top-level `priority` request field; lower values are handled earlier and the vLLM server default is `0`, so it only takes effect when vLLM runs with `--scheduling-policy priority`. Setting it on a background or batch model defers that model's long prefills behind interactive sessions. Off by default and never set on the generated catalog ([#9004](https://github.com/earendil-works/pi/pull/9004)).
 - `Model.fastRoute` and the `ModelFastRoute` type. This optional field marks a model as the fast-inference variant of another model and carries the upstream routing it needs: the base model it pairs with, the model ID to send upstream, and an optional OpenAI-style `serviceTier`. Presence of this field — never a `-fast` name suffix — is what gives a model fast semantics.
+- Added `AssistantMessageFrameEncoder` and `reduceAssistantMessageFrames` so callers can persist compact, replayable stream progress without the full event stream ([upstream `8b5899dc`](https://github.com/earendil-works/pi/commit/8b5899dce26f9f6b8d313ee6a4b4a8dccbb9bfc2)).
 
 ### Changed
 

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -36,6 +36,7 @@ export * from "./models-store.ts";
 export * from "./providers/faux.ts";
 export * from "./session-resources.ts";
 export * from "./types.ts";
+export * from "./utils/assistant-message-frame.ts";
 export * from "./utils/diagnostics.ts";
 export * from "./utils/event-stream.ts";
 export * from "./utils/json-parse.ts";

--- a/packages/ai/src/utils/assistant-message-frame.ts
+++ b/packages/ai/src/utils/assistant-message-frame.ts
@@ -1,0 +1,489 @@
+import type { AssistantMessage, AssistantMessageEvent, TextContent, ThinkingContent, ToolCall } from "../types.ts";
+import { parseStreamingJson } from "./json-parse.ts";
+
+/**
+ * Compact, replayable assistant-message progress. Terminal settlement is
+ * intentionally excluded and must be persisted separately.
+ */
+export type AssistantMessageFrame =
+	| { type: "start"; partial: AssistantMessage }
+	| { type: "text_start"; contentIndex: number; content: TextContent }
+	| { type: "text_delta"; contentIndex: number; delta: string }
+	| { type: "text_end"; contentIndex: number; content: string; textSignature?: string }
+	| { type: "thinking_start"; contentIndex: number; content: ThinkingContent }
+	| { type: "thinking_delta"; contentIndex: number; delta: string }
+	| {
+			type: "thinking_end";
+			contentIndex: number;
+			content: string;
+			thinkingSignature?: string;
+			redacted?: boolean;
+	  }
+	| { type: "toolcall_start"; contentIndex: number; toolCall: ToolCall }
+	| { type: "toolcall_checkpoint"; contentIndex: number; json: string }
+	| { type: "toolcall_delta"; contentIndex: number; delta: string }
+	| {
+			type: "toolcall_end";
+			contentIndex: number;
+			id: string;
+			name: string;
+			arguments: ToolCall["arguments"];
+			thoughtSignature?: string;
+			namespace?: string;
+	  };
+
+type EncoderBlockState =
+	| { kind: "text" | "thinking"; coveredChars: number; deltaChars: number }
+	| {
+			kind: "toolCall";
+			caughtUp: boolean;
+			catchupJson: string;
+			snapshotArguments: string;
+	  };
+
+type ReducerBlockState =
+	| { kind: "text"; ended: boolean }
+	| { kind: "thinking"; ended: boolean }
+	| { kind: "toolCall"; ended: boolean; json: string };
+
+function cloneTextContent(content: TextContent): TextContent {
+	return {
+		type: "text",
+		text: content.text,
+		...(content.textSignature === undefined ? {} : { textSignature: content.textSignature }),
+	};
+}
+
+function cloneThinkingContent(content: ThinkingContent): ThinkingContent {
+	return {
+		type: "thinking",
+		thinking: content.thinking,
+		...(content.thinkingSignature === undefined ? {} : { thinkingSignature: content.thinkingSignature }),
+		...(content.redacted === undefined ? {} : { redacted: content.redacted }),
+	};
+}
+
+function cloneToolCall(toolCall: ToolCall): ToolCall {
+	return {
+		type: "toolCall",
+		id: toolCall.id,
+		name: toolCall.name,
+		arguments: structuredClone(toolCall.arguments),
+		...(toolCall.thoughtSignature === undefined ? {} : { thoughtSignature: toolCall.thoughtSignature }),
+		...(toolCall.namespace === undefined ? {} : { namespace: toolCall.namespace }),
+	};
+}
+
+function cloneStartMessage(message: AssistantMessage): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: message.api,
+		provider: message.provider,
+		model: message.model,
+		...(message.responseModel === undefined ? {} : { responseModel: message.responseModel }),
+		...(message.responseId === undefined ? {} : { responseId: message.responseId }),
+		...(message.diagnostics === undefined ? {} : { diagnostics: structuredClone(message.diagnostics) }),
+		usage: structuredClone(message.usage),
+		stopReason: "pending",
+		timestamp: message.timestamp,
+	};
+}
+
+function assertContentIndex(contentIndex: number): void {
+	if (!Number.isSafeInteger(contentIndex) || contentIndex < 0) {
+		throw new Error(`Invalid assistant message frame contentIndex: ${contentIndex}`);
+	}
+}
+
+function eventBlock(event: Exclude<AssistantMessageEvent, { type: "start" | "done" | "error" }>) {
+	assertContentIndex(event.contentIndex);
+	const block = event.partial.content[event.contentIndex];
+	if (!block) {
+		throw new Error(`${event.type} event has no content block at index ${event.contentIndex}`);
+	}
+	return block;
+}
+
+function serializedArguments(argumentsValue: ToolCall["arguments"]): string {
+	const serialized = JSON.stringify(argumentsValue);
+	if (serialized === undefined) throw new Error("Tool-call arguments are not JSON-serializable");
+	return serialized;
+}
+
+const EMPTY_PARSED_TOOL_ARGUMENTS = serializedArguments(parseStreamingJson<ToolCall["arguments"]>(""));
+
+function isJsonPrefix(snapshot: unknown, current: unknown): boolean {
+	if (typeof snapshot === "string") return typeof current === "string" && current.startsWith(snapshot);
+	if (Array.isArray(snapshot)) {
+		return (
+			Array.isArray(current) &&
+			snapshot.length <= current.length &&
+			snapshot.every((value, index) => isJsonPrefix(value, current[index]))
+		);
+	}
+	if (typeof snapshot !== "object" || snapshot === null) return Object.is(snapshot, current);
+	if (typeof current !== "object" || current === null || Array.isArray(current)) return false;
+	const currentRecord = current as Record<string, unknown>;
+	return Object.entries(snapshot).every(
+		([key, value]) => Object.hasOwn(currentRecord, key) && isJsonPrefix(value, currentRecord[key]),
+	);
+}
+
+/**
+ * Encodes one assistant stream. `partial` remains a shared live accumulator;
+ * the encoder uses per-block offsets to avoid replaying deltas already visible
+ * when an older queued event is consumed.
+ */
+export class AssistantMessageFrameEncoder {
+	private started = false;
+	private terminal = false;
+	private readonly blocks = new Map<number, EncoderBlockState>();
+
+	encode(event: AssistantMessageEvent): AssistantMessageFrame | undefined {
+		if (this.terminal) throw new Error(`Assistant message event ${event.type} follows a terminal event`);
+
+		switch (event.type) {
+			case "start":
+				if (this.started) throw new Error("Assistant message stream contains more than one start event");
+				this.started = true;
+				return { type: "start", partial: cloneStartMessage(event.partial) };
+			case "done":
+				if (!this.started) throw new Error("Assistant message done event appears before start");
+				this.terminal = true;
+				return undefined;
+			case "error":
+				this.terminal = true;
+				return undefined;
+		}
+
+		if (!this.started) throw new Error(`Assistant message ${event.type} event appears before start`);
+
+		switch (event.type) {
+			case "text_start": {
+				const content = eventBlock(event);
+				if (content.type !== "text") {
+					throw new Error(`text_start event points to ${content.type} block at index ${event.contentIndex}`);
+				}
+				this.startBlock(event.contentIndex, {
+					kind: "text",
+					coveredChars: content.text.length,
+					deltaChars: 0,
+				});
+				return { type: "text_start", contentIndex: event.contentIndex, content: cloneTextContent(content) };
+			}
+			case "text_delta":
+				return this.encodeTextDelta(event.contentIndex, event.delta, "text");
+			case "text_end": {
+				const content = eventBlock(event);
+				if (content.type !== "text") {
+					throw new Error(`text_end event points to ${content.type} block at index ${event.contentIndex}`);
+				}
+				this.endBlock(event.contentIndex, "text");
+				return {
+					type: "text_end",
+					contentIndex: event.contentIndex,
+					content: event.content,
+					...(content.textSignature === undefined ? {} : { textSignature: content.textSignature }),
+				};
+			}
+			case "thinking_start": {
+				const content = eventBlock(event);
+				if (content.type !== "thinking") {
+					throw new Error(`thinking_start event points to ${content.type} block at index ${event.contentIndex}`);
+				}
+				this.startBlock(event.contentIndex, {
+					kind: "thinking",
+					coveredChars: content.thinking.length,
+					deltaChars: 0,
+				});
+				return {
+					type: "thinking_start",
+					contentIndex: event.contentIndex,
+					content: cloneThinkingContent(content),
+				};
+			}
+			case "thinking_delta":
+				return this.encodeTextDelta(event.contentIndex, event.delta, "thinking");
+			case "thinking_end": {
+				const content = eventBlock(event);
+				if (content.type !== "thinking") {
+					throw new Error(`thinking_end event points to ${content.type} block at index ${event.contentIndex}`);
+				}
+				this.endBlock(event.contentIndex, "thinking");
+				return {
+					type: "thinking_end",
+					contentIndex: event.contentIndex,
+					content: event.content,
+					...(content.thinkingSignature === undefined ? {} : { thinkingSignature: content.thinkingSignature }),
+					...(content.redacted === undefined ? {} : { redacted: content.redacted }),
+				};
+			}
+			case "toolcall_start": {
+				const content = eventBlock(event);
+				if (content.type !== "toolCall") {
+					throw new Error(`toolcall_start event points to ${content.type} block at index ${event.contentIndex}`);
+				}
+				const snapshotArguments = serializedArguments(content.arguments);
+				const caughtUp = snapshotArguments === EMPTY_PARSED_TOOL_ARGUMENTS;
+				this.startBlock(event.contentIndex, {
+					kind: "toolCall",
+					caughtUp,
+					catchupJson: "",
+					snapshotArguments: caughtUp ? "" : snapshotArguments,
+				});
+				return { type: "toolcall_start", contentIndex: event.contentIndex, toolCall: cloneToolCall(content) };
+			}
+			case "toolcall_delta": {
+				const state = this.block(event.contentIndex, "toolCall");
+				if (state.kind !== "toolCall") throw new Error("Unreachable tool-call encoder state");
+				if (state.caughtUp) {
+					return event.delta.length === 0
+						? undefined
+						: { type: "toolcall_delta", contentIndex: event.contentIndex, delta: event.delta };
+				}
+				state.catchupJson += event.delta;
+				const argumentsValue = parseStreamingJson<ToolCall["arguments"]>(state.catchupJson);
+				if (serializedArguments(argumentsValue) !== state.snapshotArguments) {
+					// Legacy grammar calls include the initial input in toolcall_start, but their
+					// JSON delta stream still begins at an empty input. Its parsed arguments can
+					// therefore extend, rather than exactly reproduce, the start snapshot.
+					const snapshotArguments = parseStreamingJson<ToolCall["arguments"]>(state.snapshotArguments);
+					if (!isJsonPrefix(snapshotArguments, argumentsValue)) return undefined;
+				}
+				state.caughtUp = true;
+				state.snapshotArguments = "";
+				const json = state.catchupJson;
+				state.catchupJson = "";
+				return json.length === 0
+					? undefined
+					: { type: "toolcall_checkpoint", contentIndex: event.contentIndex, json };
+			}
+			case "toolcall_end": {
+				const content = eventBlock(event);
+				if (content.type !== "toolCall") {
+					throw new Error(`toolcall_end event points to ${content.type} block at index ${event.contentIndex}`);
+				}
+				if (event.toolCall.type !== "toolCall") {
+					throw new Error(`toolcall_end event has invalid tool call at index ${event.contentIndex}`);
+				}
+				this.endBlock(event.contentIndex, "toolCall");
+				return {
+					type: "toolcall_end",
+					contentIndex: event.contentIndex,
+					id: event.toolCall.id,
+					name: event.toolCall.name,
+					arguments: structuredClone(event.toolCall.arguments),
+					...(event.toolCall.thoughtSignature === undefined
+						? {}
+						: { thoughtSignature: event.toolCall.thoughtSignature }),
+					...(event.toolCall.namespace === undefined ? {} : { namespace: event.toolCall.namespace }),
+				};
+			}
+		}
+	}
+
+	private startBlock(contentIndex: number, state: EncoderBlockState): void {
+		assertContentIndex(contentIndex);
+		if (this.blocks.has(contentIndex)) {
+			throw new Error(`Assistant message block ${contentIndex} starts more than once`);
+		}
+		this.blocks.set(contentIndex, state);
+	}
+
+	private block(contentIndex: number, kind: EncoderBlockState["kind"]): EncoderBlockState {
+		assertContentIndex(contentIndex);
+		const state = this.blocks.get(contentIndex);
+		if (state === undefined) throw new Error(`Assistant message ${kind} block ${contentIndex} has not started`);
+		if (state.kind !== kind) {
+			throw new Error(`Assistant message block ${contentIndex} is ${state.kind}, not ${kind}`);
+		}
+		return state;
+	}
+
+	private endBlock(contentIndex: number, kind: EncoderBlockState["kind"]): void {
+		this.block(contentIndex, kind);
+		this.blocks.delete(contentIndex);
+	}
+
+	private encodeTextDelta(
+		contentIndex: number,
+		delta: string,
+		kind: "text" | "thinking",
+	): AssistantMessageFrame | undefined {
+		const state = this.block(contentIndex, kind);
+		if (state.kind === "toolCall") throw new Error("Unreachable text encoder state");
+		const deltaStart = state.deltaChars;
+		state.deltaChars += delta.length;
+		const covered = Math.max(0, state.coveredChars - deltaStart);
+		if (covered >= delta.length) return undefined;
+		const uncovered = covered === 0 ? delta : delta.slice(covered);
+		return kind === "text"
+			? { type: "text_delta", contentIndex, delta: uncovered }
+			: { type: "thinking_delta", contentIndex, delta: uncovered };
+	}
+}
+
+function appendBlock(
+	message: AssistantMessage,
+	states: Map<number, ReducerBlockState>,
+	contentIndex: number,
+	block: TextContent | ThinkingContent | ToolCall,
+	state: ReducerBlockState,
+): void {
+	assertContentIndex(contentIndex);
+	if (contentIndex !== message.content.length) {
+		const reason = contentIndex < message.content.length ? "already exists" : "would leave a gap";
+		throw new Error(`Cannot start assistant message block at index ${contentIndex}: ${reason}`);
+	}
+	message.content.push(structuredClone(block));
+	states.set(contentIndex, state);
+}
+
+function activeBlock(
+	message: AssistantMessage,
+	states: Map<number, ReducerBlockState>,
+	contentIndex: number,
+	expectedKind: ReducerBlockState["kind"],
+	frameType: AssistantMessageFrame["type"],
+): { block: TextContent | ThinkingContent | ToolCall; state: ReducerBlockState } {
+	assertContentIndex(contentIndex);
+	const state = states.get(contentIndex);
+	const block = message.content[contentIndex];
+	if (!state || !block) {
+		throw new Error(`${frameType} frame has no started block at index ${contentIndex}`);
+	}
+	if (state.kind !== expectedKind || block.type !== expectedKind) {
+		throw new Error(
+			`${frameType} frame expected ${expectedKind} block at index ${contentIndex}, found ${block.type}`,
+		);
+	}
+	if (state.ended) {
+		throw new Error(`${frameType} frame follows the end of block at index ${contentIndex}`);
+	}
+	return { block, state };
+}
+
+/**
+ * Replay compact frames without mutating them. Returns `undefined` when the
+ * iterable contains no start frame.
+ */
+export function reduceAssistantMessageFrames(frames: Iterable<AssistantMessageFrame>): AssistantMessage | undefined {
+	let message: AssistantMessage | undefined;
+	let frameBeforeStart: AssistantMessageFrame["type"] | undefined;
+	const states = new Map<number, ReducerBlockState>();
+
+	for (const frame of frames) {
+		if (frame.type === "start") {
+			if (message) throw new Error("Assistant message frame sequence contains more than one start frame");
+			if (frameBeforeStart !== undefined)
+				throw new Error(`${frameBeforeStart} frame appears before the start frame`);
+			message = structuredClone(frame.partial);
+			continue;
+		}
+		if (!message) {
+			frameBeforeStart ??= frame.type;
+			continue;
+		}
+
+		switch (frame.type) {
+			case "text_start":
+				if (frame.content.type !== "text") {
+					throw new Error(`text_start frame contains ${frame.content.type} content`);
+				}
+				appendBlock(message, states, frame.contentIndex, frame.content, { kind: "text", ended: false });
+				break;
+			case "text_delta": {
+				const { block } = activeBlock(message, states, frame.contentIndex, "text", frame.type);
+				if (block.type !== "text") throw new Error("Unreachable text frame state");
+				block.text += frame.delta;
+				break;
+			}
+			case "text_end": {
+				const { block, state } = activeBlock(message, states, frame.contentIndex, "text", frame.type);
+				if (block.type !== "text") throw new Error("Unreachable text frame state");
+				block.text = frame.content;
+				delete block.textSignature;
+				if (frame.textSignature !== undefined) block.textSignature = frame.textSignature;
+				state.ended = true;
+				break;
+			}
+			case "thinking_start":
+				if (frame.content.type !== "thinking") {
+					throw new Error(`thinking_start frame contains ${frame.content.type} content`);
+				}
+				appendBlock(message, states, frame.contentIndex, frame.content, {
+					kind: "thinking",
+					ended: false,
+				});
+				break;
+			case "thinking_delta": {
+				const { block } = activeBlock(message, states, frame.contentIndex, "thinking", frame.type);
+				if (block.type !== "thinking") throw new Error("Unreachable thinking frame state");
+				block.thinking += frame.delta;
+				break;
+			}
+			case "thinking_end": {
+				const { block, state } = activeBlock(message, states, frame.contentIndex, "thinking", frame.type);
+				if (block.type !== "thinking") throw new Error("Unreachable thinking frame state");
+				block.thinking = frame.content;
+				delete block.thinkingSignature;
+				delete block.redacted;
+				if (frame.thinkingSignature !== undefined) block.thinkingSignature = frame.thinkingSignature;
+				if (frame.redacted !== undefined) block.redacted = frame.redacted;
+				state.ended = true;
+				break;
+			}
+			case "toolcall_start":
+				if (frame.toolCall.type !== "toolCall") {
+					throw new Error(`toolcall_start frame contains ${frame.toolCall.type} content`);
+				}
+				appendBlock(message, states, frame.contentIndex, frame.toolCall, {
+					kind: "toolCall",
+					ended: false,
+					json: "",
+				});
+				break;
+			case "toolcall_checkpoint": {
+				const { block, state } = activeBlock(message, states, frame.contentIndex, "toolCall", frame.type);
+				if (block.type !== "toolCall" || state.kind !== "toolCall") {
+					throw new Error("Unreachable tool-call checkpoint state");
+				}
+				state.json = frame.json;
+				block.arguments = parseStreamingJson<ToolCall["arguments"]>(frame.json);
+				break;
+			}
+			case "toolcall_delta": {
+				const { block, state } = activeBlock(message, states, frame.contentIndex, "toolCall", frame.type);
+				if (block.type !== "toolCall" || state.kind !== "toolCall") {
+					throw new Error("Unreachable tool-call frame state");
+				}
+				state.json += frame.delta;
+				break;
+			}
+			case "toolcall_end": {
+				const { block, state } = activeBlock(message, states, frame.contentIndex, "toolCall", frame.type);
+				if (block.type !== "toolCall") throw new Error("Unreachable tool-call frame state");
+				block.id = frame.id;
+				block.name = frame.name;
+				block.arguments = structuredClone(frame.arguments);
+				delete block.thoughtSignature;
+				delete block.namespace;
+				if (frame.thoughtSignature !== undefined) block.thoughtSignature = frame.thoughtSignature;
+				if (frame.namespace !== undefined) block.namespace = frame.namespace;
+				state.ended = true;
+				break;
+			}
+		}
+	}
+
+	if (!message) return undefined;
+	for (const [contentIndex, state] of states) {
+		if (state.kind !== "toolCall" || state.ended || state.json.length === 0) continue;
+		const block = message.content[contentIndex];
+		if (block?.type !== "toolCall") throw new Error("Unreachable tool-call frame state");
+		block.arguments = parseStreamingJson<ToolCall["arguments"]>(state.json);
+	}
+
+	return message;
+}

--- a/packages/ai/test/assistant-message-frame.test.ts
+++ b/packages/ai/test/assistant-message-frame.test.ts
@@ -1,0 +1,596 @@
+import type { ResponseStreamEvent } from "openai/resources/responses/responses.js";
+import { describe, expect, it } from "vitest";
+import { processResponsesStream } from "../src/api/openai-responses-shared.ts";
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	type AssistantMessageFrame,
+	AssistantMessageFrameEncoder,
+	type Model,
+	reduceAssistantMessageFrames,
+} from "../src/index.ts";
+import { AssistantMessageEventStream } from "../src/utils/event-stream.ts";
+
+function seed(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "test-api",
+		provider: "test-provider",
+		model: "test-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "pending",
+		timestamp: 1,
+	};
+}
+
+function frame(encoder: AssistantMessageFrameEncoder, event: AssistantMessageEvent): AssistantMessageFrame {
+	const converted = encoder.encode(event);
+	if (!converted) throw new Error(`Expected ${event.type} event to produce a frame`);
+	return converted;
+}
+
+describe("assistant message frames", () => {
+	it("uses authoritative text end content and signature", () => {
+		const partial = seed();
+		const encoder = new AssistantMessageFrameEncoder();
+		const frames: AssistantMessageFrame[] = [frame(encoder, { type: "start", partial })];
+		partial.content.push({ type: "text", text: "Hello " });
+		frames.push(frame(encoder, { type: "text_start", contentIndex: 0, partial }));
+		partial.content[0] = { type: "text", text: "Hello world", textSignature: "sig-text" };
+		frames.push(
+			frame(encoder, { type: "text_delta", contentIndex: 0, delta: "incorrect", partial }),
+			frame(encoder, { type: "text_end", contentIndex: 0, content: "Hello world", partial }),
+		);
+
+		expect(frames.at(-1)).toEqual({
+			type: "text_end",
+			contentIndex: 0,
+			content: "Hello world",
+			textSignature: "sig-text",
+		});
+		expect(reduceAssistantMessageFrames(frames)?.content).toEqual([
+			{ type: "text", text: "Hello world", textSignature: "sig-text" },
+		]);
+	});
+
+	it("preserves initial and final thinking metadata, including redaction", () => {
+		const partial = seed();
+		const encoder = new AssistantMessageFrameEncoder();
+		const frames: AssistantMessageFrame[] = [frame(encoder, { type: "start", partial })];
+		partial.content.push({
+			type: "thinking",
+			thinking: "[redacted]",
+			thinkingSignature: "encrypted-start",
+			redacted: true,
+		});
+		frames.push(frame(encoder, { type: "thinking_start", contentIndex: 0, partial }));
+		partial.content[0] = {
+			type: "thinking",
+			thinking: "[redacted]",
+			thinkingSignature: "encrypted-final",
+			redacted: true,
+		};
+		frames.push(frame(encoder, { type: "thinking_end", contentIndex: 0, content: "[redacted]", partial }));
+
+		expect(frames.at(-1)).toEqual({
+			type: "thinking_end",
+			contentIndex: 0,
+			content: "[redacted]",
+			thinkingSignature: "encrypted-final",
+			redacted: true,
+		});
+		expect(reduceAssistantMessageFrames(frames)?.content[0]).toEqual({
+			type: "thinking",
+			thinking: "[redacted]",
+			thinkingSignature: "encrypted-final",
+			redacted: true,
+		});
+	});
+
+	it("parses unfinished tool JSON once and uses authoritative completed arguments", () => {
+		const initialFrames: AssistantMessageFrame[] = [
+			{ type: "start", partial: seed() },
+			{
+				type: "toolcall_start",
+				contentIndex: 0,
+				toolCall: { type: "toolCall", id: "initial-id", name: "write", arguments: {} },
+			},
+			{ type: "toolcall_delta", contentIndex: 0, delta: '{"path":"READ' },
+		];
+
+		expect(reduceAssistantMessageFrames(initialFrames)?.content[0]).toMatchObject({
+			type: "toolCall",
+			arguments: { path: "READ" },
+		});
+
+		const completeFrames: AssistantMessageFrame[] = [
+			...initialFrames,
+			{ type: "toolcall_delta", contentIndex: 0, delta: 'ME.md","lines":[1,2]}' },
+			{
+				type: "toolcall_end",
+				contentIndex: 0,
+				id: "final-id",
+				name: "write_file",
+				arguments: { path: "final.md", lines: [3] },
+				thoughtSignature: "thought",
+				namespace: "files",
+			},
+		];
+		expect(reduceAssistantMessageFrames(completeFrames)?.content[0]).toEqual({
+			type: "toolCall",
+			id: "final-id",
+			name: "write_file",
+			arguments: { path: "final.md", lines: [3] },
+			thoughtSignature: "thought",
+			namespace: "files",
+		});
+	});
+
+	it("round-trips OpenAI Responses content supplied only by authoritative end events", async () => {
+		const output = seed();
+		output.api = "openai-responses";
+		output.provider = "openai";
+		const model: Model<"openai-responses"> = {
+			id: output.model,
+			name: "Test",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1000,
+			maxTokens: 100,
+		};
+		const events: ResponseStreamEvent[] = [
+			{
+				type: "response.output_item.added",
+				sequence_number: 0,
+				output_index: 0,
+				item: { type: "message", id: "msg", role: "assistant", status: "in_progress", content: [] },
+			} as ResponseStreamEvent,
+			{
+				type: "response.output_item.done",
+				sequence_number: 1,
+				output_index: 0,
+				item: {
+					type: "message",
+					id: "msg",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "final text", annotations: [] }],
+				},
+			} as ResponseStreamEvent,
+			{
+				type: "response.output_item.added",
+				sequence_number: 2,
+				output_index: 1,
+				item: {
+					type: "function_call",
+					id: "fc",
+					call_id: "call",
+					name: "lookup",
+					arguments: "",
+				},
+			} as ResponseStreamEvent,
+			{
+				type: "response.output_item.done",
+				sequence_number: 3,
+				output_index: 1,
+				item: {
+					type: "function_call",
+					id: "fc",
+					call_id: "call",
+					name: "lookup",
+					arguments: '{"query":"pi"}',
+				},
+			} as ResponseStreamEvent,
+			{
+				type: "response.completed",
+				sequence_number: 4,
+				response: { id: "response", status: "completed", output: [] },
+			} as unknown as ResponseStreamEvent,
+		];
+		async function* source(): AsyncGenerator<ResponseStreamEvent> {
+			for (const event of events) yield event;
+		}
+
+		const encoder = new AssistantMessageFrameEncoder();
+		const frames: AssistantMessageFrame[] = [frame(encoder, { type: "start", partial: output })];
+		const stream = new AssistantMessageEventStream();
+		const push = stream.push.bind(stream);
+		stream.push = (event) => {
+			const converted = encoder.encode(event);
+			if (converted) frames.push(converted);
+			push(event);
+		};
+		await processResponsesStream(source(), output, stream, model);
+
+		expect(reduceAssistantMessageFrames(frames)?.content).toEqual(output.content);
+	});
+
+	it("reconciles queued text events against one advanced live partial without duplicate content", () => {
+		const partial = seed();
+		const events: AssistantMessageEvent[] = [{ type: "start", partial }];
+		const text = { type: "text" as const, text: "" };
+		partial.content.push(text);
+		events.push({ type: "text_start", contentIndex: 0, partial });
+		for (const delta of ["Hel", "lo", " ", "world"]) {
+			text.text += delta;
+			events.push({ type: "text_delta", contentIndex: 0, delta, partial });
+		}
+
+		const encoder = new AssistantMessageFrameEncoder();
+		const frames = events.flatMap((event) => {
+			const encoded = encoder.encode(event);
+			return encoded === undefined ? [] : [encoded];
+		});
+
+		expect(frames.map((item) => item.type)).toEqual(["start", "text_start"]);
+		expect(frames[0]).toMatchObject({ type: "start", partial: { content: [], stopReason: "pending" } });
+		expect(reduceAssistantMessageFrames(frames)?.content).toEqual([{ type: "text", text: "Hello world" }]);
+	});
+
+	it("trims only the covered prefix when a start snapshot lands inside a delta", () => {
+		const partial = seed();
+		const encoder = new AssistantMessageFrameEncoder();
+		const frames: AssistantMessageFrame[] = [frame(encoder, { type: "start", partial })];
+		const text = { type: "text" as const, text: "Hel" };
+		partial.content.push(text);
+		frames.push(frame(encoder, { type: "text_start", contentIndex: 0, partial }));
+		expect(encoder.encode({ type: "text_delta", contentIndex: 0, delta: "He", partial })).toBeUndefined();
+		const remainder = encoder.encode({ type: "text_delta", contentIndex: 0, delta: "llo", partial });
+		if (remainder === undefined) throw new Error("Expected uncovered text delta");
+		frames.push(remainder);
+
+		expect(remainder).toEqual({ type: "text_delta", contentIndex: 0, delta: "lo" });
+		expect(reduceAssistantMessageFrames(frames)?.content).toEqual([{ type: "text", text: "Hello" }]);
+	});
+
+	it("checkpoints queued tool JSON without replaying covered deltas", () => {
+		const partial = seed();
+		const toolCall = { type: "toolCall" as const, id: "call", name: "write", arguments: {} };
+		const events: AssistantMessageEvent[] = [{ type: "start", partial }];
+		partial.content.push(toolCall);
+		events.push({ type: "toolcall_start", contentIndex: 0, partial });
+		toolCall.arguments = { path: "README.md" };
+		events.push(
+			{ type: "toolcall_delta", contentIndex: 0, delta: '{"path":"READ', partial },
+			{ type: "toolcall_delta", contentIndex: 0, delta: 'ME.md"}', partial },
+		);
+
+		const encoder = new AssistantMessageFrameEncoder();
+		const frames = events.flatMap((event) => {
+			const encoded = encoder.encode(event);
+			return encoded === undefined ? [] : [encoded];
+		});
+		expect(frames.map((item) => item.type)).toEqual(["start", "toolcall_start", "toolcall_checkpoint"]);
+		expect(frames.at(-1)).toEqual({
+			type: "toolcall_checkpoint",
+			contentIndex: 0,
+			json: '{"path":"README.md"}',
+		});
+		expect(reduceAssistantMessageFrames(frames)?.content).toEqual([
+			{ type: "toolCall", id: "call", name: "write", arguments: { path: "README.md" } },
+		]);
+	});
+
+	it("resumes legacy grammar tool JSON from initial arguments", () => {
+		const partial = seed();
+		const encoder = new AssistantMessageFrameEncoder();
+		const frames: AssistantMessageFrame[] = [frame(encoder, { type: "start", partial })];
+		const toolCall = { type: "toolCall" as const, id: "call", name: "bash", arguments: { input: "a" } };
+		partial.content.push(toolCall);
+		frames.push(frame(encoder, { type: "toolcall_start", contentIndex: 0, partial }));
+		toolCall.arguments = { input: "ab" };
+		frames.push(
+			frame(encoder, {
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: '{"input":"ab',
+				partial,
+			}),
+		);
+		toolCall.arguments = { input: "abc" };
+		frames.push(
+			frame(encoder, {
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: 'c"}',
+				partial,
+			}),
+		);
+
+		expect(frames.slice(2)).toEqual([
+			{ type: "toolcall_checkpoint", contentIndex: 0, json: '{"input":"ab' },
+			{ type: "toolcall_delta", contentIndex: 0, delta: 'c"}' },
+		]);
+		expect(reduceAssistantMessageFrames(frames)?.content).toEqual([
+			{ type: "toolCall", id: "call", name: "bash", arguments: { input: "abc" } },
+		]);
+	});
+
+	it("streams tool JSON compactly from an empty argument start", () => {
+		const partial = seed();
+		const encoder = new AssistantMessageFrameEncoder();
+		const frames: AssistantMessageFrame[] = [frame(encoder, { type: "start", partial })];
+		const toolCall = { type: "toolCall" as const, id: "call", name: "bash", arguments: {} };
+		partial.content.push(toolCall);
+		frames.push(frame(encoder, { type: "toolcall_start", contentIndex: 0, partial }));
+		toolCall.arguments = { command: "ls -la /tmp" };
+		frames.push(
+			frame(encoder, {
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: '{"command":"ls -la /tmp"}',
+				partial,
+			}),
+		);
+
+		expect(frames.at(-1)).toEqual({
+			type: "toolcall_delta",
+			contentIndex: 0,
+			delta: '{"command":"ls -la /tmp"}',
+		});
+		expect(reduceAssistantMessageFrames(frames)?.content[0]).toMatchObject({
+			type: "toolCall",
+			arguments: { command: "ls -la /tmp" },
+		});
+	});
+
+	it("accepts a pre-generation error but rejects success or updates before start", () => {
+		const failed = seed();
+		failed.stopReason = "error";
+		failed.errorMessage = "setup failed";
+		expect(
+			new AssistantMessageFrameEncoder().encode({ type: "error", reason: "error", error: failed }),
+		).toBeUndefined();
+
+		const completed = seed();
+		completed.stopReason = "stop";
+		expect(() =>
+			new AssistantMessageFrameEncoder().encode({ type: "done", reason: "stop", message: completed }),
+		).toThrow("done event appears before start");
+		expect(() =>
+			new AssistantMessageFrameEncoder().encode({
+				type: "text_delta",
+				contentIndex: 0,
+				delta: "x",
+				partial: seed(),
+			}),
+		).toThrow("text_delta event appears before start");
+	});
+
+	it("treats end signature metadata, including absence, as authoritative", () => {
+		const frames: AssistantMessageFrame[] = [
+			{ type: "start", partial: seed() },
+			{
+				type: "text_start",
+				contentIndex: 0,
+				content: { type: "text", text: "", textSignature: "stale-text" },
+			},
+			{ type: "text_end", contentIndex: 0, content: "" },
+			{
+				type: "thinking_start",
+				contentIndex: 1,
+				content: {
+					type: "thinking",
+					thinking: "",
+					thinkingSignature: "stale-thinking",
+					redacted: true,
+				},
+			},
+			{ type: "thinking_end", contentIndex: 1, content: "", thinkingSignature: "", redacted: false },
+			{
+				type: "toolcall_start",
+				contentIndex: 2,
+				toolCall: {
+					type: "toolCall",
+					id: "call",
+					name: "read",
+					arguments: {},
+					thoughtSignature: "stale-tool",
+					namespace: "stale-namespace",
+				},
+			},
+			{ type: "toolcall_end", contentIndex: 2, id: "call", name: "read", arguments: {} },
+		];
+
+		expect(reduceAssistantMessageFrames(frames)?.content).toEqual([
+			{ type: "text", text: "" },
+			{ type: "thinking", thinking: "", thinkingSignature: "", redacted: false },
+			{ type: "toolCall", id: "call", name: "read", arguments: {} },
+		]);
+	});
+
+	it("stores authoritative final arguments in toolcall_end frames", () => {
+		const partial = seed();
+		const toolCall = {
+			type: "toolCall" as const,
+			id: "call-1",
+			name: "read",
+			arguments: { path: "README.md" },
+			thoughtSignature: "thought",
+			namespace: "files",
+		};
+		partial.content.push(toolCall);
+
+		const encoder = new AssistantMessageFrameEncoder();
+		frame(encoder, { type: "start", partial });
+		frame(encoder, { type: "toolcall_start", contentIndex: 0, partial });
+		const end = frame(encoder, { type: "toolcall_end", contentIndex: 0, toolCall, partial });
+		expect(end).toEqual({
+			type: "toolcall_end",
+			contentIndex: 0,
+			id: "call-1",
+			name: "read",
+			arguments: { path: "README.md" },
+			thoughtSignature: "thought",
+			namespace: "files",
+		});
+	});
+
+	it("whitelists public block fields from provider-shaped partials", () => {
+		const partial = seed();
+		const text = { type: "text" as const, text: "visible", textSignature: "text-sig", index: 4 };
+		const thinking = {
+			type: "thinking" as const,
+			thinking: "reasoning",
+			thinkingSignature: "thinking-sig",
+			redacted: false,
+			index: 5,
+		};
+		const toolCall = {
+			type: "toolCall" as const,
+			id: "call",
+			name: "run",
+			arguments: { value: 1 },
+			thoughtSignature: "tool-sig",
+			namespace: "tools",
+			partialJson: '{"value":',
+			streamIndex: 6,
+		};
+		partial.content.push(text, thinking, toolCall);
+		const partialWithScratch = partial as AssistantMessage & { outputIndex?: number };
+		partialWithScratch.outputIndex = 3;
+
+		const encoder = new AssistantMessageFrameEncoder();
+		const start = frame(encoder, { type: "start", partial });
+		const textStart = frame(encoder, { type: "text_start", contentIndex: 0, partial });
+		const thinkingStart = frame(encoder, { type: "thinking_start", contentIndex: 1, partial });
+		const toolStart = frame(encoder, { type: "toolcall_start", contentIndex: 2, partial });
+
+		expect(start.type === "start" && start.partial.content).toEqual([]);
+		expect(start).not.toHaveProperty("partial.outputIndex");
+		expect(textStart).not.toHaveProperty("content.index");
+		expect(thinkingStart).not.toHaveProperty("content.index");
+		expect(toolStart).not.toHaveProperty("toolCall.partialJson");
+		expect(toolStart).not.toHaveProperty("toolCall.streamIndex");
+	});
+
+	it("supports interleaved streams by contentIndex", () => {
+		const frames: AssistantMessageFrame[] = [
+			{ type: "start", partial: seed() },
+			{ type: "text_start", contentIndex: 0, content: { type: "text", text: "" } },
+			{
+				type: "toolcall_start",
+				contentIndex: 1,
+				toolCall: { type: "toolCall", id: "call", name: "lookup", arguments: {} },
+			},
+			{ type: "thinking_start", contentIndex: 2, content: { type: "thinking", thinking: "" } },
+			{ type: "text_delta", contentIndex: 0, delta: "answer" },
+			{ type: "toolcall_delta", contentIndex: 1, delta: '{"query":"pi"}' },
+			{ type: "thinking_delta", contentIndex: 2, delta: "check" },
+			{ type: "toolcall_end", contentIndex: 1, id: "call", name: "lookup", arguments: { query: "pi" } },
+			{ type: "text_end", contentIndex: 0, content: "answer" },
+			{ type: "thinking_end", contentIndex: 2, content: "check" },
+		];
+
+		expect(reduceAssistantMessageFrames(frames)?.content).toEqual([
+			{ type: "text", text: "answer" },
+			{ type: "toolCall", id: "call", name: "lookup", arguments: { query: "pi" } },
+			{ type: "thinking", thinking: "check" },
+		]);
+	});
+
+	it("snapshots mutable event data and keeps reduction pure", () => {
+		const partial = seed();
+		partial.diagnostics = [{ type: "test", timestamp: 2, details: { value: "original" } }];
+		const encoder = new AssistantMessageFrameEncoder();
+		const start = frame(encoder, { type: "start", partial });
+		partial.diagnostics[0]!.details!.value = "mutated";
+		partial.usage.cost.total = 99;
+
+		partial.content.push({
+			type: "toolCall",
+			id: "call",
+			name: "run",
+			arguments: { nested: { value: "original" } },
+		});
+		const toolStart = frame(encoder, { type: "toolcall_start", contentIndex: 0, partial });
+		const sourceTool = partial.content[0];
+		if (sourceTool?.type !== "toolCall") throw new Error("Expected source tool call");
+		(sourceTool.arguments.nested as Record<string, unknown>).value = "mutated";
+
+		const reduced = reduceAssistantMessageFrames([start, toolStart]);
+		expect(reduced?.diagnostics?.[0]?.details?.value).toBe("original");
+		expect(reduced?.usage.cost.total).toBe(0);
+		expect(reduced?.content[0]).toMatchObject({ arguments: { nested: { value: "original" } } });
+
+		if (reduced?.content[0]?.type !== "toolCall") throw new Error("Expected reduced tool call");
+		reduced.content[0].arguments.nested = "changed-output";
+		expect(toolStart.type === "toolcall_start" && toolStart.toolCall.arguments.nested).toEqual({
+			value: "original",
+		});
+	});
+
+	it("omits terminal events because settlement is separate", () => {
+		const message = seed();
+		const completed = new AssistantMessageFrameEncoder();
+		completed.encode({ type: "start", partial: message });
+		message.stopReason = "stop";
+		expect(completed.encode({ type: "done", reason: "stop", message })).toBeUndefined();
+		message.stopReason = "error";
+		message.errorMessage = "failed";
+		expect(
+			new AssistantMessageFrameEncoder().encode({ type: "error", reason: "error", error: message }),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when there is no start frame", () => {
+		expect(reduceAssistantMessageFrames([])).toBeUndefined();
+		expect(reduceAssistantMessageFrames([{ type: "text_delta", contentIndex: 0, delta: "x" }])).toBeUndefined();
+	});
+
+	it("rejects frames before start, wrong block kinds, duplicate ends, and index gaps", () => {
+		expect(() =>
+			reduceAssistantMessageFrames([
+				{ type: "text_delta", contentIndex: 0, delta: "x" },
+				{ type: "start", partial: seed() },
+			]),
+		).toThrow("before the start frame");
+		expect(() =>
+			reduceAssistantMessageFrames([
+				{ type: "start", partial: seed() },
+				{
+					type: "toolcall_start",
+					contentIndex: 0,
+					toolCall: { type: "toolCall", id: "call", name: "run", arguments: {} },
+				},
+				{ type: "text_delta", contentIndex: 0, delta: "wrong" },
+			]),
+		).toThrow("expected text block");
+		expect(() =>
+			reduceAssistantMessageFrames([
+				{ type: "start", partial: seed() },
+				{ type: "text_start", contentIndex: 0, content: { type: "text", text: "" } },
+				{ type: "text_end", contentIndex: 0, content: "" },
+				{ type: "text_end", contentIndex: 0, content: "" },
+			]),
+		).toThrow("follows the end");
+		expect(() =>
+			reduceAssistantMessageFrames([
+				{ type: "start", partial: seed() },
+				{ type: "text_start", contentIndex: 1, content: { type: "text", text: "" } },
+			]),
+		).toThrow("would leave a gap");
+	});
+
+	it("rejects conversion events whose contentIndex points to the wrong block kind", () => {
+		const partial = seed();
+		const encoder = new AssistantMessageFrameEncoder();
+		encoder.encode({ type: "start", partial });
+		partial.content.push({ type: "thinking", thinking: "" });
+		expect(() => encoder.encode({ type: "text_start", contentIndex: 0, partial })).toThrow(
+			"text_start event points to thinking block",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Adds AssistantMessageFrameEncoder and reduceAssistantMessageFrames from upstream 8b5899dc. API stream hunks from that commit are already on main.

## Changes

- New packages/ai/src/utils/assistant-message-frame.ts
- Public export from @bastani/pi-ai
- Encoder/reducer tests

## Notes

Stacked follow-up: thinking-level preservation (0fdec07b).

Assistant-model: Grok 4.6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791073344&installation_model_id=10562&pr_number=2833&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2833&signature=da82dcb8f92207bea4ae2f60a61c67df07b567849a9904330e146cc708542e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds compact assistant-message frames for persisting and replaying in-progress responses. The replay path currently drops the provider’s thinking-effort setting, which can change the semantics of a resumed Anthropic conversation. The new source and tests also need to follow the repository’s required import and assertion conventions before merging.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until persisted frames retain provider thinking-effort metadata and the repository-required source and test conventions are satisfied.

A reproduced replay-data loss affects persisted assistant-message state. The remaining findings are explicit repository requirements that must be corrected before merge.

**Files Needing Attention:** packages/ai/src/utils/assistant-message-frame.ts, packages/ai/src/index.ts, and packages/ai/test/assistant-message-frame.test.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the review comment.
- T-Rex attached two artifacts to the P1 proof: a TypeScript artifact and a runtime log artifact, to support review inspection.
- T-Rex produced a proof for the posted P2 finding and noted its presence in the review flow.
- T-Rex performed general-contract-validation by inspecting the runtime JSON, correlating it with the source declarations, and uploading the before/after artifacts that capture the relevant state changes.

<a href="https://app.greptile.com/trex/runs/22422384/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Start-frame cloning drops providerThinkingLevel**

   - **Bug**
     - A start-frame round trip loses `AssistantMessage.providerThinkingLevel`. The executed test supplied `"high"`; the encoded frame and reduced message both had the field absent.
   - **Cause**
     - `cloneStartMessage` (`packages/ai/src/utils/assistant-message-frame.ts:77-91`) constructs a new message but omits `providerThinkingLevel`, despite that optional property being part of `AssistantMessage` at `packages/ai/src/types.ts:501`. The reducer clones the already incomplete start-frame partial.
   - **Fix**
     - Add conditional copying in `cloneStartMessage`, consistent with adjacent optional fields: `...(message.providerThinkingLevel === undefined ? {} : { providerThinkingLevel: message.providerThinkingLevel })`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/ai/src/utils/assistant-message-frame.ts:77-91
**Preserve thinking effort metadata**

When a streamed assistant message carries `providerThinkingLevel`, the start-frame clone omits it. Reducing persisted frames therefore returns a message without the original provider effort level, so replaying that history into a later Anthropic request can use different reasoning semantics.

### Issue 2
packages/ai/src/utils/assistant-message-frame.ts:1-2
**Use JavaScript import specifiers**

The new relative imports use `.ts` specifiers, including the public export and test imports added with this feature. This violates the repository directive that TypeScript source uses ESM `.js` import specifiers. This repository requirement must be satisfied before merging.

### Issue 3
packages/ai/test/assistant-message-frame.test.ts:2
**Use required test assertions**

This new Vitest suite imports and uses `expect` rather than the repository-required `node:assert/strict` assertion style. This violates the repository testing directive. This repository requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ai): add compact assistant-message ..."](https://github.com/bastani-inc/atomic/commit/8f51396d9eb38e19d5635c6a87fc3f8938d91d0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60225458)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/bastani-inc/atomic/blob/main/CLAUDE.md))
- Knowledge Base — [AI integration layer](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/ai-integration.md)

<!-- /greptile_comment -->