### PR TITLE
fix(ai): align Astra metadata and caching with upstream

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -33,6 +33,7 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 - **Breaking:** `githubCopilotProvider().filterModels` no longer strips every model ID ending in `-fast` from the selectable list. It now exposes a model carrying `fastRoute` only when the OAuth credential's `fastModelIds` advertises that exact ID, and treats a Copilot-owned model that merely ends in `-fast` as an ordinary picker model gated by `availableModelIds`.
 - Qwen3.8 Max and Qwen3.8 Flash no longer offer the `off` thinking level on the `qwen-token-plan`, `qwen-token-plan-cn`, and `qwen-token-plan-individual` providers. Their selectable effort levels now follow models.dev metadata: `low`, `medium`, and `xhigh`.
 - `reduceAssistantMessageFrames` now rebuilds an ended text, thinking, or tool-call block as a value the reducer owns, assembled from the end frame and the rest of the replayed block's own data, instead of deleting optional fields on a value read out of externally supplied frame content. Reduced output is unchanged for every input, including field order and any property the frame carried that the declared block types do not name.
+- OpenAI Responses models that accept `prompt_cache_options`, including GPT-6 Astra, now send `ttl: "30m"` for long prompt-cache retention instead of combining that API with the legacy `prompt_cache_retention: "24h"` field. Earlier Responses models keep the 24-hour field, explicit no-cache mode remains limited to capable models, and short retention omits both controls.
 
 ### Fixed
 

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -1063,8 +1063,22 @@ function applyThinkingLevelMetadata(model: Model<any>): void {
 	) {
 		mergeThinkingLevelMap(model, { off: null });
 	}
-	if (isOpenAiGpt6AstraModelId(model.id)) {
-		mergeThinkingLevelMap(model, { off: null, minimal: null });
+	if (
+		(model.id === "gpt-6-astra" &&
+			(model.api === "openai-responses" ||
+				model.api === "azure-openai-responses" ||
+				model.api === "openai-codex-responses")) ||
+		(model.api === "bedrock-converse-stream" && isOpenAiGpt6AstraModelId(model.id))
+	) {
+		mergeThinkingLevelMap(model, {
+			off: null,
+			minimal: null,
+			low: "low",
+			medium: "medium",
+			high: "high",
+			xhigh: "xhigh",
+			max: "max",
+		});
 	}
 	if (model.provider === "github-copilot" && model.id.startsWith("gpt-5")) {
 		mergeThinkingLevelMap(model, { minimal: "low" });

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -94,7 +94,19 @@ function getPromptCacheRetention(
 	compat: Required<OpenAIResponsesCompat>,
 	cacheRetention: CacheRetention,
 ): "24h" | undefined {
-	return cacheRetention === "long" && compat.supportsLongCacheRetention ? "24h" : undefined;
+	return cacheRetention === "long" && compat.supportsLongCacheRetention && !compat.supportsExplicitPromptCacheMode
+		? "24h"
+		: undefined;
+}
+
+function getPromptCacheOptions(
+	compat: Required<OpenAIResponsesCompat>,
+	cacheRetention: CacheRetention,
+): { mode?: "explicit"; ttl?: "30m" } | undefined {
+	if (!compat.supportsExplicitPromptCacheMode) return undefined;
+	if (cacheRetention === "none") return { mode: "explicit" };
+	if (cacheRetention === "long" && compat.supportsLongCacheRetention) return { ttl: "30m" };
+	return undefined;
 }
 
 function formatOpenAIResponsesError(error: unknown): string {
@@ -322,8 +334,9 @@ function buildParams(
 	});
 
 	const cacheRetention = resolveCacheRetention(options?.cacheRetention, options?.env);
-	const disableImplicitPromptCache = cacheRetention === "none" && compat.supportsExplicitPromptCacheMode;
-	const params: ResponseCreateParamsStreaming & { prompt_cache_options?: { mode: "explicit" } } = {
+	const params: ResponseCreateParamsStreaming & {
+		prompt_cache_options?: { mode?: "explicit"; ttl?: "30m" };
+	} = {
 		// A fast variant keeps its canonical `-fast` id on the model object — that is the identity the
 		// caller selected and records — while routing to the base upstream model plus a service tier.
 		model: model.fastRoute?.upstreamModelId ?? model.id,
@@ -331,7 +344,7 @@ function buildParams(
 		stream: true,
 		prompt_cache_key: cacheRetention === "none" ? undefined : clampOpenAIPromptCacheKey(options?.sessionId),
 		prompt_cache_retention: getPromptCacheRetention(compat, cacheRetention),
-		prompt_cache_options: disableImplicitPromptCache ? { mode: "explicit" } : undefined,
+		prompt_cache_options: getPromptCacheOptions(compat, cacheRetention),
 		store: false,
 	};
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -726,7 +726,7 @@ export interface OpenAIResponsesCompat {
 	supportsDeveloperRole?: boolean;
 	/** Session-affinity header format: `openai` sends `session_id` and `x-client-request-id`; `openai-nosession` sends `x-client-request-id`; `openrouter` sends `x-session-id`. Does not affect the `prompt_cache_key` body param, which is governed by cache retention. Default: auto-detected. */
 	sessionAffinityFormat?: SessionAffinityFormat;
-	/** Whether the provider supports `prompt_cache_retention: "24h"`. Default: true. */
+	/** Whether the provider supports long prompt cache retention. This uses `prompt_cache_options.ttl: "30m"` on GPT-5.6+ and `prompt_cache_retention: "24h"` on earlier models. Default: true. */
 	supportsLongCacheRetention?: boolean;
 	/** Whether the provider supports strict JSON-schema function tools. Defaults are API-specific; generated OpenAI models enable it explicitly. */
 	supportsStrictMode?: boolean;
@@ -736,7 +736,7 @@ export interface OpenAIResponsesCompat {
 	supportsAdditionalTools?: boolean;
 	/** Whether the model supports client-executed tool search for deferred tools. Default: false. */
 	supportsToolSearch?: boolean;
-	/** Whether the model accepts `prompt_cache_options` (OpenAI GPT-5.6+ explicit prompt caching). Older OpenAI models reject the parameter. Default: false. */
+	/** Whether the model accepts `prompt_cache_options` (OpenAI GPT-5.6+ prompt caching). Older OpenAI models reject the parameter. Default: false. */
 	supportsExplicitPromptCacheMode?: boolean;
 	/** Whether the provider accepts the `max_output_tokens` parameter. Some Codex-protocol gateways reject it. Default: true. */
 	supportsMaxOutputTokens?: boolean;

--- a/packages/ai/test/cache-retention.test.ts
+++ b/packages/ai/test/cache-retention.test.ts
@@ -4,7 +4,7 @@ import { stream as streamOpenAICompletions } from "../src/api/openai-completions
 import { stream as streamOpenAIResponses } from "../src/api/openai-responses.ts";
 import { getModel, stream } from "../src/compat.ts";
 import { MODELS } from "../src/models.generated.ts";
-import type { Context, Model } from "../src/types.ts";
+import type { CacheRetention, Context, Model, OpenAIResponsesCompat } from "../src/types.ts";
 
 class PayloadCaptured extends Error {
 	constructor() {
@@ -19,7 +19,7 @@ interface OpenAICompletionsCachePayload {
 }
 
 interface OpenAIResponsesCachePayload extends OpenAICompletionsCachePayload {
-	prompt_cache_options?: { mode: "explicit" };
+	prompt_cache_options?: { mode?: "explicit"; ttl?: "30m" };
 }
 
 function stopAfterPayload<TPayload>(capture: (payload: TPayload) => void): (payload: unknown) => never {
@@ -317,112 +317,69 @@ describe("Cache Retention (PI_CACHE_RETENTION)", () => {
 			expect(capturedPayload.prompt_cache_retention).toBe("24h");
 		});
 
-		it("should omit prompt_cache_retention when supportsLongCacheRetention is false", async () => {
-			const model = {
-				...getModel("openai", "gpt-4o-mini"),
-				compat: { supportsLongCacheRetention: false },
-			};
-			let capturedPayload: any = null;
-
-			try {
-				const s = streamOpenAIResponses(model, context, {
-					apiKey: "fake-key",
-					cacheRetention: "long",
-					sessionId: "session-compat-false",
-					onPayload: stopAfterPayload((payload) => {
-						capturedPayload = payload;
-					}),
-				});
-
-				for await (const event of s) {
-					if (event.type === "error") break;
-				}
-			} catch {
-				// Expected to fail
-			}
-
-			expect(capturedPayload).not.toBeNull();
-			expect(capturedPayload.prompt_cache_retention).toBeUndefined();
-		});
-
-		it("should omit prompt_cache_key and disable implicit writes when cacheRetention is none", async () => {
-			const model = getModel("openai", "gpt-5.6-sol");
+		async function captureResponsesCachePayload(
+			model: Model<"openai-responses">,
+			cacheRetention: CacheRetention,
+			compat?: OpenAIResponsesCompat,
+		): Promise<OpenAIResponsesCachePayload> {
 			let capturedPayload: OpenAIResponsesCachePayload | undefined;
+			const configuredModel = compat ? { ...model, compat: { ...model.compat, ...compat } } : model;
 
 			try {
-				const s = streamOpenAIResponses(model, context, {
+				const response = streamOpenAIResponses(configuredModel, context, {
 					apiKey: "fake-key",
-					cacheRetention: "none",
-					sessionId: "session-1",
+					cacheRetention,
+					sessionId: "session-cache-test",
 					onPayload: stopAfterPayload<OpenAIResponsesCachePayload>((payload) => {
 						capturedPayload = payload;
 					}),
 				});
 
-				for await (const event of s) {
+				for await (const event of response) {
 					if (event.type === "error") break;
 				}
 			} catch {
-				// Expected to fail
+				// Expected after the payload hook stops the request.
 			}
 
-			expect(capturedPayload).toBeDefined();
-			expect(capturedPayload?.prompt_cache_key).toBeUndefined();
-			expect(capturedPayload?.prompt_cache_retention).toBeUndefined();
-			expect(capturedPayload?.prompt_cache_options).toEqual({ mode: "explicit" });
-		});
+			if (!capturedPayload) throw new Error("OpenAI Responses payload was not captured");
+			return capturedPayload;
+		}
 
-		it("should omit prompt_cache_options for models that reject it", async () => {
-			const model = getModel("openai", "gpt-4o-mini");
-			let capturedPayload: OpenAIResponsesCachePayload | undefined;
+		it.each([
+			["gpt-4o-mini", "none", undefined, undefined, undefined],
+			["gpt-4o-mini", "short", "session-cache-test", undefined, undefined],
+			["gpt-4o-mini", "long", "session-cache-test", "24h", undefined],
+			["gpt-5.6-sol", "none", undefined, undefined, { mode: "explicit" }],
+			["gpt-6-astra", "none", undefined, undefined, { mode: "explicit" }],
+			["gpt-6-astra", "short", "session-cache-test", undefined, undefined],
+			["gpt-6-astra", "long", "session-cache-test", undefined, { ttl: "30m" }],
+		] as const)(
+			"uses the supported cache payload for %s with %s retention",
+			async (modelId, cacheRetention, cacheKey, retention, cacheOptions) => {
+				const payload = await captureResponsesCachePayload(getModel("openai", modelId), cacheRetention);
 
-			try {
-				const s = streamOpenAIResponses(model, context, {
-					apiKey: "fake-key",
-					cacheRetention: "none",
-					sessionId: "session-1",
-					onPayload: stopAfterPayload<OpenAIResponsesCachePayload>((payload) => {
-						capturedPayload = payload;
-					}),
-				});
+				expect(payload.prompt_cache_key).toBe(cacheKey);
+				expect(payload.prompt_cache_retention).toBe(retention);
+				expect(payload.prompt_cache_options).toEqual(cacheOptions);
+			},
+		);
 
-				for await (const event of s) {
-					if (event.type === "error") break;
-				}
-			} catch {
-				// Expected to fail
-			}
+		it.each([
+			["gpt-4o-mini", { supportsLongCacheRetention: false }, undefined, undefined],
+			["gpt-4o-mini", { supportsExplicitPromptCacheMode: true }, undefined, { ttl: "30m" }],
+			["gpt-6-astra", { supportsExplicitPromptCacheMode: false }, "24h", undefined],
+			["gpt-6-astra", { supportsLongCacheRetention: false }, undefined, undefined],
+		] as const)(
+			"honors cache capability overrides for %s with %j",
+			async (modelId, compat, retention, cacheOptions) => {
+				const payload = await captureResponsesCachePayload(getModel("openai", modelId), "long", compat);
 
-			expect(capturedPayload).toBeDefined();
-			expect(capturedPayload?.prompt_cache_key).toBeUndefined();
-			expect(capturedPayload?.prompt_cache_options).toBeUndefined();
-		});
-
-		it("should set prompt_cache_retention when cacheRetention is long", async () => {
-			const model = getModel("openai", "gpt-4o-mini");
-			let capturedPayload: any = null;
-
-			try {
-				const s = streamOpenAIResponses(model, context, {
-					apiKey: "fake-key",
-					cacheRetention: "long",
-					sessionId: "session-2",
-					onPayload: stopAfterPayload((payload) => {
-						capturedPayload = payload;
-					}),
-				});
-
-				for await (const event of s) {
-					if (event.type === "error") break;
-				}
-			} catch {
-				// Expected to fail
-			}
-
-			expect(capturedPayload).not.toBeNull();
-			expect(capturedPayload.prompt_cache_key).toBe("session-2");
-			expect(capturedPayload.prompt_cache_retention).toBe("24h");
-		});
+				expect(payload.prompt_cache_key).toBe("session-cache-test");
+				expect(payload.prompt_cache_retention).toBe(retention);
+				expect(payload.prompt_cache_options).toEqual(cacheOptions);
+			},
+		);
 	});
 
 	describe("OpenAI Completions Provider", () => {

--- a/packages/ai/test/generate-models-gpt-6-astra.test.ts
+++ b/packages/ai/test/generate-models-gpt-6-astra.test.ts
@@ -106,7 +106,15 @@ function assertAstraCapabilities(model: GeneratedModel, provider: string): void 
 	assert.deepEqual(model.input, ["text", "image"]);
 	assert.equal(model.contextWindow, 272_000);
 	assert.equal(model.maxTokens, 128_000);
-	assert.deepEqual(model.thinkingLevelMap, { off: null, minimal: null, xhigh: "xhigh", max: "max" });
+	assert.deepEqual(model.thinkingLevelMap, {
+		off: null,
+		minimal: null,
+		low: "low",
+		medium: "medium",
+		high: "high",
+		xhigh: "xhigh",
+		max: "max",
+	});
 	assert.deepEqual(getSupportedThinkingLevels(model as unknown as Model<Api>), [
 		"low",
 		"medium",
@@ -124,7 +132,7 @@ afterEach(() => {
 	for (const root of temporaryRoots.splice(0)) rmSync(root, { force: true, recursive: true });
 });
 
-test("generates authoritative OpenAI and Codex GPT-6-Astra metadata without internal policy fields", () => {
+test("falls back to authoritative OpenAI and Codex GPT-6-Astra metadata without internal policy fields", () => {
 	const catalogs = generate();
 	const openai = catalogs.openai["gpt-6-astra"];
 	const codex = catalogs["openai-codex"]["gpt-6-astra"];
@@ -153,6 +161,38 @@ test("generates authoritative OpenAI and Codex GPT-6-Astra metadata without inte
 		assert.equal("persistent_instructions" in model, false);
 		assert.equal("tools" in model, false);
 	}
+	assert.equal(openai.compat?.supportsExplicitPromptCacheMode, true);
+});
+
+test("prefers a models.dev OpenAI Astra row over the missing-model fallback", () => {
+	const openai = generate([], [], {
+		openai: {
+			models: {
+				"gpt-6-astra": {
+					name: "models.dev Astra fixture",
+					tool_call: true,
+					reasoning: true,
+					reasoning_options: [{ type: "effort", values: ["none", "low", "medium", "high", "xhigh", "max"] }],
+					modalities: { input: ["text", "image"], output: ["text"] },
+					limit: { context: 1_050_000, output: 128_000 },
+					cost: { input: 10, output: 50, cache_read: 1, cache_write: 12.5 },
+				},
+			},
+		},
+	}).openai["gpt-6-astra"];
+
+	assert.ok(openai);
+	assert.equal(openai.name, "models.dev Astra fixture");
+	assertAstraCapabilities(openai, "openai");
+	assert.deepEqual(openai.cost, {
+		input: 10,
+		output: 50,
+		cacheRead: 1,
+		cacheWrite: 12.5,
+		tiers: [{ inputTokensAbove: 272_000, input: 20, output: 75, cacheRead: 2, cacheWrite: 25 }],
+	});
+	assert.equal(openai.compat?.supportsAdditionalTools, true);
+	assert.equal(openai.compat?.supportsToolSearch, true);
 	assert.equal(openai.compat?.supportsExplicitPromptCacheMode, true);
 });
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -44,6 +44,7 @@
 - `ModelRuntime.getProvider()` now returns the same published provider as `getProviders()`, so every catalog accessor agrees about derived `-fast` models. It is the registered provider behind a `{ ...provider, getModels }` overlay, so `auth`, `login`, `stream`, and `streamSimple` remain the same function references; use `getRegisteredNativeProvider()` when you need the exact registered object.
 - The chat footer, startup banner, workflow stage labels, and subagent result labels no longer append a separate `fast` marker. The selected model ID carries the `-fast` suffix itself, so a subagent renders as `codebase-analyzer (openai-codex/gpt-5.6-sol-fast · thinking medium)`.
 - The `edit` tool's model-facing hashline guidance now includes compact worked examples and anti-patterns for commonly rejected patch shapes, and correctly identifies native Rust tree-sitter block resolution as primary with the brace/indent heuristic as its fallback. The hashline reference documentation is now a specification covering inputs, verified tolerated shapes, outputs, worked examples, limits, literal error messages, and warnings.
+- OpenAI Responses models that advertise explicit prompt-cache support, including GPT-5.6 and GPT-6 Astra, now use `prompt_cache_options.ttl: "30m"` for long cache retention. Earlier Responses models retain `prompt_cache_retention: "24h"`; no-cache and short-cache requests continue to omit unsupported fields.
 
 ### Fixed
 

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -240,6 +240,8 @@ Amazon Bedrock exposes `openai.gpt-6-astra`, `global.openai.gpt-6-astra`, and `u
 
 Atomic does not synthesize Azure OpenAI Astra entries. Live-provider catalogs remain authoritative: the current OpenRouter catalog publishes `openai/gpt-6-astra` and `openai/gpt-6-astra-pro`, while the Vercel AI Gateway publishes `openai/gpt-6-astra` and `openai/gpt-6-astra-fast`. Atomic imports those exact IDs and their request-wide long-context prices. Vercel owns its suffixed ID, so it remains route-less and does not gain Atomic's first-party fast-route behavior.
 
+On OpenAI Responses, Astra uses the newer prompt-cache payload. `cacheRetention: "long"` sends `prompt_cache_options.ttl: "30m"` instead of the legacy `prompt_cache_retention: "24h"`; `none` sends explicit mode without a cache key, and `short` sends neither cache option. Earlier Responses models keep the 24-hour field for long retention.
+
 ### Sampling Parameters
 
 `samplingParams` is a free-form object merged into every request body for an OpenAI-compatible model after the fields Atomic sets, so its keys win. Use it to send parameters that Atomic does not model, including server-specific values such as llama.cpp's `min_p` or vLLM's `top_k`:
@@ -613,7 +615,7 @@ For providers with partial OpenAI compatibility, use the `compat` field.
 | `supportsStrictTools`                         | Anthropic/Bedrock strict-tool capability, normally generated from verified model metadata. |
 | `supportsOpenAIGrammarTools`                  | Canonical Pi capability for OpenAI Lark/regex custom tools. Keep false unless the endpoint passes custom tools through unchanged. |
 | `supportsGrammarTools`                        | Atomic compatibility alias for `supportsOpenAIGrammarTools`; the canonical field wins if both disagree. |
-| `supportsLongCacheRetention`                  | Whether the provider accepts long cache retention when cache retention is `long`: `prompt_cache_retention: "24h"` for OpenAI prompt caching, or `cache_control.ttl: "1h"` when `cacheControlFormat` is `anthropic`. Default: `true`. |
+| `supportsLongCacheRetention`                  | Whether the provider accepts long cache retention when cache retention is `long`: `prompt_cache_options.ttl: "30m"` for GPT-5.6+ Responses models, `prompt_cache_retention: "24h"` for earlier OpenAI models, or `cache_control.ttl: "1h"` when `cacheControlFormat` is `anthropic`. Default: `true`. |
 | `vllmPriority`                                | vLLM scheduler priority sent as the top-level `priority` request field. Lower values are handled earlier and the server default is `0`, so it only takes effect when vLLM runs with `--scheduling-policy priority`. Off by default; not set on the generated catalog. |
 | `openRouterRouting`                           | OpenRouter provider routing preferences. This object is sent as-is in the `provider` field of the [OpenRouter API request](https://openrouter.ai/docs/guides/routing/provider-selection).                                            |
 | `vercelGatewayRouting`                        | Vercel AI Gateway routing config for provider selection (`only`, `order`)                                                                                                                                                            |


### PR DESCRIPTION
## Summary

Align GPT-6 Astra reasoning metadata and OpenAI Responses prompt caching with [earendil-works/pi@17de82d](https://github.com/earendil-works/pi/commit/17de82d7bea18a6589677a9761baabc2060c9efb). This is a separate follow-up to the already-merged model-defaults PR #2860.

## Changes

- Match upstream's complete Astra reasoning map, disabling `off` and `minimal` and mapping `low` through `max` explicitly. Retain Atomic's existing Bedrock support and fast-model routing.
- Use `prompt_cache_options.ttl: "30m"` for long retention on capable Responses models. Keep the legacy 24-hour field on older models and preserve explicit no-cache behavior.
- Cover models.dev row precedence over missing-model fallbacks, cache retention variants, and capability overrides with deterministic tests.
- Update API comments, model documentation, and Unreleased notes.

## Validation

- Refreshed models.dev through the repository generator and checked a fresh no-cache API snapshot.
- `npm run check` passed, including commit hooks.
- Full AI suite: 1,313 passed, 841 existing skips.
- Coding-agent fast identity/variant tests: 41 passed.
- Generated Astra assertions passed for context/output limits, complete reasoning maps, and tool capabilities.
- `git diff --check` passed. Commit is SSH-signed.
- Independent review approved the final patch.

## Notes

The refreshed snapshot includes Astra metadata for OpenRouter and Vercel but still lacks direct OpenAI, Codex, and Copilot rows. Existing narrow fallbacks remain; the new fixture verifies that a published OpenAI row takes precedence. Generated model data is refreshed through the normal generator and is not tracked.

The separate AI test typecheck retains its existing credential-fixture error at `packages/ai/test/github-copilot-oauth.test.ts:248`. The AI source build typecheck and repository check pass. No live paid inference was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791154840&installation_model_id=10562&pr_number=2861&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2861&signature=ba72700c8ce31ddc3599e184bcc2033530e9bb9d28e59c20a13603c3e0476f8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns GPT-6 Astra metadata and OpenAI Responses cache-retention payloads with supported model compatibility settings.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

The scoped cache-retention behavior was exercised with a custom Responses model and matched the repository compatibility contract; no actionable findings remain.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Exercised a programmatic OpenAI Responses model configured with supportsExplicitPromptCacheMode: true and long cache retention against a local Responses endpoint.
- Verified that the request includes prompt\_cache\_options: { "ttl": "30m" } and that the legacy retention field is omitted.
- Validated that setting supportsLongCacheRetention: false suppresses the long-retention TTL request.
- Ran the focused cache-retention coverage: 27 tests passed and 2 credential-dependent tests were skipped.

<a href="https://app.greptile.com/trex/runs/22623237/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ai): align Astra metadata and cachin..."](https://github.com/bastani-inc/atomic/commit/40250391e3d2ad7d32c2d9ca318104c409173bbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60620715)</sub>

**Context used:**

- Knowledge Base — [AI integration layer](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/ai-integration.md)
- Knowledge Base — [AI providers, authentication, and models](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/ai-providers-auth-and-models.md)

<!-- /greptile_comment -->