### PR TITLE
docs(changelog): prepare 0.9.18-alpha.6 release notes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
+## [0.9.18-alpha.6] - 2026-09-04
+
 ### Breaking Changes
 
 - **Breaking:** `createGatewayBindingFetch` now requires `binding.fetch()` and always forwards requests verbatim. The `gateway(id).run(...)` universal-endpoint fallback is removed. `baseUrl` and `gateway` options are ignored. Bindings without `fetch()` throw at construction. Point each model's `baseUrl` at `https://workers-binding.ai/ai-gateway/gateways/{gateway}/{provider}`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.18-alpha.6] - 2026-09-04
+
 ### Breaking Changes
 
 - Replaced the `/fast` toggle with explicit selectable fast model identity. `/fast`, its selector UI, the `codexFastMode.chat`/`codexFastMode.workflow` settings, the `ATOMIC_CODEX_FAST_MODE` environment variable, chat-versus-workflow scope inheritance, and every public export tied to that toggle state are removed with no compatibility shim or migration. Select fast inference by choosing a fast model.

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.18-alpha.6] - 2026-09-04
+
 ### Breaking Changes
 
 - Workflow-stage targets now accept only root-anchored `workflow:<rootRunId>/<segment>[/<segment>...]` paths. The legacy `<runId>:<stageKey>` form is refused with a canonical-path migration hint.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.18-alpha.6] - 2026-09-04
+
 ### Breaking Changes
 
 - Removed the redundant `fastMode` fields from subagent result, progress, runtime metadata, persisted artifact metadata, and run-history records. Agents now select fast inference by pinning a canonical `-fast` model ID in `model` or fallback model fields, for example `openai-codex/gpt-5.6-sol-fast:medium`.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.18-alpha.6] - 2026-09-04
+
 ### Breaking Changes
 
 - Workflow-stage Intercom targets now accept only root-anchored `workflow:<rootRunId>/<segment>[/<segment>...]` paths. The legacy `<runId>:<stageKey>` form is refused with a canonical-path migration hint.


### PR DESCRIPTION
## Summary

Prepare the AI, coding-agent, Intercom, subagents, and workflows release notes for `0.9.18-alpha.6`. Promote the accumulated `Unreleased` entries into release sections dated 2026-09-04 without changing their contents or any previously released section.

## Changes

- Record explicit fast-model identities and routing, removal of the `/fast` toggle, Pi 0.85 compatibility, provider recovery, and Cloudflare binding transport changes.
- Record GPT-6 Astra, Gemini 3.8 Flash, Copilot Claude Fable, and Baseten GLM catalog updates, prompt-cache handling, and bundled agent/workflow model defaults.
- Record canonical workflow-stage Intercom paths, sticky broadcasts, reconnect and retry identity fixes, protected delivery records, and stage-owned subagent cancellation.
- Record embedded PostgreSQL platform support, structured-output fallback, terminal delivery failure handling, and transcript/tool fixes.

## Scope

Exactly five changelogs change, with ten added lines and no deletions. All eight package manifests, direct lockfile workspace entries, first-party version pins, Cargo metadata, and generated native version checks remain at `0.0.0`. The target version appears only in the five prepared changelogs.

`main` stays versionless. After this PR merges, only `scripts/cut-release.ts` may stamp the real version on the detached Release commit. Pushing that version tag starts `publish.yml`; this stage does not merge, tag, publish, dispatch, or rerun publication.

## Validation

- `bun run vitest --run --project unit test/unit/build-release-notes.test.ts test/unit/changelog.test.ts test/unit/package-metadata.test.ts test/unit/bump-version-script.test.ts`: all 35 tests passed across four files.
- `bun run scripts/build-release-notes.ts 0.9.18-alpha.6`: merged release notes generated successfully.
- Bun-based checks verified versionless invariants, exact changelog-only paths, heading-only promotion, unchanged historical content, and target-version scope.
- `git diff --check` and enabled pre-commit hooks passed, including the repository's `npm run check` hook.
- Post-commit checks confirmed one changelog-only commit, all eight manifests at `0.0.0`, and a clean worktree. Branch pushed without force.

Assistant-model: GPT-6-Astra

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791155525&installation_model_id=10562&pr_number=2862&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2862&signature=ca31fa9c0133f5daab0ee1358a2d9f74c2cdcb613279df7f2055f7aa01374eca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary

Promotes the accumulated Unreleased notes into dated `0.9.18-alpha.6` sections across the five package changelogs while retaining empty Unreleased sections for future changes.

The release-note generator successfully recognizes each new section and includes all documented entries.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking or non-blocking issues were found.

The scoring set is empty.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The release-note generator behavior was compared before and after the changelog-heading change.
- The previous revision rejected 0.9.18-alpha.6 because no package documented that version.
- The current revision generated release notes successfully and found exactly one 0.9.18-alpha.6 heading in each of coding-agent, ai, intercom, subagents, and workflows.
- The generated notes contained all 123 expected entry bullets across the Breaking Changes, Added, Changed, and Fixed sections.

<a href="https://app.greptile.com/trex/runs/22625063/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): prepare 0.9.18-alpha.6 ..."](https://github.com/bastani-inc/atomic/commit/d33a50d43155ea5591ef8f7318dc1452337f19b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60623918)</sub>

<!-- /greptile_comment -->