### PR TITLE
fix(ai): rebuild ended assistant-message frame blocks

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -25,6 +25,7 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 - **Breaking:** the `service_tier` cost multiplier in both adapters now keys on `model.fastRoute?.baseModelId ?? model.id`. Without this, `gpt-5.5-fast` would have been priced at the generic 2x priority rate instead of gpt-5.5's 2.5x once the adapters started receiving the canonical model.
 - **Breaking:** `githubCopilotProvider().filterModels` no longer strips every model ID ending in `-fast` from the selectable list. It now exposes a model carrying `fastRoute` only when the OAuth credential's `fastModelIds` advertises that exact ID, and treats a Copilot-owned model that merely ends in `-fast` as an ordinary picker model gated by `availableModelIds`.
 - Qwen3.8 Max and Qwen3.8 Flash no longer offer the `off` thinking level on the `qwen-token-plan`, `qwen-token-plan-cn`, and `qwen-token-plan-individual` providers. Their selectable effort levels now follow models.dev metadata: `low`, `medium`, and `xhigh`.
+- `reduceAssistantMessageFrames` now rebuilds an ended text, thinking, or tool-call block as a value the reducer owns, assembled from the end frame and the rest of the replayed block's own data, instead of deleting optional fields on a value read out of externally supplied frame content. Reduced output is unchanged for every input, including field order and any property the frame carried that the declared block types do not name.
 
 ### Fixed
 

--- a/packages/ai/src/utils/assistant-message-frame.ts
+++ b/packages/ai/src/utils/assistant-message-frame.ts
@@ -401,11 +401,22 @@ export function reduceAssistantMessageFrames(frames: Iterable<AssistantMessageFr
 				break;
 			}
 			case "text_end": {
-				const { block, state } = activeBlock(message, states, frame.contentIndex, "text", frame.type);
+				// Read the index once: `frame` is caller-supplied, so a second read could return a
+				// different value than the one `activeBlock` validated and target a different slot.
+				const contentIndex = frame.contentIndex;
+				const { block, state } = activeBlock(message, states, contentIndex, "text", frame.type);
 				if (block.type !== "text") throw new Error("Unreachable text frame state");
-				block.text = frame.content;
-				delete block.textSignature;
-				if (frame.textSignature !== undefined) block.textSignature = frame.textSignature;
+				// The end frame is authoritative for the optional fields it controls, including the
+				// ones it omits, so those are destructured away. Everything else the block carries is
+				// spread across verbatim, which keeps the result — and its key order — identical to
+				// the in-place mutation this replaced, while the only write targets an object the
+				// reducer owns rather than deleting properties on a value read out of caller frames.
+				const { textSignature: _staleTextSignature, ...rest } = block;
+				message.content[contentIndex] = {
+					...rest,
+					text: frame.content,
+					...(frame.textSignature === undefined ? {} : { textSignature: frame.textSignature }),
+				};
 				state.ended = true;
 				break;
 			}
@@ -425,13 +436,17 @@ export function reduceAssistantMessageFrames(frames: Iterable<AssistantMessageFr
 				break;
 			}
 			case "thinking_end": {
-				const { block, state } = activeBlock(message, states, frame.contentIndex, "thinking", frame.type);
+				const contentIndex = frame.contentIndex;
+				const { block, state } = activeBlock(message, states, contentIndex, "thinking", frame.type);
 				if (block.type !== "thinking") throw new Error("Unreachable thinking frame state");
-				block.thinking = frame.content;
-				delete block.thinkingSignature;
-				delete block.redacted;
-				if (frame.thinkingSignature !== undefined) block.thinkingSignature = frame.thinkingSignature;
-				if (frame.redacted !== undefined) block.redacted = frame.redacted;
+				// See `text_end`: end-frame-controlled optionals off, everything else across verbatim.
+				const { thinkingSignature: _staleThinkingSignature, redacted: _staleRedacted, ...rest } = block;
+				message.content[contentIndex] = {
+					...rest,
+					thinking: frame.content,
+					...(frame.thinkingSignature === undefined ? {} : { thinkingSignature: frame.thinkingSignature }),
+					...(frame.redacted === undefined ? {} : { redacted: frame.redacted }),
+				};
 				state.ended = true;
 				break;
 			}
@@ -463,15 +478,19 @@ export function reduceAssistantMessageFrames(frames: Iterable<AssistantMessageFr
 				break;
 			}
 			case "toolcall_end": {
-				const { block, state } = activeBlock(message, states, frame.contentIndex, "toolCall", frame.type);
+				const contentIndex = frame.contentIndex;
+				const { block, state } = activeBlock(message, states, contentIndex, "toolCall", frame.type);
 				if (block.type !== "toolCall") throw new Error("Unreachable tool-call frame state");
-				block.id = frame.id;
-				block.name = frame.name;
-				block.arguments = structuredClone(frame.arguments);
-				delete block.thoughtSignature;
-				delete block.namespace;
-				if (frame.thoughtSignature !== undefined) block.thoughtSignature = frame.thoughtSignature;
-				if (frame.namespace !== undefined) block.namespace = frame.namespace;
+				// See `text_end`: end-frame-controlled optionals off, everything else across verbatim.
+				const { thoughtSignature: _staleThoughtSignature, namespace: _staleNamespace, ...rest } = block;
+				message.content[contentIndex] = {
+					...rest,
+					id: frame.id,
+					name: frame.name,
+					arguments: structuredClone(frame.arguments),
+					...(frame.thoughtSignature === undefined ? {} : { thoughtSignature: frame.thoughtSignature }),
+					...(frame.namespace === undefined ? {} : { namespace: frame.namespace }),
+				};
 				state.ended = true;
 				break;
 			}

--- a/packages/ai/test/assistant-message-frame.test.ts
+++ b/packages/ai/test/assistant-message-frame.test.ts
@@ -8,6 +8,7 @@ import {
 	AssistantMessageFrameEncoder,
 	type Model,
 	reduceAssistantMessageFrames,
+	type ThinkingContent,
 } from "../src/index.ts";
 import { AssistantMessageEventStream } from "../src/utils/event-stream.ts";
 
@@ -35,6 +36,32 @@ function frame(encoder: AssistantMessageFrameEncoder, event: AssistantMessageEve
 	const converted = encoder.encode(event);
 	if (!converted) throw new Error(`Expected ${event.type} event to produce a frame`);
 	return converted;
+}
+
+function deepFreeze<T>(value: T): T {
+	if (value === null || typeof value !== "object") return value;
+	for (const key of Reflect.ownKeys(value)) {
+		deepFreeze((value as Record<PropertyKey, unknown>)[key]);
+	}
+	return Object.freeze(value);
+}
+
+/**
+ * Builds a frame whose `contentIndex` accessor yields a different value on each read. A handler
+ * that reads it more than once validates one slot and then acts on another.
+ */
+function shiftingIndexFrame(base: Record<string, unknown>, values: unknown[]): AssistantMessageFrame {
+	let reads = 0;
+	const frame = { ...base };
+	Object.defineProperty(frame, "contentIndex", {
+		enumerable: true,
+		get() {
+			const value = values[Math.min(reads, values.length - 1)];
+			reads += 1;
+			return value;
+		},
+	});
+	return frame as unknown as AssistantMessageFrame;
 }
 
 describe("assistant message frames", () => {
@@ -602,5 +629,275 @@ describe("assistant message frames", () => {
 		expect(() => encoder.encode({ type: "text_start", contentIndex: 0, partial })).toThrow(
 			"text_start event points to thinking block",
 		);
+	});
+
+	it("drops stale optional fields as own properties when end frames omit them", () => {
+		const reduced = reduceAssistantMessageFrames([
+			{ type: "start", partial: seed() },
+			{
+				type: "text_start",
+				contentIndex: 0,
+				content: { type: "text", text: "", textSignature: "stale-text" },
+			},
+			{ type: "text_end", contentIndex: 0, content: "done" },
+			{
+				type: "thinking_start",
+				contentIndex: 1,
+				content: { type: "thinking", thinking: "", thinkingSignature: "stale-thinking", redacted: true },
+			},
+			{ type: "thinking_end", contentIndex: 1, content: "thought" },
+			{
+				type: "toolcall_start",
+				contentIndex: 2,
+				toolCall: {
+					type: "toolCall",
+					id: "stale-id",
+					name: "stale-name",
+					arguments: { stale: true },
+					thoughtSignature: "stale-tool",
+					namespace: "stale-namespace",
+				},
+			},
+			{ type: "toolcall_end", contentIndex: 2, id: "call", name: "read", arguments: { path: "a" } },
+			{ type: "thinking_start", contentIndex: 3, content: { type: "thinking", thinking: "" } },
+			{ type: "thinking_end", contentIndex: 3, content: "kept", thinkingSignature: "", redacted: false },
+		]);
+
+		// `toEqual` treats an own property explicitly set to `undefined` as absent, so absence is
+		// pinned structurally with `toStrictEqual` and directly with `Object.hasOwn`.
+		expect(reduced?.content).toStrictEqual([
+			{ type: "text", text: "done" },
+			{ type: "thinking", thinking: "thought" },
+			{ type: "toolCall", id: "call", name: "read", arguments: { path: "a" } },
+			{ type: "thinking", thinking: "kept", thinkingSignature: "", redacted: false },
+		]);
+		const [text, thinking, toolCall, falsyThinking] = reduced?.content ?? [];
+		expect(Object.hasOwn(text, "textSignature")).toBe(false);
+		expect(Object.hasOwn(thinking, "thinkingSignature")).toBe(false);
+		expect(Object.hasOwn(thinking, "redacted")).toBe(false);
+		expect(Object.hasOwn(toolCall, "thoughtSignature")).toBe(false);
+		expect(Object.hasOwn(toolCall, "namespace")).toBe(false);
+		// Falsy-but-present end-frame metadata still survives.
+		expect(Object.hasOwn(falsyThinking, "thinkingSignature")).toBe(true);
+		expect(Object.hasOwn(falsyThinking, "redacted")).toBe(true);
+	});
+
+	it("reduces prototype-bearing frames without polluting prototypes or mutating sources", () => {
+		const partial = seed();
+		// A `__proto__:` key in an object literal sets the prototype; `defineProperty` is what
+		// smuggles an own `__proto__` data property through a frame.
+		Object.defineProperty(partial, "__proto__", {
+			value: { polluted: "yes" },
+			enumerable: true,
+			writable: true,
+			configurable: true,
+		});
+		const frames: AssistantMessageFrame[] = [
+			{ type: "start", partial },
+			{
+				type: "text_start",
+				contentIndex: 0,
+				content: { type: "text", text: "", textSignature: "stale-text" },
+			},
+			{ type: "text_end", contentIndex: 0, content: "hi" },
+			{
+				type: "toolcall_start",
+				contentIndex: 1,
+				toolCall: {
+					type: "toolCall",
+					id: "stale",
+					name: "stale",
+					arguments: {},
+					thoughtSignature: "stale-tool",
+					namespace: "stale-namespace",
+				},
+			},
+			{ type: "toolcall_delta", contentIndex: 1, delta: '{"__proto__":{"polluted":"yes"},"a":1}' },
+			{
+				type: "toolcall_end",
+				contentIndex: 1,
+				id: "call",
+				name: "read",
+				arguments: JSON.parse('{"__proto__":{"polluted":"yes"},"constructor":{"polluted":"yes"},"a":1}'),
+			},
+		];
+		const framesBefore = structuredClone(frames);
+		deepFreeze(frames);
+
+		const reduced = reduceAssistantMessageFrames(frames);
+		if (!reduced) throw new Error("Expected the frame sequence to reduce to a message");
+
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		expect(Object.prototype).not.toHaveProperty("polluted");
+		expect(Object.getPrototypeOf(reduced)).toBe(Object.prototype);
+		// The smuggled key stays own data on the reduced message rather than becoming its prototype.
+		expect(Object.hasOwn(reduced, "__proto__")).toBe(true);
+
+		const [text, toolCall] = reduced.content;
+		expect(text).toStrictEqual({ type: "text", text: "hi" });
+		expect(Object.getPrototypeOf(text)).toBe(Object.prototype);
+		if (toolCall.type !== "toolCall") throw new Error("Expected a tool-call block at index 1");
+		expect(Object.hasOwn(toolCall, "thoughtSignature")).toBe(false);
+		expect(Object.hasOwn(toolCall, "namespace")).toBe(false);
+		expect(Object.getPrototypeOf(toolCall)).toBe(Object.prototype);
+		expect(Object.getPrototypeOf(toolCall.arguments)).toBe(Object.prototype);
+		expect(Object.hasOwn(toolCall.arguments, "__proto__")).toBe(true);
+		expect(Object.hasOwn(toolCall.arguments, "constructor")).toBe(true);
+		expect(toolCall.arguments.a).toBe(1);
+		expect(toolCall.arguments.polluted).toBeUndefined();
+
+		// Deep-frozen sources reduce without a single write escaping into the frames: under ESM
+		// strict mode any write would already have thrown. `toEqual` rather than `toStrictEqual`
+		// because the latter compares `.constructor` identity, which the own `constructor` key
+		// above deliberately subverts on both sides.
+		expect(frames).toEqual(framesBefore);
+		expect(Reflect.ownKeys(frames[0])).toEqual(Reflect.ownKeys(framesBefore[0]));
+	});
+
+	it("rejects a prototype-shaped contentIndex before any content lookup", () => {
+		expect(() =>
+			reduceAssistantMessageFrames([
+				{ type: "start", partial: seed() },
+				{ type: "text_delta", contentIndex: "__proto__", delta: "x" } as unknown as AssistantMessageFrame,
+			]),
+		).toThrow("Invalid assistant message frame contentIndex: __proto__");
+	});
+
+	it("preserves unspecified own fields and key order through end frames", () => {
+		// Excess-property checking only fires on fresh literals in a typed position, so these
+		// blocks are bound to variables first. No cast is involved: carrying a field the block
+		// types do not name is valid public reducer input, and reduction must pass it through.
+		const text = {
+			text: "old",
+			type: "text" as const,
+			providerExtension: { version: 1 },
+			textSignature: "stale",
+		};
+		const thinking = {
+			type: "thinking" as const,
+			redacted: true,
+			vendorTag: "keep",
+			thinking: "old",
+			thinkingSignature: "stale",
+		};
+		const toolCall = {
+			type: "toolCall" as const,
+			namespace: "stale-ns",
+			id: "stale",
+			ext: { v: 2 },
+			name: "stale",
+			arguments: { x: 1 },
+			thoughtSignature: "stale",
+		};
+		const reduced = reduceAssistantMessageFrames([
+			{ type: "start", partial: seed() },
+			{ type: "text_start", contentIndex: 0, content: text },
+			{ type: "text_end", contentIndex: 0, content: "done" },
+			{ type: "thinking_start", contentIndex: 1, content: thinking },
+			{ type: "thinking_end", contentIndex: 1, content: "thought", thinkingSignature: "fresh" },
+			{ type: "toolcall_start", contentIndex: 2, toolCall },
+			{ type: "toolcall_end", contentIndex: 2, id: "call", name: "read", arguments: { p: 1 }, namespace: "ns" },
+		]);
+
+		// Compared as JSON because that is what pins key order: an end frame supersedes the
+		// optionals it controls without reordering or dropping anything else the block carried.
+		expect(JSON.stringify(reduced?.content)).toBe(
+			JSON.stringify([
+				{ text: "done", type: "text", providerExtension: { version: 1 } },
+				{ type: "thinking", vendorTag: "keep", thinking: "thought", thinkingSignature: "fresh" },
+				{ type: "toolCall", id: "call", ext: { v: 2 }, name: "read", arguments: { p: 1 }, namespace: "ns" },
+			]),
+		);
+		expect(Reflect.ownKeys(reduced?.content[2] ?? {})).toEqual([
+			"type",
+			"id",
+			"ext",
+			"name",
+			"arguments",
+			"namespace",
+		]);
+	});
+
+	it("carries block own data across an end frame without letting it reach a prototype", () => {
+		const text = { type: "text" as const, text: "old" };
+		// An own `__proto__` data property on the block itself now flows through the end frame's
+		// object spread, which uses CreateDataProperty rather than Set.
+		Object.defineProperty(text, "__proto__", {
+			value: { polluted: "yes" },
+			enumerable: true,
+			writable: true,
+			configurable: true,
+		});
+		// A start block whose own prototype carries an attacker key, built without `Object.assign`
+		// so the test itself introduces no extend-call sink.
+		const inherited: ThinkingContent = Object.create({ polluted: "yes" });
+		inherited.type = "thinking";
+		inherited.thinking = "old";
+
+		const reduced = reduceAssistantMessageFrames([
+			{ type: "start", partial: seed() },
+			{ type: "text_start", contentIndex: 0, content: text },
+			{ type: "text_end", contentIndex: 0, content: "done" },
+			{ type: "thinking_start", contentIndex: 1, content: inherited },
+			{ type: "thinking_end", contentIndex: 1, content: "thought" },
+		]);
+		if (!reduced) throw new Error("Expected the frame sequence to reduce to a message");
+
+		const [endedText, endedThinking] = reduced.content;
+		expect(Object.hasOwn(endedText, "__proto__")).toBe(true);
+		expect(Object.getPrototypeOf(endedText)).toBe(Object.prototype);
+		expect(Object.getPrototypeOf(endedThinking)).toBe(Object.prototype);
+		// An inherited key is never promoted to own data anywhere in the pipeline.
+		expect(JSON.stringify(endedThinking)).toBe(JSON.stringify({ type: "thinking", thinking: "thought" }));
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+		expect(Object.prototype).not.toHaveProperty("polluted");
+	});
+
+	it("reads a text end frame's contentIndex once", () => {
+		const text = reduceAssistantMessageFrames([
+			{ type: "start", partial: seed() },
+			{ type: "text_start", contentIndex: 0, content: { type: "text", text: "" } },
+			shiftingIndexFrame({ type: "text_end", content: "done" }, [0, "__proto__"]),
+		]);
+		expect(text?.content).toStrictEqual([{ type: "text", text: "done" }]);
+		// A second read of `"__proto__"` would install the rebuilt block as the array's prototype.
+		expect(Object.getPrototypeOf(text?.content ?? [])).toBe(Array.prototype);
+
+		// The same defect is reachable with two ordinary indices, so it needs no exotic key: a
+		// second read of `1` would end block 0 but overwrite block 1.
+		const twoBlocks = reduceAssistantMessageFrames([
+			{ type: "start", partial: seed() },
+			{ type: "text_start", contentIndex: 0, content: { type: "text", text: "a" } },
+			{ type: "text_start", contentIndex: 1, content: { type: "text", text: "b" } },
+			shiftingIndexFrame({ type: "text_end", content: "done" }, [0, 1]),
+		]);
+		expect(twoBlocks?.content).toStrictEqual([
+			{ type: "text", text: "done" },
+			{ type: "text", text: "b" },
+		]);
+	});
+
+	it("reads a thinking end frame's contentIndex once", () => {
+		const thinking = reduceAssistantMessageFrames([
+			{ type: "start", partial: seed() },
+			{ type: "thinking_start", contentIndex: 0, content: { type: "thinking", thinking: "" } },
+			shiftingIndexFrame({ type: "thinking_end", content: "thought" }, [0, "__proto__"]),
+		]);
+		expect(thinking?.content).toStrictEqual([{ type: "thinking", thinking: "thought" }]);
+		expect(Object.getPrototypeOf(thinking?.content ?? [])).toBe(Array.prototype);
+	});
+
+	it("reads a tool-call end frame's contentIndex once", () => {
+		const toolCall = reduceAssistantMessageFrames([
+			{ type: "start", partial: seed() },
+			{
+				type: "toolcall_start",
+				contentIndex: 0,
+				toolCall: { type: "toolCall", id: "a", name: "b", arguments: {} },
+			},
+			shiftingIndexFrame({ type: "toolcall_end", id: "c", name: "d", arguments: { p: 1 } }, [0, "__proto__"]),
+		]);
+		expect(toolCall?.content).toStrictEqual([{ type: "toolCall", id: "c", name: "d", arguments: { p: 1 } }]);
+		expect(Object.getPrototypeOf(toolCall?.content ?? [])).toBe(Array.prototype);
 	});
 });


### PR DESCRIPTION
Resolves the five open CodeQL alerts #189–#193 (`js/prototype-polluting-assignment`) in
`packages/ai/src/utils/assistant-message-frame.ts` by eliminating the tainted sinks rather than
suppressing them. Each end handler now snapshots its `contentIndex` once, destructures away only the
optionals that end frame controls, spreads the rest of the replayed block, and assigns the result into
`message.content[contentIndex]` — a fixed-name base that never carries the query's `objectPrototype`
state. No `delete`, no `Object.assign`, no `lgtm`/CodeQL annotation.

Diff vs `origin/main`: 3 files, all under `packages/ai` (+335/−18).

**Closure gate is pending by construction.** `.github/workflows/codeql.yml` triggers on push-to-`main`
and `pull_request` only, so no analysis ran on the branch push. This PR's `javascript-typescript`
CodeQL run is the sole authoritative confirmation that #189–#193 are gone; it has not completed yet
and alert closure below is argued from the query source plus removal of all five `delete` sinks, not
observed.

**Hook skip disclosed.** The commit was made with `PREK_SKIP=check` — prek's documented selector skip
— because `prek.toml`'s local `check` hook runs the repo-wide `npm run check`, which the task's
minimal-validation policy forbids. Every other filename-scoped hook ran, including the repo-wide
`biome check --write`.

**Commit-message correction (review finding, non-blocking P3).** The commit body of `7b305c6155` says
"Five are true fail-before-fix" and then "All eight pass against the pre-change reducer and against
this one." Only the second sentence is right *relative to `origin/main`*: a reviewer swapped
`git show origin/main:packages/ai/src/utils/assistant-message-frame.ts` into the tree and measured
28/28 passing, so none of the eight fails against this branch's actual baseline. The five did fail
against the discarded iteration-2 HEAD `2a1b4d2da8`, which is where the wording came from. The commit
was left unamended so the SHA both reviewers verified stays intact; this note is the correction of
record. The tests remain correct and valuable as characterization and security pins.

---

# Implementation Notes

Task: Resolve the five open GitHub CodeQL alerts (#189–#193, `js/prototype-polluting-assignment`) in the
isolated worktree `/Users/tonystark/Documents/projects/atomic-codeql-assistant-frame`, branch
`fix/codeql-assistant-frame-prototype-pollution`.

## Contract amendments received

No user-authored steering has arrived in any iteration. The launch objective, acceptance criteria, and literal
objective contract remain the sole source of required behavior.

One **agent-authored** mid-run message reached the *research* stage from
`subagent-chat-01a069da-55a9-7c4f-bf76-adb2248e9c03` and is restated verbatim in the research artifact:

> Research-only boundary: do not leave source/test edits in the shared worktree. Your probe currently shows a
> broken partial hoist (`contentIndex` missing in toolcall_end), 7 focused-test failures, and a tsgo error.
> Before completing, restore every temporary/probe edit so the worktree exactly matches committed HEAD
> 2a1b4d2da8 and remove zz-toctou-probe.test.ts. Record the required production repair precisely: snapshot
> contentIndex once in each of text_end, thinking_end, and toolcall_end before activeBlock, then reuse it for
> the replacement write; add one committed regression covering changing accessors in all three handlers. The
> orchestrator—not research—must implement and validate it.

That is process direction to a peer agent, not a user contract amendment, so it is recorded here as an
observation rather than a new acceptance criterion. Its substance — the snapshot repair and the regression —
was already required by the inherited criteria ("preserve exact reducer behavior", "frame validation", "safe
handling of prototype-bearing inputs"), and I implemented and validated it in this iteration.

## Iteration history

- **Iteration 1** removed the five `delete` sinks by rebuilding each ended block as a **closed literal**.
  Blocking review finding: closed literals dropped own fields the block types do not name and canonicalized
  key order.
- **Iteration 2** replaced the closed literals with rest-destructure + spread, restoring byte-exact baseline
  output for ordinary inputs. Blocking review finding: the rebuilt handlers read `frame.contentIndex` **twice**
  (once for `activeBlock`, once for the write) where the baseline read it **once** — a time-of-check /
  time-of-use hole reachable from a caller-supplied accessor.
- **Iteration 3 (this one)** repairs the double read. Commit amended to `7b305c6155`.

## The TOCTOU repair

Each of `text_end`, `thinking_end`, and `toolcall_end` now snapshots the index once, before `activeBlock`, and
reuses that local for both the validation call and the replacement write:

```ts
// Read the index once: `frame` is caller-supplied, so a second read could return a
// different value than the one `activeBlock` validated and target a different slot.
const contentIndex = frame.contentIndex;
const { block, state } = activeBlock(message, states, contentIndex, "text", frame.type);
…
message.content[contentIndex] = { ...rest, text: frame.content, … };
```

Edited by hand, one handler at a time, and re-read afterwards. The research artifact warned that the string
`const { block, state } = activeBlock(message, states, frame.contentIndex, "toolCall", frame.type);` occurs
**three** times (`toolcall_checkpoint`, `toolcall_delta`, `toolcall_end`) and that a scripted search/replace
lands the snapshot in the wrong case; `grep -n "frame.contentIndex\|const contentIndex"` after the edit
confirms the three snapshots sit at lines 406/439/481 and that `toolcall_checkpoint` (464) and
`toolcall_delta` (473) are untouched.

Nothing else changed. `text_delta`, `thinking_delta`, `toolcall_checkpoint`, `toolcall_delta`, the three
`*_start` `appendBlock` calls, and the post-loop fixup each already read `frame.contentIndex` exactly once, so
they match baseline read-count and needed no edit.

## Acceptance matrix

| # | Contract clause | Evidence (this session unless noted) |
|---|---|---|
| 1 | Resolve #189–#193 without suppression | `grep -n "delete \|Object.assign\|lgtm\|codeql" src/utils/assistant-message-frame.ts` → `none`. |
| 2 | Eliminate tainted sinks, not annotate | Only write is `message.content[contentIndex] = {…}`; base `message.content` is a fixed-name read that cannot carry the `objectPrototype` state. Rest-destructure is a read; object spread is not a `DataFlow::CallNode`, so it cannot be an `ExtendCall` sink. |
| 3 | Preserve exact reducer behavior / exact valid output | **28/28 pass against the `origin/main` baseline source**, including all three accessor tests. |
| 4 | Preserve frame typing / discriminated union | `tsgo -p tsconfig.build.json --noEmit` exit 0. |
| 5 | Preserve frame validation and state transitions | The validated index is now the one written to, so `assertContentIndex` can no longer be bypassed between check and use. Existing error-string tests (`before the start frame`, `expected text block`, `follows the end`, `would leave a gap`) pass. |
| 6 | Preserve input immutability | Deep-frozen-frames test passes. |
| 7 | Preserve streaming / tool-call reconstruction | Checkpoint/delta/post-loop paths untouched; their tests pass. |
| 8 | Signatures / redaction / namespace semantics | Absence pinned with `toStrictEqual` + `Object.hasOwn`; falsy-but-present survival pinned. |
| 9 | Safe handling of prototype-bearing inputs | Own `__proto__` on the block survives `{...rest}` as own data; custom-prototype start block normalizes; and the new tests prove `message.content`'s **own prototype** is no longer replaceable via an accessor returning `"__proto__"`. |
| 10 | Focused security regression coverage | 8 new `it` blocks total across three iterations; 5 are fail-before-fix. |
| 11 | Changelog | Unchanged this iteration. Its claim "Reduced output is unchanged for every input" was *false at HEAD* for accessor frames and is true again with the repair. Still a single `+1` hunk in `[Unreleased] > ### Changed`; no released section touched. No second entry added — the snapshot restores parity rather than changing shipped behavior. |
| 12 | Scoped diff | 3 files, all under `packages/ai`. |
| 13 | Minimal validation only | One focused vitest file, package-local Biome on 2 files, 2 `tsgo` project checks. No `npm run check`, suites, builds, or CodeQL DB. |
| 14 | Primary worktree untouched | Only read-only symlinks pointed at it; removed before committing. |
| 15 | Conventional commit + trailer, signed, pushed | Amended, `%G?` = `G`, force-pushed with lease. |
| 16 | PR CodeQL is authoritative closure gate | **Pending.** Not verifiable locally; no PR exists. |

## Regression evidence — three-way differential, per handler

The suite was held constant and only `src/utils/assistant-message-frame.ts` was swapped:

| Source under test | Result |
|---|---|
| Committed HEAD `2a1b4d2da8` (double read) | **3 failed / 25 passed.** All three per-handler tests fail with the stale-block signature: text `expected [{type:'text',text:''}] to strictly equal [{type:'text',text:'done'}]`; thinking `[{type:'thinking',thinking:''}]`; tool call `[{type:'toolCall',id:'a',…}]` vs `id:'c'`. |
| `origin/main` baseline (single read, `delete`-based) | **28 passed / 28.** |
| Repaired tree | **28 passed / 28.** |

I deliberately split the new coverage into three per-handler `it` blocks rather than the single test the
research recommended. With one combined test the run aborts at the first failed assertion, so HEAD would only
ever have proven the `text_end` case — and `toolcall_end` was exactly what the research artifact listed as
**explicitly unverified** (its probe mis-placed the snapshot and never exercised a correct tool-call version).
The split closes that gap with durable in-suite evidence: all three handlers are independently shown broken at
HEAD and correct against baseline. The `text_end` test also carries the type-clean `0 → 1` variant, which
proves the defect needs no exotic key — two ordinary indices clobber the wrong block.

Helper used (`shiftingIndexFrame`) defines `contentIndex` as an enumerable accessor returning successive values.

## Validation (all measured this session, from `packages/ai`)

| Command | Observed |
|---|---|
| `../../node_modules/.bin/vitest --run test/assistant-message-frame.test.ts` | **28 passed / 28** |
| `../../node_modules/.bin/biome check --error-on-warnings src/utils/assistant-message-frame.ts test/assistant-message-frame.test.ts` | `Checked 2 files in 46ms. No fixes applied.`, exit 0 |
| `../../node_modules/.bin/tsgo -p tsconfig.build.json --noEmit` | exit 0, no output |
| `../../node_modules/.bin/tsgo -p tsconfig.json --noEmit` | 6 errors, **0** in `assistant-message-frame`; all pre-existing in `github-copilot-oauth.test.ts` (1) and `openai-codex-stream.test.ts` (5) |

`contentIndex` is read twice inside each handler so no unused-binding question arises, and the only other
`contentIndex` binding is the post-loop `for (const [contentIndex, state] of states)`, a separate scope.

## Deferred / out of scope

1. **PR CodeQL confirmation** — the sole authoritative closure gate; needs the PR. Unverified.
2. **Secondary CodeQL argument slightly weaker.** The research notes that the "numeric property name ⇒
   `isIgnoredLibraryFlow`" *secondary* argument softens when the index is a local `const` rather than
   `frame.contentIndex`, because JS type inference is looser through a local. The **primary** argument is
   unaffected: `message.content` is a fixed-name read and never acquires the `objectPrototype` state, which is
   the only way a base becomes a sink. Recording it because it is a real (if minor) change in the reasoning.
3. **`partial-json` prototype behavior (pre-existing).** `parseStreamingJson` routes *incomplete* tool JSON to
   `partial-json`'s `parse`, which honors `__proto__` as a prototype setter. Per-object, not global; lives in
   `packages/ai/src/utils/json-parse.ts`; affects every streaming tool-argument path; not one of #189–#193.
4. **Residual CodeQL exposure.** `block.text += frame.delta`, `block.arguments = parseStreamingJson(...)`, and
   the post-loop fixup still mutate the replayed block with fixed property names, unreported only because
   `isIgnoredLibraryFlow` drops fixed-name `PropWrite` sinks from `ExternalInputSource`.

## Delivery

Amended to `7b305c6155` and force-pushed with `--force-with-lease` (single-commit branch, remote was at exactly
the prior SHA, no PR anchored to it). Conventional subject `fix(ai): …`, `Assistant-model: GPT-5.6 Sol`
trailer, SSH-signed (`%G?` verified `G` after the amend).

**Hook skip disclosed:** `PREK_SKIP=check`, prek's documented selector skip, required because `prek.toml`'s
local `check` hook runs the contract-forbidden repo-wide `npm run check`. All other filename-scoped hooks ran,
including the repo-wide `biome check --write`. Restate in the PR body.

Worktree hygiene: three untracked symlinks into the primary worktree avoid a multi-minute `npm ci`; they show
in `git status` because `.gitignore` uses trailing-slash patterns. Only explicit paths were ever staged — never
`git add -A` — and all three were removed before committing. No `issues.md` was needed. `/tmp/amf-toctou.bak`
held the repaired source during the differential and the tree was restored from it.

## QA E2E Video

Not applicable; no video produced. This is an internal reducer in the `@bastani/pi-ai` library
(`reduceAssistantMessageFrames`), exported only through `packages/ai/src/index.ts`, with no other importer in
the repository. There is no web page and no TUI screen whose behavior differs before and after the diff, so a
Playwright or tmux recording would capture nothing attributable to it. The equivalent proof is the focused
vitest run against the real public entry point — including a full OpenAI Responses stream replay whose reduced
content must equal the live stream output — plus the three-way source differential above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791083064&installation_model_id=10562&pr_number=2843&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2843&signature=ad76e95551ad77a3b5262e0de76994c7bb8d6c3ec6eaa3f70feb1ab8792df6e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change rebuilds completed assistant-message blocks from reducer-owned values, keeping end-frame metadata authoritative while preserving extension fields and property order. The focused replay checks completed successfully.

<h3>Confidence Score: 5/5</h3>

Safe to merge: no actionable issue was found in the changed reducer behavior.

No final findings remain. Focused replay coverage passed for frozen inputs, prototype-bearing data, extension fields, key ordering, and changing content-index accessors.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the general contract-validation probe on the PR head and confirmed all checks passed with 1/1 tests and exit code 0.
- Validated the focused existing test suite on the PR head and confirmed all 28/28 tests passed with exit code 0.
- Executed the same narrow probe on the base worktree and confirmed it also passed, indicating no before/after regression.
- Inspected the uploaded log artifacts to confirm the exact test counts and exit codes for the PR head and base worktree runs.

<a href="https://app.greptile.com/trex/runs/22442491/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ai): rebuild ended assistant-message..."](https://github.com/bastani-inc/atomic/commit/7b305c615579400c9fb71f96e2f2265d7dd1689c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60263802)</sub>

**Context used:**

- Knowledge Base — [AI integration layer](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/ai-integration.md)

<!-- /greptile_comment -->