### PR TITLE
fix(coding-agent): cap branch summaries at 4096 tokens

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Fixed signal-killed child processes reporting a null exit code that callers could mistake for success; Unix signals now use the shell convention `128 + signal`, with unknown signal names falling back to the non-zero status 128 ([#8994](https://github.com/earendil-works/pi/pull/8994)).
 - Fixed Linux managed-tool downloads to use statically linked musl archives for fd and ripgrep on both x64 and ARM64 ([#9070](https://github.com/earendil-works/pi/pull/9070) by [@charlesisworkinghard](https://github.com/charlesisworkinghard)).
 - Fixed a jump-to-latest click discarding other mouse reports delivered in the same terminal input chunk.
+- Fixed branch summaries failing when reasoning consumes a 2048-token output cap by raising the cap to 4096 tokens, clamped to the model's `maxTokens` ([#8845](https://github.com/earendil-works/pi/issues/8845)).
 
 ## [0.9.18-alpha.5] - 2026-09-01
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -195,7 +195,7 @@ The model emits numbered line ranges only; Atomic reconstructs retained text mec
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `branchSummary.reserveTokens` | number | `16384` | Tokens withheld from branch-summary input so the prompt and uncapped response have context-window headroom |
+| `branchSummary.reserveTokens` | number | `16384` | Tokens reserved when selecting branch history; output is capped at 4096 tokens |
 | `branchSummary.skipPrompt` | boolean | `false` | Skip "Summarize branch?" prompt on `/tree` navigation (defaults to no summary) |
 
 ### Session Summary

--- a/packages/coding-agent/src/core/compaction/branch-summarization.ts
+++ b/packages/coding-agent/src/core/compaction/branch-summarization.ts
@@ -81,11 +81,11 @@ export interface GenerateBranchSummaryOptions {
 	customInstructions?: string;
 	/** If true, customInstructions replaces the default prompt instead of being appended */
 	replaceInstructions?: boolean;
-	/** Tokens reserved for prompt + LLM response (default 16384) */
+	/** Tokens reserved when selecting branch history (default 16384) */
 	reserveTokens?: number;
 	/**
 	 * Session reasoning level, inherited by the summarization request.
-	 * No output cap is sent, so thinking has no artificial budget to exhaust.
+	 * Output is capped at 4096 tokens, or the model's `maxTokens` if lower.
 	 */
 	thinkingLevel?: ThinkingLevel;
 	/** Optional session stream function. Used to preserve SDK request behavior without mutating agent state. */
@@ -364,17 +364,17 @@ export async function generateBranchSummary(
 	// request behavior stays consistent without mutating agent state.
 	const context = { systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages };
 	const requestModel = baseUrl === undefined || baseUrl === model.baseUrl ? model : { ...model, baseUrl };
-	// Same budget rule as the compaction planner: no output cap is sent, so
-	// pi-ai's context clamp is the only bound and the inherited reasoning level
-	// has no artificial budget to exhaust. `reserveTokens` keeps its input-side
-	// meaning above, unchanged.
+	// Output is capped at 4096 tokens so reasoning cannot exhaust a 2048-token
+	// cap. `reserveTokens` keeps its input-side meaning above, unchanged.
 	const budget = resolvePlannerRequest(requestModel, thinkingLevel);
+	const maxTokens = Math.min(4096, model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY);
 	const requestOptions: SimpleStreamOptions = {
 		apiKey,
 		headers,
 		signal,
 		cacheRetention: "none",
 		sessionId: uuidv7(),
+		maxTokens,
 		...(budget.reasoning && budget.reasoning !== "off" ? { reasoning: budget.reasoning } : {}),
 	};
 	const response = await (async () => {

--- a/packages/coding-agent/test/branch-summarization.test.ts
+++ b/packages/coding-agent/test/branch-summarization.test.ts
@@ -150,6 +150,38 @@ describe("safe prose summarization", () => {
 		expect(requestOptions?.toolChoice).toBeUndefined();
 	});
 
+	it("caps branch summary output at 4096 tokens", async () => {
+		resetIds();
+		let requestOptions: import("@bastani/pi-ai/compat").SimpleStreamOptions | undefined;
+		await generateBranchSummary([entry(user("summarize safely"))], {
+			model: nonCopilotModel(),
+			signal: new AbortController().signal,
+			streamFn: async (_requestModel, _context, options) => {
+				requestOptions = options;
+				const stream = createAssistantMessageEventStream();
+				stream.end(assistantBlocks([{ type: "text", text: "summary" }]));
+				return stream;
+			},
+		});
+		expect(requestOptions?.maxTokens).toBe(4096);
+	});
+
+	it("clamps the branch summary output cap to the model limit", async () => {
+		resetIds();
+		let requestOptions: import("@bastani/pi-ai/compat").SimpleStreamOptions | undefined;
+		await generateBranchSummary([entry(user("summarize safely"))], {
+			model: { ...nonCopilotModel(), maxTokens: 1024 },
+			signal: new AbortController().signal,
+			streamFn: async (_requestModel, _context, options) => {
+				requestOptions = options;
+				const stream = createAssistantMessageEventStream();
+				stream.end(assistantBlocks([{ type: "text", text: "summary" }]));
+				return stream;
+			},
+		});
+		expect(requestOptions?.maxTokens).toBe(1024);
+	});
+
 	it.each([
 		["branch", generateBranchSummary],
 		["session", generateSessionSummary],


### PR DESCRIPTION
## Summary

Port e44d75c2: branch summarization sends maxTokens 4096, clamped to the model limit.

## Changes

- generateBranchSummary request options
- settings.md
- tests for 4096 and clamp-to-1024

Assistant-model: Grok 4.6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791073347&installation_model_id=10562&pr_number=2835&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2835&signature=d53d26c8f54e616c0dbc8b57643a9a984aad35c9dbee73bd462fcfd69a61b46d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary

- Branch summaries can still fail without producing summary text when an OpenAI Responses reasoning model consumes the shared output budget on reasoning.
- The existing root compaction-budget regression asserts the opposite of the new request behavior and must be updated with this change.

## T-Rex validation blocked

- The root regression test could not be collected because the local `@bastani/pi-ai/compat` module is unavailable; its required local build is blocked by missing generated provider data.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the regression expectation is updated and branch summaries reserve output capacity when reasoning is enabled.

Two independently supported failures remain: the changed request options conflict with an existing regression assertion, and an executed OpenAI Responses flow showed reasoning can consume the entire summary budget before visible text is emitted.

**Files Needing Attention:** packages/coding-agent/src/core/compaction/branch-summarization.ts and test/unit/compaction-planner-budget.test.ts need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The root compaction-budget regression was located and identified as invoking branch summarization and asserting maxTokens is absent from the request options.
- T-Rex ran the root regression and the focused package suite to validate behavior, but test collection stopped due to unresolved @bastani/pi-ai/compat, so no tests executed.
- The candidate root regression validation script was authored and the results showed exit code 1 for both root and package runs due to unresolved compatibility dependency.
- T-Rex produced a finding-proof for a posted P1 finding, including branch-budget validation, isolated validation configuration, and a local compatibility stub, along with cap-exhaustion reasoning and a larger-budget summary.

<a href="https://app.greptile.com/trex/runs/22422394/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/core/compaction/branch-summarization.ts:377
**Update Conflicting Regression Test**

Every branch-summary request now includes `maxTokens`, but the root compaction-budget regression still asserts that this option is absent after invoking the same summary path. Update that assertion and its documented invariant with this behavior; otherwise the root unit suite will fail when it can collect this test.

### Issue 2
packages/coding-agent/src/core/compaction/branch-summarization.ts:370-378
**Reserve Summary Output Tokens**

OpenAI Responses shares `max_output_tokens` between reasoning and visible output. This change sends the 4096-token branch-summary cap together with inherited reasoning, so high reasoning can consume the entire budget before any summary text is produced. The response is then incomplete and branch compaction receives an error instead of the summary it needs; reserve visible-output capacity or disable reasoning for this request before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(coding-agent): cap branch summaries ..."](https://github.com/bastani-inc/atomic/commit/fac2444688cd5b1d39a2aa847cb71c3c25117e6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60225475)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Coding agent application](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/coding-agent.md)

<!-- /greptile_comment -->