### PR TITLE
fix(coding-agent): pin fd 10.3.0 on darwin/x64

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Fixed Linux managed-tool downloads to use statically linked musl archives for fd and ripgrep on both x64 and ARM64 ([#9070](https://github.com/earendil-works/pi/pull/9070) by [@charlesisworkinghard](https://github.com/charlesisworkinghard)).
 - Fixed a jump-to-latest click discarding other mouse reports delivered in the same terminal input chunk.
 - Fixed branch summaries failing when reasoning consumes a 2048-token output cap by raising the cap to 4096 tokens, clamped to the model's `maxTokens` ([#8845](https://github.com/earendil-works/pi/issues/8845)).
+- Pinned managed fd downloads on darwin/x64 to 10.3.0, matching upstream pi's known-good archive for that host ([#8708](https://github.com/earendil-works/pi/issues/8708)).
 
 ## [0.9.18-alpha.5] - 2026-09-01
 

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -247,7 +247,9 @@ async function downloadTool(tool: "fd" | "rg"): Promise<string> {
 	const plat = platform();
 	const architecture = arch();
 
-	const version = await getLatestVersion(config.repo);
+	// fd is pinned on darwin/x64; skip the version lookup there.
+	const version =
+		tool === "fd" && plat === "darwin" && architecture === "x64" ? "10.3.0" : await getLatestVersion(config.repo);
 
 	// Get asset name for this platform
 	const assetName = config.getAssetName(version, plat, architecture);

--- a/packages/coding-agent/test/tools-manager.test.ts
+++ b/packages/coding-agent/test/tools-manager.test.ts
@@ -119,6 +119,22 @@ describe("managed tool downloads", () => {
 		expect(fetchMock.mock.calls.some(([input]) => String(input) === archiveUrl)).toBe(true);
 	});
 
+	it("pins fd 10.3.0 on darwin/x64 without looking up the latest release", async () => {
+		mocks.platform.mockReturnValue("darwin");
+		mocks.arch.mockReturnValue("x64");
+		const archiveUrl =
+			"https://github.com/sharkdp/fd/releases/download/v10.3.0/fd-v10.3.0-x86_64-apple-darwin.tar.gz";
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+			if (String(input) === archiveUrl) return new Response("archive");
+			return new Response("unexpected request", { status: 404 });
+		});
+
+		await expect(ensureTool("fd")).resolves.toBeUndefined();
+
+		expect(fetchMock.mock.calls.some(([input]) => String(input) === archiveUrl)).toBe(true);
+		expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/releases/latest"))).toBe(false);
+	});
+
 	it("resolves the version from the release page redirect", async () => {
 		const fetchMock = vi.fn(
 			async () =>


### PR DESCRIPTION
## Summary

Restore the 57e53b0d darwin/x64 fd pin to 10.3.0. Redirect-based latest lookup stays for every other host.

Assistant-model: Grok 4.6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791073349&installation_model_id=10562&pr_number=2836&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2836&signature=5ab7271d5a50a85adc84af0c2460eac562bdebf5b51a7738faf9ce1d7051a2ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change restores managed `fd` downloads on Darwin x64 by selecting the known-good 10.3.0 archive directly. The focused checks confirm that this path avoids the latest-release request while dynamic version resolution remains available for other platform combinations.

Safe to merge.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the targeted download behavior and its dynamic-resolution control both completed successfully.

No actionable findings were identified.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused managed-tool download tests using an isolated test configuration.
- Verified the Darwin x64 path downloaded the pinned file fd-v10.3.0-x86\_64-apple-darwin.tar.gz without requesting /releases/latest.
- Verified the Linux x64 control path resolves a release version before downloading.
- The focused runs completed successfully, with one selected test and eleven skipped tests.

<a href="https://app.greptile.com/trex/runs/22422689/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(coding-agent): pin fd 10.3.0 on darw..."](https://github.com/bastani-inc/atomic/commit/1751494e7302e529f04c41603410abade73e87cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60225485)</sub>

<!-- /greptile_comment -->