### PR TITLE
fix(ai): preserve provider thinking level in frames

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -35,6 +35,7 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 - Fixed the Workers AI binding transport to use the binding's plain `fetch` passthrough for models migrated to the `workers-binding.ai` base URL, preserving request methods, headers, query strings, and streaming bodies instead of translating requests through the universal-endpoint shim. See **Breaking Changes** for the required base-URL and binding-type migration ([#8287](https://github.com/earendil-works/pi/pull/8287)).
 - Fixed OpenAI Codex SSE parsing to process terminal events that are not followed by a blank line ([#9047](https://github.com/earendil-works/pi/issues/9047)).
 - Fixed the Qwen Token Plan Individual catalog to include Qwen3.8 Flash ([#9021](https://github.com/earendil-works/pi/issues/9021)).
+- Fixed assistant-message frames dropping `providerThinkingLevel` from the start snapshot ([upstream `0fdec07b`](https://github.com/earendil-works/pi/commit/0fdec07ba397)).
 
 ## [0.9.18-alpha.5] - 2026-09-01
 

--- a/packages/ai/src/utils/assistant-message-frame.ts
+++ b/packages/ai/src/utils/assistant-message-frame.ts
@@ -83,6 +83,7 @@ function cloneStartMessage(message: AssistantMessage): AssistantMessage {
 		model: message.model,
 		...(message.responseModel === undefined ? {} : { responseModel: message.responseModel }),
 		...(message.responseId === undefined ? {} : { responseId: message.responseId }),
+		...(message.providerThinkingLevel === undefined ? {} : { providerThinkingLevel: message.providerThinkingLevel }),
 		...(message.diagnostics === undefined ? {} : { diagnostics: structuredClone(message.diagnostics) }),
 		usage: structuredClone(message.usage),
 		stopReason: "pending",

--- a/packages/ai/test/assistant-message-frame.test.ts
+++ b/packages/ai/test/assistant-message-frame.test.ts
@@ -61,6 +61,16 @@ describe("assistant message frames", () => {
 		]);
 	});
 
+	it("preserves provider thinking level from the stream start", () => {
+		const partial = seed();
+		partial.providerThinkingLevel = "high";
+		const encoder = new AssistantMessageFrameEncoder();
+		const start = frame(encoder, { type: "start", partial });
+
+		expect(start).toMatchObject({ type: "start", partial: { providerThinkingLevel: "high" } });
+		expect(reduceAssistantMessageFrames([start])?.providerThinkingLevel).toBe("high");
+	});
+
 	it("preserves initial and final thinking metadata, including redaction", () => {
 		const partial = seed();
 		const encoder = new AssistantMessageFrameEncoder();


### PR DESCRIPTION
## Summary

Port 0fdec07b: keep providerThinkingLevel on the start frame snapshot.

## Notes

Stacked on fix/ai-assistant-message-frame. Merge that PR first, or merge this after rebasing onto main once the encoder lands.

Assistant-model: Grok 4.6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791073346&installation_model_id=10562&pr_number=2834&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2834&signature=5ba47ea246130b1aadc53682ad0c2b8f342d0c2c24ecb959cd1b9619421d080e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change preserves provider thinking-level metadata in assistant-message start frames and confirms that reduced messages retain the original value. The accompanying regression coverage also confirms ordinary frames without this metadata continue to work normally.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the changed frame encoding and reduction behavior was exercised successfully.

No actionable issues were found. A focused before-and-after check confirmed that the new field is retained while frames that omit it continue to behave normally.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Performed a focused frame encoding and reduction check for providerThinkingLevel: 'high' and compared it against the parent revision.
- Verified that this revision retained the value through the start frame and reduced message, while a normal frame without the field also passed.
- Documented the exact authored runner and the inner command used for provider thinking level validation.
- Captured before and after validation evidence showing the field omission before, and retention of 'high' after encoding and reduction, with normal-frame tests still passing.

<a href="https://app.greptile.com/trex/runs/22422391/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ai): preserve provider thinking leve..."](https://github.com/bastani-inc/atomic/commit/be5b024804cd258353983ee65de68d529f84a4b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60225472)</sub>

**Context used:**

- Knowledge Base — [AI integration layer](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/ai-integration.md)

<!-- /greptile_comment -->