### PR TITLE
test: repair the two main-branch CI baseline contract regressions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -14,3 +14,23 @@
 # bad resolve reaches users. Restore the gate by setting both values back to 2.
 save-exact=true
 min-release-age=0
+
+# npm's defaults let one registry request wait 300000 ms before either of two
+# retries, with retry backoff reaching 60000 ms. That failure mode is longer
+# than the job that has to recover from it: in run 33833721342, static-checks
+# restored the exact npm cache key, printed two warnings, then produced nothing
+# until its six-minute job cap killed `npm ci`. Other installs on the same head
+# took 260-422 seconds; the last green run, 33783316787, installed in 7 seconds.
+# The lockfile was identical, so widening job caps would preserve the stall.
+#
+# Give each request 25 seconds and two quick retries. Conservatively charging
+# all three attempts the full fetch timeout and both backoffs the 5-second
+# maximum bounds one stalled request to 85 seconds. That is below one third of
+# the smallest job budget in test.yml (the CI contract derives that relationship
+# from the workflow), while a healthy warm-cache install pays no timeout or
+# backoff at all. What this gives up: one unusually slow response no longer gets
+# five uninterrupted minutes; it is abandoned after 25 seconds and retried.
+fetch-timeout=25000
+fetch-retries=2
+fetch-retry-mintimeout=1000
+fetch-retry-maxtimeout=5000

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -76,6 +76,87 @@ test("every test suite entry point resolves to one shared per-test timeout", asy
 	assert.match(await readText(join(root, ".github/workflows/test.yml")), /run-flaky-test-suite\.ts/u);
 });
 
+/**
+ * Run 33833721342 reached `npm ci` with an exact-key cache hit, then emitted
+ * nothing for the full six-minute static-checks job cap. npm's former default
+ * allowed one HTTP request to wait 300 seconds before either of its retries,
+ * so the install policy could not recover before the job that owned it died.
+ *
+ * Bound one request conservatively as every attempt consuming fetch-timeout
+ * plus every retry consuming the maximum backoff. Keeping that below one third
+ * of the smallest job cap leaves the rest of the job two thirds of its budget
+ * and makes a future cap reduction move together with the repository policy.
+ */
+test("npm registry retries finish well inside the smallest CI job budget", async () => {
+	const npmConfig = new Map(
+		(await readText(join(root, ".npmrc")))
+			.split("\n")
+			.map((line) => /^(?<key>[a-z][a-z-]*)=(?<value>\S+)$/u.exec(line)?.groups)
+			.filter((entry): entry is { key: string; value: string } => entry !== undefined)
+			.map(({ key, value }) => [key, value]),
+	);
+	const integerConfig = (name: string): number => {
+		const value = npmConfig.get(name);
+		assert.ok(value, `.npmrc must declare ${name}`);
+		assert.match(value, /^\d+$/u, `${name} must be an integer, received ${value}`);
+		return Number(value);
+	};
+	const fetchTimeoutMs = integerConfig("fetch-timeout");
+	const fetchRetries = integerConfig("fetch-retries");
+	const retryMinTimeoutMs = integerConfig("fetch-retry-mintimeout");
+	const retryMaxTimeoutMs = integerConfig("fetch-retry-maxtimeout");
+	assert.ok(fetchRetries >= 1, "a transient registry stall must receive at least one retry");
+	assert.ok(retryMinTimeoutMs > 0, "registry retries need a positive backoff");
+	assert.ok(retryMinTimeoutMs <= retryMaxTimeoutMs, "minimum retry backoff must not exceed its maximum");
+
+	const workflow = parseYaml(await readText(testPath)) as Workflow;
+	const jobBudgetsMinutes = Object.values(workflow.jobs ?? {}).flatMap((job) => {
+		const directBudget = job["timeout-minutes"];
+		const direct = typeof directBudget === "number" ? [directBudget] : [];
+		const matrix = (job.strategy?.matrix?.include ?? []).flatMap((entry) => {
+			const budget = entry.timeout_minutes;
+			return typeof budget === "number" ? [budget] : [];
+		});
+		return [...direct, ...matrix];
+	});
+	assert.ok(jobBudgetsMinutes.length > 0, "test.yml must declare job timeout budgets");
+	const smallestJobBudgetMs = Math.min(...jobBudgetsMinutes) * 60_000;
+	const stalledRequestBudgetMs = fetchTimeoutMs * (fetchRetries + 1) + retryMaxTimeoutMs * fetchRetries;
+	assert.ok(
+		stalledRequestBudgetMs * 3 <= smallestJobBudgetMs,
+		`one stalled npm request can consume ${stalledRequestBudgetMs}ms, more than one third of the smallest CI job budget (${smallestJobBudgetMs}ms)`,
+	);
+});
+
+/**
+ * Run 33833721342 let the packed-artifact test's npm child consume the same
+ * 240-second budget as the whole test. The child timed out, and the 243795 ms
+ * test duration then exceeded the suite's 70% headroom gate as a second,
+ * guaranteed failure. The fixture lives outside the repository too, so npm
+ * does not discover the committed project .npmrc by walking up from its cwd.
+ */
+test("packed-artifact children cannot consume the whole test budget", async () => {
+	const source = await readText(join(root, "test/integration/packed-workflow-sdk-types.test.ts"));
+	const namedBudget = (name: string): number => {
+		const declaration = new RegExp(`^const ${name} = ([\\d_]+);$`, "mu").exec(source);
+		assert.ok(declaration, `packed-artifact test must declare ${name}`);
+		return Number((declaration[1] as string).replaceAll("_", ""));
+	};
+	const subprocessBudgetMs = namedBudget("PACKED_ARTIFACT_SUBPROCESS_TIMEOUT_MS");
+	const testBudgetMs = namedBudget("PACKED_ARTIFACT_TYPECHECK_TEST_TIMEOUT_MS");
+	assert.ok(
+		subprocessBudgetMs < testBudgetMs,
+		`packed-artifact subprocess budget ${subprocessBudgetMs}ms must be strictly smaller than its ${testBudgetMs}ms test budget`,
+	);
+	assert.match(source, /timeout: PACKED_ARTIFACT_SUBPROCESS_TIMEOUT_MS/u);
+	assert.match(source, /^\tPACKED_ARTIFACT_TYPECHECK_TEST_TIMEOUT_MS,$/mu);
+	assert.match(
+		source,
+		/`--userconfig=\$\{npmConfigPath\}`/u,
+		"the temp-dir install must explicitly use the repo .npmrc",
+	);
+});
+
 test("global setups provide artifacts and native bindings to every project", async () => {
 	const config = (await import("../../vitest.config.js")) as {
 		default: {
@@ -799,8 +880,14 @@ interface WorkflowMatrix {
 	[key: string]: string[] | MatrixEntry[] | undefined;
 }
 
+interface WorkflowJob {
+	"runs-on"?: string | string[];
+	"timeout-minutes"?: number | string;
+	strategy?: { matrix?: WorkflowMatrix };
+}
+
 interface Workflow {
-	jobs?: Record<string, { "runs-on"?: string | string[]; strategy?: { matrix?: WorkflowMatrix } }>;
+	jobs?: Record<string, WorkflowJob>;
 }
 
 /**

--- a/test/ci/fast-model-identity-contracts.test.ts
+++ b/test/ci/fast-model-identity-contracts.test.ts
@@ -218,9 +218,13 @@ const proseNames = new Set([
 	"enabledModels",
 	"buildBaseOptions",
 	"supportsMidConvoEffort",
+	// `Model`/`SimpleStreamOptions` request field, never a package export.
+	"maxTokens",
 	"tsgo",
 	"write",
 	"edit",
+	// Terminal UI copy, not a symbol: the interactive working-status label.
+	"Working",
 ]);
 
 function unreleasedBlock(changelogPath: string): string {

--- a/test/integration/packed-workflow-sdk-types.test.ts
+++ b/test/integration/packed-workflow-sdk-types.test.ts
@@ -24,7 +24,12 @@ const packageDir = join(repoRoot, "packages", "coding-agent");
 const nativePackageDir = join(repoRoot, "packages", "natives");
 const piAiPackageDir = join(repoRoot, "packages", "ai");
 const tscEntry = join(repoRoot, "node_modules", "typescript", "bin", "tsc");
-const PACKED_ARTIFACT_TYPECHECK_TIMEOUT_MS = 240_000;
+const npmConfigPath = join(repoRoot, ".npmrc");
+// A stalled child must fail early enough to preserve a useful error and the
+// outer test's duration headroom. The total remains structural: it includes a
+// real package archive, a built-package install, and a tsc process.
+const PACKED_ARTIFACT_SUBPROCESS_TIMEOUT_MS = 100_000;
+const PACKED_ARTIFACT_TYPECHECK_TEST_TIMEOUT_MS = 300_000;
 const PACKED_PACKAGE_INPUTS = [
 	"package.json",
 	"dist",
@@ -118,7 +123,7 @@ function run(command: readonly string[], cwd: string): CommandOutput {
 		cwd,
 		stdout: "pipe",
 		stderr: "pipe",
-		timeout: PACKED_ARTIFACT_TYPECHECK_TIMEOUT_MS,
+		timeout: PACKED_ARTIFACT_SUBPROCESS_TIMEOUT_MS,
 	});
 	const stdout = result.stdout.toString();
 	const stderr = result.stderr.toString();
@@ -191,6 +196,7 @@ test(
 		run(
 			npmCommand(
 				"install",
+				`--userconfig=${npmConfigPath}`,
 				"--ignore-scripts",
 				"--no-package-lock",
 				"--omit=optional",
@@ -202,5 +208,5 @@ test(
 		);
 		run([process.execPath, tscEntry, "--project", "tsconfig.json", "--pretty", "false"], consumerDir);
 	},
-	PACKED_ARTIFACT_TYPECHECK_TIMEOUT_MS,
+	PACKED_ARTIFACT_TYPECHECK_TEST_TIMEOUT_MS,
 );

--- a/test/unit/compaction-planner-budget.test.ts
+++ b/test/unit/compaction-planner-budget.test.ts
@@ -92,8 +92,11 @@ const branchEntries = [
 
 test("branch summarization caps output at 4096 tokens and inherits the session reasoning level", async () => {
 	const stream = scriptedStream({ default: [{ text: "a branch summary" }] });
+	// The model limit is deliberately *above* the cap. `testModel()`'s own `maxTokens` is
+	// 4096, so the bare fixture would satisfy the assertion below even if the runtime
+	// forwarded `model.maxTokens` verbatim — proving nothing about the cap it names.
 	const result = await generateBranchSummary(branchEntries as never, {
-		model: testModel(),
+		model: testModel({ maxTokens: 8192 }),
 		apiKey: "primary-key",
 		signal: new AbortController().signal,
 		streamFn: stream.streamFn,

--- a/test/unit/compaction-planner-budget.test.ts
+++ b/test/unit/compaction-planner-budget.test.ts
@@ -2,8 +2,10 @@
  * RFC §8 — Unit: budget.
  *
  * The invented `0.8 × reserveTokens` output cap is gone. `PlannerBudget.maxTokens`
- * is declared `undefined` at the type level, the runtime request owns no
+ * is declared `undefined` at the type level, the planner's runtime request owns no
  * `maxTokens` key at all, and reasoning is inherited without per-attempt variation.
+ * Branch summarization is the one caller that does send an output cap: a fixed 4096
+ * tokens, clamped to the model's own `maxTokens` when that is lower.
  */
 
 import assert from "node:assert/strict";
@@ -74,22 +76,23 @@ test("an `off` inherited level sends no reasoning parameter", async () => {
 	assert.equal("reasoning" in stream.calls[0].options, false);
 });
 
-test("branch summarization omits maxTokens and inherits the session reasoning level", async () => {
-	const stream = scriptedStream({ default: [{ text: "a branch summary" }] });
-	const entries = [
-		{
-			id: "m1",
-			type: "message" as const,
-			parentId: null,
-			timestamp: new Date().toISOString(),
-			message: {
-				role: "user" as const,
-				content: [{ type: "text" as const, text: "hello there" }],
-				timestamp: Date.now(),
-			},
+const branchEntries = [
+	{
+		id: "m1",
+		type: "message" as const,
+		parentId: null,
+		timestamp: new Date().toISOString(),
+		message: {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: "hello there" }],
+			timestamp: Date.now(),
 		},
-	];
-	const result = await generateBranchSummary(entries as never, {
+	},
+];
+
+test("branch summarization caps output at 4096 tokens and inherits the session reasoning level", async () => {
+	const stream = scriptedStream({ default: [{ text: "a branch summary" }] });
+	const result = await generateBranchSummary(branchEntries as never, {
 		model: testModel(),
 		apiKey: "primary-key",
 		signal: new AbortController().signal,
@@ -98,6 +101,20 @@ test("branch summarization omits maxTokens and inherits the session reasoning le
 	});
 	assert.equal(result.error, undefined);
 	assert.equal(stream.calls.length, 1);
-	assert.equal("maxTokens" in stream.calls[0].options, false);
+	assert.equal(stream.calls[0].options.maxTokens, 4096);
 	assert.equal(stream.calls[0].options.reasoning, "medium");
+});
+
+test("branch summarization clamps its output cap to a smaller model limit", async () => {
+	const stream = scriptedStream({ default: [{ text: "a branch summary" }] });
+	const result = await generateBranchSummary(branchEntries as never, {
+		model: testModel({ maxTokens: 1024 }),
+		apiKey: "primary-key",
+		signal: new AbortController().signal,
+		streamFn: stream.streamFn,
+		thinkingLevel: "medium",
+	});
+	assert.equal(result.error, undefined);
+	assert.equal(stream.calls.length, 1);
+	assert.equal(stream.calls[0].options.maxTokens, 1024);
 });


### PR DESCRIPTION
# Implementation Notes

Task: Repair the two CI regressions already present on `origin/main` in the pre-created isolated worktree, then create a separate PR.

Worktree: `/Users/tonystark/Documents/projects/atomic-ci-baseline-repair`, branch `fix/ci-baseline-contract-regressions`, base `origin/main` @ `0488a86dec`. Primary and feature worktrees untouched; no new worktree or branch created.

## Acceptance matrix

| # | Contract clause | Evidence |
|---|---|---|
| 1 | Separate PR from `fix/ci-baseline-contract-regressions` against `main` | branch already checked out from `origin/main`; commit + `git push -u origin HEAD`; PR creation left to the workflow final stage per the stage constraint ("Ignore requests to submit a PR") |
| 2 | Stale root branch-summary budget assertion now proves the 4,096-token/clamped contract from #2835 | `test/unit/compaction-planner-budget.test.ts`: `maxTokens === 4096` with `testModel({ maxTokens: 8192 })` (fixed cap) and `maxTokens === 1024` with `testModel({ maxTokens: 1024 })` (clamp); 8/8 green, was 1 failed/6 passed. Mutation-proven in iteration 2 (below) |
| 3 | No runtime behavior change | only two `test/**` files in the diff (`git diff --stat`) |
| 4 | Planner no-cap invariant preserved | `"the planner request object owns no maxTokens key"` and both `@ts-expect-error` type assertions untouched; `npx tsc --noEmit` exit 0 |
| 5 | Changelog identifier contract narrowly recognizes `Working` as UI prose | `"Working"` added to `proseNames` with a UI-copy comment; nothing else in the guard changed |
| 6 | Export validation not weakened | `removedNames`, `isExported`, `IDENTIFIER_PATTERN`, and the other four tests unchanged; 5/5 green |
| 7 | Released changelog sections untouched | no `CHANGELOG.md` in the diff |
| 8 | No package changelog entry | none added (test-only reconciliation of already-shipped behavior; matches AGENTS.md rules) |
| 9 | Smallest relevant files only | exactly 2 files changed |
| 10 | Only the two exact test files + targeted format/type checks run | commands recorded below; no `npm run check`, no suites, no builds |
| 11 | Commit trailer `Assistant-model: GPT-5.6 Sol`, signing preserved | both commits verified via `git log --show-signature` → `Good "git" signature … ED25519 SHA256:kbcL7f…` |

## Decisions and deviations from research

- **Second unresolved identifier confirmed.** The changelog guard failed on `Working` first, but `node:assert` stops at the first failure. The `[Unreleased]` block also backticks `maxTokens` (line "clamped to the model's `maxTokens`", added by #2835/`fac2444688` — the *same* baseline regression). Adding only `Working` would have left `static-checks` red. Both were added to `proseNames`; `maxTokens` sits with the existing request-field names (`service_tier`, `fastRoute`, `modelId`), `Working` with the UI copy (`write`, `edit`, `tsgo`). This is a narrowing of the allowlist's existing escape hatch, not a weakening of identifier checking.
- **Attribution correction.** `` `Working` `` was introduced by PR #2830 (`07117e44b6`) and *preserved* by PR #2838 (`bfe08c89a1`), which rewrote the same `### Changed` bullet. The objective's framing (#2838 added it) is off by one PR; the fix and its narrowness are unchanged.
- **Branch fixture hoisted.** The message fixture inside the old branch-summary test became a module-level `branchEntries` const so the new clamp test reuses it rather than duplicating twelve lines.
- **Rejected alternatives** (from research, re-confirmed): un-backticking the changelog prose (edits merged release notes from other PRs), and a capitalized-word skip heuristic (would let real `PascalCase` export names through).
- **Deferred:** a third assertion for the `model.maxTokens <= 0 → POSITIVE_INFINITY` branch. Added coverage, not repair; out of contract.

### Iteration 2 — resolving the review finding (fixed-cap assertion was fixture-satisfied)

- **Finding reproduced independently this session, not accepted on inspection.** With commit `2f7ae3efa8` in place, mutating `packages/coding-agent/src/core/compaction/branch-summarization.ts:370` to `const maxTokens = model.maxTokens;` left the unit file at **8 passed (8)**. `testModel()` returns `maxTokens: 4_096`, identical to the runtime constant, so `assert.equal(options.maxTokens, 4096)` was satisfied by the model limit alone. The clamp half of #2835's contract was proven; the fixed-cap half was not.
- **Fix:** the fixed-cap test now passes `testModel({ maxTokens: 8192 })` — a limit *above* the cap, so only `Math.min(4096, …)` can yield 4096 — plus a three-line comment recording why the bare fixture is insufficient. One line of test input changed; no runtime, fixture-helper, docblock, changelog, or CI-guard edit.
- **Mutant killed, and by the right test.** Re-running the same mutant with the fix applied gave **1 failed | 7 passed (8)**, failing exactly on `branch summarization caps output at 4096 tokens and inherits the session reasoning level` with `8192 !== 4096` at line 107 — not collateral breakage elsewhere.
- **Runtime restored byte-identically.** `git checkout HEAD -- branch-summarization.ts` then `diff` against a pre-probe copy printed nothing; `git status --porcelain` afterwards showed only the intended test file plus the untracked `node_modules` symlink. `contextWindow` stays `100_000`, so the input budget is unaffected.
- **Delivered as a follow-up commit, not an amend.** `cbe2644359` on top of `2f7ae3efa8`, pushed as a fast-forward (`2f7ae3efa8..cbe2644359`). Research allowed either; the follow-up avoids a force-push entirely and keeps the already-pushed SHA stable for anyone who fetched it.
- **Deferred (unchanged, still out of contract):** the same fixture coincidence in the already-merged `packages/coding-agent/test/branch-summarization.test.ts` (`copilotModel()` sets `maxTokens: 4096`), which is a different file in a different suite and would require running the package suite; and coverage for the `model.maxTokens <= 0 → POSITIVE_INFINITY` branch.

## Validation (this session)

| Command | Iteration 1 | Iteration 2 |
|---|---|---|
| `npx vitest --run --project unit test/unit/compaction-planner-budget.test.ts` | RED 1 failed / 6 passed (`:101` `true !== false`) → GREEN 8 passed | mutant survives 8/8 → with fix, mutant dies 1 failed / 7 passed (`8192 !== 4096`) → runtime restored, GREEN 8 passed |
| `npx vitest --run --project ci test/ci/fast-model-identity-contracts.test.ts` | RED 1 failed / 4 passed (``names `Working` ``) → GREEN 5 passed | GREEN 5 passed (untouched by this finding) |
| `npx biome check` on both changed test files | "Checked 2 files in 38ms. No fixes applied." | "Checked 2 files in 28ms. No fixes applied." |
| `npx tsc --noEmit` | exit 0 | exit 0 |

Nothing broader was run in either iteration: no `npm run check`, no full suites, no install, no build. The pre-commit `check` hook was skipped with `PREK_SKIP=check`; the cheap builtins and `biome check --write` ran and passed on both commits.

Benign stderr on every vitest run: "the compiled native binding is older than the Rust sources" — a `git checkout` mtime artifact of the symlinked binding, a warning by design (`test/global-setup-natives.ts`).

## Environment

`node_modules` and `packages/natives/native/atomic_natives.darwin-arm64.node` are read-only symlinks into the primary checkout (created during research; the same convention sibling worktrees use). No `npm ci`, no `npm run build`. The `node_modules` symlink is **not** gitignored (`.gitignore:1` is `node_modules/`, directories only), so files were staged explicitly rather than with `git add -A`.

`issues.md` was never needed — nothing unexpected failed.

## QA E2E Video

Not applicable. The change touches only two test/contract files; there is no user-visible UI or web/TUI scenario to record. `playwright-cli` was not invoked because the diff contains no runtime, frontend, or terminal-rendering behavior — the proof of correctness is the red→green transition of the two named test files, strengthened in iteration 2 by a mutate-and-restore probe of the runtime line the test claims to cover.

## Contract amendments received

None. No mid-run user steering, follow-up, or resume message was received during this stage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791084891&installation_model_id=10562&pr_number=2845&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2845&signature=75a01d081a2a6d97c4913ccd01f4dfe24247e0a3cdca1ce20878f7a667f61dd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change bounds npm registry retries, applies repository npm configuration to the packed-artifact fixture, and adds CI contract coverage for the registry and timeout policies. No outstanding issues were identified.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

There are no accepted new findings, severity-bearing validation findings, or outstanding previous findings.

<sub>Reviews (2): Last reviewed commit: ["fix(ci): bound registry and fixture stal..."](https://github.com/bastani-inc/atomic/commit/f2606402fb18d458a87c8c37d6178104be08fc0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60270768)</sub>

<!-- /greptile_comment -->