### PR TITLE
test(intercom): await broker closure before fixture cleanup

### DIFF
--- a/test/helpers/intercom-broker-fixture.ts
+++ b/test/helpers/intercom-broker-fixture.ts
@@ -1,0 +1,101 @@
+import type { ChildProcess } from "node:child_process";
+import { rmSync } from "node:fs";
+
+const BROKER_TERMINATE_GRACE_MS = 1_000;
+const BROKER_CLEANUP_TIMEOUT_MS = 5_000;
+
+async function bounded<T>(operation: Promise<T>, message: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			operation,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error(message)), BROKER_CLEANUP_TIMEOUT_MS);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/** Lifecycle ownership for the raw-child broker suites (including inherited log fds). */
+export class IntercomBrokerFixture {
+	private broker: ChildProcess | undefined;
+	private closed: Promise<void> = Promise.resolve();
+	private hasClosed = false;
+	private processError: Error | undefined;
+	private readonly cleanups: Array<() => void | Promise<void>> = [];
+	private restoreEnvironment: (() => void) | undefined;
+
+	constructor(readonly agentDir: string) {}
+
+	overrideAgentDir(): void {
+		const original = process.env.ATOMIC_CODING_AGENT_DIR;
+		process.env.ATOMIC_CODING_AGENT_DIR = this.agentDir;
+		this.restoreEnvironment = () => {
+			if (original === undefined) delete process.env.ATOMIC_CODING_AGENT_DIR;
+			else process.env.ATOMIC_CODING_AGENT_DIR = original;
+		};
+	}
+
+	onCleanup(cleanup: () => void | Promise<void>): void {
+		this.cleanups.push(cleanup);
+	}
+
+	trackBroker(broker: ChildProcess): void {
+		this.broker = broker;
+		// Attach at spawn, not teardown: close/error may precede readiness or afterAll.
+		broker.on("error", (error: Error) => {
+			this.processError = error;
+		});
+		this.closed = new Promise<void>((resolveClosed) => {
+			broker.once("close", () => {
+				this.hasClosed = true;
+				resolveClosed();
+			});
+		});
+	}
+
+	assertRunning(): void {
+		if (this.processError) throw this.processError;
+		if (this.hasClosed || (this.broker && (this.broker.exitCode !== null || this.broker.signalCode !== null))) {
+			throw new Error(
+				`Broker exited during startup: code ${this.broker?.exitCode}, signal ${this.broker?.signalCode}`,
+			);
+		}
+	}
+
+	private async stopBroker(): Promise<void> {
+		const broker = this.broker;
+		if (!broker || this.hasClosed) return;
+		const signal = (name: NodeJS.Signals) => {
+			// A failed spawn has no pid; still await its close, but never signal it.
+			if (broker.pid !== undefined && broker.exitCode === null && broker.signalCode === null) broker.kill(name);
+		};
+		const force = setTimeout(() => signal("SIGKILL"), BROKER_TERMINATE_GRACE_MS);
+		try {
+			signal("SIGTERM");
+			// Unlike exit or kill success, close also proves inherited stdio was released.
+			await bounded(this.closed, "Broker did not close before cleanup deadline; keeping its files");
+		} finally {
+			clearTimeout(force);
+		}
+	}
+
+	async cleanup(): Promise<void> {
+		try {
+			try {
+				await bounded(
+					Promise.all(this.cleanups.splice(0).map(async (cleanup) => cleanup())),
+					"Broker clients did not close before cleanup deadline",
+				);
+			} finally {
+				await this.stopBroker();
+			}
+			rmSync(this.agentDir, { recursive: true, force: true });
+		} finally {
+			this.restoreEnvironment?.();
+			this.restoreEnvironment = undefined;
+		}
+	}
+}

--- a/test/unit/intercom-broker-fixture.test.ts
+++ b/test/unit/intercom-broker-fixture.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { ChildProcess, spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, test, vi } from "vitest";
+import { IntercomBrokerFixture } from "../helpers/intercom-broker-fixture.js";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+function resources() {
+	const agentDir = mkdtempSync(join(tmpdir(), "intercom-fixture-"));
+	mkdirSync(join(agentDir, "intercom"));
+	const files = ["delivered-messages.sqlite", "broker.log"].map((name) => join(agentDir, "intercom", name));
+	for (const file of files) writeFileSync(file, "owned by broker");
+	const fixture = new IntercomBrokerFixture(agentDir);
+	// Control the OS event boundary, not the fixture: signal, exit and stdio close
+	// are deliberately separate. This ordering oracle also runs on non-Windows hosts.
+	const child = new ChildProcess();
+	Object.assign(child, { pid: 12345 });
+	const kill = vi.spyOn(child, "kill").mockReturnValue(true);
+	fixture.trackBroker(child);
+	return { agentDir, files, fixture, child, kill };
+}
+
+test("cleanup keeps SQLite and logs until close, not merely a signal or exit", async () => {
+	const { agentDir, files, fixture, child, kill } = resources();
+	const cleanup = fixture.cleanup();
+	try {
+		await vi.advanceTimersByTimeAsync(0);
+		assert.deepEqual(kill.mock.calls, [["SIGTERM"]]);
+		for (const file of files) assert.equal(existsSync(file), true, `${file} removed before child close`);
+		Object.assign(child, { exitCode: 0 });
+		child.emit("exit", 0, null);
+		await vi.advanceTimersByTimeAsync(0);
+		for (const file of files) assert.equal(existsSync(file), true, `${file} removed at exit before stdio close`);
+		child.emit("close", 0, null);
+		await cleanup;
+		assert.equal(existsSync(agentDir), false);
+	} finally {
+		child.emit("close", 0, null);
+		await cleanup;
+		rmSync(agentDir, { recursive: true, force: true });
+	}
+});
+
+test.each([null, "SIGTERM"] as const)("cleanup remembers a child already closed with signal %s", async (signal) => {
+	const { agentDir, fixture, child, kill } = resources();
+	try {
+		Object.assign(child, { exitCode: signal ? null : 0, signalCode: signal });
+		child.emit("exit", child.exitCode, signal);
+		child.emit("close", child.exitCode, signal);
+		await fixture.cleanup();
+		assert.equal(kill.mock.calls.length, 0, "do not signal an already-closed child");
+		assert.equal(existsSync(agentDir), false);
+	} finally {
+		rmSync(agentDir, { recursive: true, force: true });
+	}
+});
+
+test("cleanup escalates but rejects within its local bound without deleting live-owned files", async () => {
+	const { agentDir, files, fixture, child, kill } = resources();
+	let failure: Error | undefined;
+	const cleanup = fixture.cleanup().catch((error: Error) => {
+		failure = error;
+	});
+	try {
+		await vi.runAllTimersAsync();
+		assert.ok(failure instanceof Error, "cleanup must reject when close never arrives");
+		assert.match(failure.message, /Broker did not close/);
+		assert.deepEqual(kill.mock.calls, [["SIGTERM"], ["SIGKILL"]]);
+		for (const file of files) assert.equal(existsSync(file), true);
+		assert.equal(vi.getTimerCount(), 0);
+	} finally {
+		child.emit("close", 0, null);
+		await cleanup;
+		rmSync(agentDir, { recursive: true, force: true });
+	}
+});
+
+test("startup errors are observed immediately but cleanup still waits for close", async () => {
+	const { agentDir, files, fixture, child } = resources();
+	try {
+		const failure = Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" });
+		assert.doesNotThrow(() => child.emit("error", failure));
+		assert.throws(() => fixture.assertRunning(), failure);
+		const cleanup = fixture.cleanup();
+		await vi.advanceTimersByTimeAsync(0);
+		for (const file of files) assert.equal(existsSync(file), true, "error is not close");
+		child.emit("close", -2, null);
+		await cleanup;
+		assert.equal(existsSync(agentDir), false);
+	} finally {
+		child.emit("close", -2, null);
+		await fixture.cleanup();
+	}
+});
+
+test.each([undefined, "", " /original agent directory/ "])(
+	"cleanup restores agent-dir value %j and destroys owned sockets even on a close timeout",
+	async (original) => {
+		const saved = process.env.ATOMIC_CODING_AGENT_DIR;
+		const { agentDir, fixture, child } = resources();
+		const socket = new net.Socket();
+		try {
+			if (original === undefined) delete process.env.ATOMIC_CODING_AGENT_DIR;
+			else process.env.ATOMIC_CODING_AGENT_DIR = original;
+			fixture.overrideAgentDir();
+			assert.equal(process.env.ATOMIC_CODING_AGENT_DIR, agentDir);
+			fixture.onCleanup(() => {
+				socket.destroy();
+			});
+			await Promise.all([assert.rejects(fixture.cleanup(), /Broker did not close/), vi.runAllTimersAsync()]);
+			assert.equal(socket.destroyed, true);
+			assert.equal(process.env.ATOMIC_CODING_AGENT_DIR, original);
+		} finally {
+			child.emit("close", 0, null);
+			await fixture.cleanup();
+			socket.destroy();
+			if (saved === undefined) delete process.env.ATOMIC_CODING_AGENT_DIR;
+			else process.env.ATOMIC_CODING_AGENT_DIR = saved;
+		}
+	},
+);
+
+test("cleanup also waits for stdio close when exit happened before teardown", async () => {
+	const { agentDir, files, fixture, child, kill } = resources();
+	Object.assign(child, { exitCode: 1 });
+	child.emit("exit", 1, null);
+	assert.throws(() => fixture.assertRunning(), /Broker exited during startup: code 1/);
+	const cleanup = fixture.cleanup();
+	try {
+		await vi.advanceTimersByTimeAsync(0);
+		assert.equal(kill.mock.calls.length, 0);
+		for (const file of files) assert.equal(existsSync(file), true);
+	} finally {
+		child.emit("close", 1, null);
+		await cleanup;
+	}
+	assert.equal(existsSync(agentDir), false);
+});
+
+test("cleanup accepts forced termination only after close and clears its timers", async () => {
+	const { agentDir, fixture, child, kill } = resources();
+	kill.mockImplementation((signal) => {
+		if (signal === "SIGKILL") child.emit("close", null, signal);
+		return true;
+	});
+	const cleanup = fixture.cleanup();
+	try {
+		await vi.runAllTimersAsync();
+		await cleanup;
+		assert.deepEqual(kill.mock.calls, [["SIGTERM"], ["SIGKILL"]]);
+		assert.equal(existsSync(agentDir), false);
+		assert.equal(vi.getTimerCount(), 0);
+	} finally {
+		child.emit("close", 0, null);
+		await cleanup;
+	}
+});
+
+test.each(["throws", "hangs"])(
+	"a client cleanup that %s cannot prevent other cleanup or broker termination",
+	async (mode) => {
+		const { agentDir, fixture, child, kill } = resources();
+		const original = process.env.ATOMIC_CODING_AGENT_DIR;
+		fixture.overrideAgentDir();
+		fixture.onCleanup(() => {
+			if (mode === "throws") throw new Error("client cleanup failed");
+			return new Promise<void>(() => {});
+		});
+		const socket = new net.Socket();
+		fixture.onCleanup(() => {
+			socket.destroy();
+		});
+		kill.mockImplementation(() => {
+			child.emit("close", 0, null);
+			return true;
+		});
+		try {
+			await Promise.all([
+				assert.rejects(fixture.cleanup(), /client cleanup failed|Broker clients did not close/),
+				vi.runAllTimersAsync(),
+			]);
+			assert.equal(socket.destroyed, true);
+			assert.deepEqual(kill.mock.calls, [["SIGTERM"]]);
+			assert.equal(process.env.ATOMIC_CODING_AGENT_DIR, original);
+			assert.equal(vi.getTimerCount(), 0);
+		} finally {
+			child.emit("close", 0, null);
+			await fixture.cleanup();
+			socket.destroy();
+			rmSync(agentDir, { recursive: true, force: true });
+		}
+	},
+);
+
+test("cleanup restores the environment when setup failed before spawning a child", async () => {
+	const agentDir = mkdtempSync(join(tmpdir(), "intercom-not-spawned-"));
+	const fixture = new IntercomBrokerFixture(agentDir);
+	const original = process.env.ATOMIC_CODING_AGENT_DIR;
+	fixture.overrideAgentDir();
+	await fixture.cleanup();
+	assert.equal(process.env.ATOMIC_CODING_AGENT_DIR, original);
+	assert.equal(existsSync(agentDir), false);
+	assert.equal(vi.getTimerCount(), 0);
+});
+
+test("a real failed spawn closes and can be cleaned without an unhandled error", async () => {
+	vi.useRealTimers();
+	const agentDir = mkdtempSync(join(tmpdir(), "intercom-spawn-failure-"));
+	const fixture = new IntercomBrokerFixture(agentDir);
+	const child = spawn(join(agentDir, "missing-executable"), [], { stdio: "ignore" });
+	// Never send a real signal without a pid, even if this regression fails.
+	const kill = vi.spyOn(child, "kill").mockImplementation(() => assert.fail("cannot signal an unspawned child"));
+	fixture.trackBroker(child);
+	try {
+		await fixture.cleanup();
+		assert.throws(() => fixture.assertRunning(), { code: "ENOENT" });
+		assert.equal(kill.mock.calls.length, 0);
+		assert.equal(existsSync(agentDir), false);
+	} finally {
+		await fixture.cleanup();
+	}
+});

--- a/test/unit/intercom-broker-peer-disconnect.test.ts
+++ b/test/unit/intercom-broker-peer-disconnect.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { type ChildProcess, spawn } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { mkdtempSync } from "node:fs";
 import net from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -11,15 +11,16 @@ import { getJitiCliPath } from "../../packages/intercom/broker/spawn.js";
 import { type PeerDisconnectNotice, routePeerDisconnect } from "../../packages/intercom/peer-disconnect-routing.js";
 import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
 import type { BrokerMessage, ClientMessage } from "../../packages/intercom/types.js";
+import { IntercomBrokerFixture } from "../helpers/intercom-broker-fixture.js";
+
+const BROKER_PROBE_TIMEOUT_MS = 250;
 
 const repoRoot = resolve(import.meta.dirname, "../..");
 const extensionDir = join(repoRoot, "packages/intercom");
 const agentDir = mkdtempSync(join(tmpdir(), "intercom-peer-disconnect-"));
 const socketPath = getBrokerSocketPath(process.platform, agentDir);
-const originalAgentDir = process.env.ATOMIC_CODING_AGENT_DIR;
-process.env.ATOMIC_CODING_AGENT_DIR = agentDir;
-const { IntercomClient } = await import("../../packages/intercom/broker/client.js");
-let broker: ChildProcess | undefined;
+const fixture = new IntercomBrokerFixture(agentDir);
+let IntercomClient: typeof import("../../packages/intercom/broker/client.js").IntercomClient;
 
 class WireClient {
 	readonly received: BrokerMessage[] = [];
@@ -27,6 +28,9 @@ class WireClient {
 	private consumed = new Set<number>();
 
 	constructor() {
+		fixture.onCleanup(() => {
+			this.socket.destroy();
+		});
 		this.socket.on(
 			"data",
 			createMessageReader(
@@ -71,13 +75,21 @@ class WireClient {
 async function waitForBroker(): Promise<void> {
 	const deadline = Date.now() + 10_000;
 	while (Date.now() < deadline) {
+		fixture.assertRunning();
 		const connected = await new Promise<boolean>((resolveConnected) => {
 			const probe = net.createConnection(socketPath);
+			probe.setTimeout(BROKER_PROBE_TIMEOUT_MS, () => {
+				probe.destroy();
+				resolveConnected(false);
+			});
 			probe.once("connect", () => {
 				probe.destroy();
 				resolveConnected(true);
 			});
-			probe.once("error", () => resolveConnected(false));
+			probe.once("error", () => {
+				probe.destroy();
+				resolveConnected(false);
+			});
 		});
 		if (connected) return;
 		await new Promise((resolveDelay) => setTimeout(resolveDelay, 20));
@@ -105,18 +117,18 @@ const disconnected = (replyTo: string, peerSessionId: string, peerName?: string)
 });
 
 beforeAll(async () => {
-	broker = spawn(process.execPath, [getJitiCliPath(extensionDir), join(extensionDir, "broker/broker.ts")], {
+	fixture.overrideAgentDir();
+	({ IntercomClient } = await import("../../packages/intercom/broker/client.js"));
+	const broker = spawn(process.execPath, [getJitiCliPath(extensionDir), join(extensionDir, "broker/broker.ts")], {
 		env: { ...process.env, ATOMIC_CODING_AGENT_DIR: agentDir, PI_CODING_AGENT_DIR: undefined },
 		stdio: "ignore",
 	});
+	fixture.trackBroker(broker);
 	await waitForBroker();
 });
 
-afterAll(() => {
-	broker?.kill("SIGTERM");
-	if (originalAgentDir === undefined) delete process.env.ATOMIC_CODING_AGENT_DIR;
-	else process.env.ATOMIC_CODING_AGENT_DIR = originalAgentDir;
-	rmSync(agentDir, { recursive: true, force: true });
+afterAll(async () => {
+	await fixture.cleanup();
 });
 
 test("broker emits exact idempotent peer_disconnected frames for graceful and abrupt target exits", async () => {
@@ -232,6 +244,7 @@ test("broker emits exact idempotent peer_disconnected frames for graceful and ab
 
 test("real client stays connected when a pending peer disconnects", async () => {
 	const asker = new IntercomClient();
+	fixture.onCleanup(() => asker.disconnect());
 	const target = new WireClient();
 	const errors: Error[] = [];
 	asker.on("error", (error: Error) => errors.push(error));
@@ -259,6 +272,7 @@ test("real client stays connected when a pending peer disconnects", async () => 
 
 test("real client rejects the exact waiter when its target disconnects", async () => {
 	const asker = new IntercomClient();
+	fixture.onCleanup(() => asker.disconnect());
 	const target = new WireClient();
 	const slot = new ReplyWaiterRegistry();
 	const targetName = "waiter-release-target";

--- a/test/unit/intercom-broker-stale-session.test.ts
+++ b/test/unit/intercom-broker-stale-session.test.ts
@@ -27,8 +27,8 @@
  */
 
 import assert from "node:assert/strict";
-import { type ChildProcess, spawn } from "node:child_process";
-import { closeSync, mkdirSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { closeSync, mkdirSync, mkdtempSync, openSync, readFileSync } from "node:fs";
 import net from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -37,13 +37,16 @@ import { createMessageReader, writeMessage } from "../../packages/intercom/broke
 import { getBrokerSocketPath } from "../../packages/intercom/broker/paths.js";
 import { getJitiCliPath } from "../../packages/intercom/broker/spawn.js";
 import type { BrokerMessage, ClientMessage } from "../../packages/intercom/types.js";
+import { IntercomBrokerFixture } from "../helpers/intercom-broker-fixture.js";
+
+const BROKER_PROBE_TIMEOUT_MS = 250;
 
 const repoRoot = resolve(import.meta.dirname, "../..");
 const extensionDir = join(repoRoot, "packages/intercom");
 const agentDir = mkdtempSync(join(tmpdir(), "intercom-stale-"));
 const socketPath = getBrokerSocketPath(process.platform, agentDir);
 const brokerLogPath = join(agentDir, "intercom", "broker.log");
-let broker: ChildProcess | undefined;
+const fixture = new IntercomBrokerFixture(agentDir);
 
 class WireClient {
 	readonly received: BrokerMessage[] = [];
@@ -58,6 +61,9 @@ class WireClient {
 	 */
 	constructor(halfOpen = false) {
 		this.socket = net.createConnection({ path: socketPath, allowHalfOpen: halfOpen });
+		fixture.onCleanup(() => {
+			this.socket.destroy();
+		});
 		this.socket.on(
 			"data",
 			createMessageReader(
@@ -107,13 +113,21 @@ class WireClient {
 async function waitForBroker(): Promise<void> {
 	const deadline = Date.now() + 10_000;
 	while (Date.now() < deadline) {
+		fixture.assertRunning();
 		const connected = await new Promise<boolean>((resolveConnected) => {
 			const probe = net.createConnection(socketPath);
+			probe.setTimeout(BROKER_PROBE_TIMEOUT_MS, () => {
+				probe.destroy();
+				resolveConnected(false);
+			});
 			probe.once("connect", () => {
 				probe.destroy();
 				resolveConnected(true);
 			});
-			probe.once("error", () => resolveConnected(false));
+			probe.once("error", () => {
+				probe.destroy();
+				resolveConnected(false);
+			});
 		});
 		if (connected) return;
 		await new Promise((resolveDelay) => setTimeout(resolveDelay, 20));
@@ -157,17 +171,20 @@ function brokerLog(): string {
 beforeAll(async () => {
 	mkdirSync(join(agentDir, "intercom"), { recursive: true });
 	const logFd = openSync(brokerLogPath, "w");
-	broker = spawn(process.execPath, [getJitiCliPath(extensionDir), join(extensionDir, "broker/broker.ts")], {
-		env: { ...process.env, ATOMIC_CODING_AGENT_DIR: agentDir, PI_CODING_AGENT_DIR: undefined },
-		stdio: ["ignore", "ignore", logFd],
-	});
-	closeSync(logFd);
+	try {
+		const broker = spawn(process.execPath, [getJitiCliPath(extensionDir), join(extensionDir, "broker/broker.ts")], {
+			env: { ...process.env, ATOMIC_CODING_AGENT_DIR: agentDir, PI_CODING_AGENT_DIR: undefined },
+			stdio: ["ignore", "ignore", logFd],
+		});
+		fixture.trackBroker(broker);
+	} finally {
+		closeSync(logFd);
+	}
 	await waitForBroker();
 });
 
-afterAll(() => {
-	broker?.kill("SIGTERM");
-	rmSync(agentDir, { recursive: true, force: true });
+afterAll(async () => {
+	await fixture.cleanup();
 });
 
 test("a broker-ended session is retired, and healthy peers keep working without write-after-end", async () => {


### PR DESCRIPTION
## Summary

Fix the Windows `EBUSY` teardown race in the peer-disconnect and stale-session broker tests. Both fixtures previously sent `SIGTERM` and immediately removed the broker directory; they now await child `close` before deleting SQLite and logs.

## Changes

- Add a shared test-only fixture that observes `error` and `close` from spawn, handles early exit and failed spawn, and bounds termination with SIGKILL escalation. Unproven closure rejects and preserves broker-owned files.
- Register owned client/socket cleanup, restore the exact agent-directory environment value, bound readiness probes, and close the parent log descriptor in `finally`.
- Add 14 deterministic lifecycle regressions covering signal versus exit versus close, startup failures, escalation, cleanup failures, and environment restoration. Preserve all seven original behavioral tests and their assertions.

Only four paths under `test/` change. No shipped packages, docs, changelogs, shared timeout policy, or CI configuration change. No EBUSY suppression, deletion retries, skips, or global serialization are added.

## Validation

Implementation and independent review receipts for goal `670c886f-2159-42b0-b39c-4e139cbe97f8` record:

- `npm ci --ignore-scripts` and `npm run build` passed.
- The focused npm/Node Vitest command below passed all 21 tests across three files.
- `npm run check` passed Biome, both typechecks, and shrinkwrap verification.
- Removing the actual close-await produced nine regression failures, including `delivered-messages.sqlite removed before child close`; restoring it passed.
- Independent real-child/SQLite probes reproduced premature deletion with the original callback and verified retention through close with the fix. Additional probes covered ignored SIGTERM, delayed stdio closure, EACCES startup failure, exact environment restoration, and EBUSY propagation.
- Three independent reviewers approved exact head `b13c52c3a9e71aeabffcef35c370013f8daab7c1` with no findings. The goal ledger records completion and the PR handoff decision.

```sh
npm run test:unit -- \
  test/unit/intercom-broker-peer-disconnect.test.ts \
  test/unit/intercom-broker-stale-session.test.ts \
  test/unit/intercom-broker-fixture.test.ts \
  --reporter=verbose
npm run check
```

The PR preparation stage independently verified the SSH commit signature, clean worktree, and full base/index diff. It did not rerun the implementation/reviewer tests.

All post-fix execution reported above was on macOS. Deterministic ordering and real broker integration are verified; native Windows file-lock behavior on this repaired head remains unverified. Supplemental qlty checks could not run because repository configuration is absent; required repository checks passed.

## Notes

This is the separate test-only repair associated with release changelog PR #2862. That PR remains unchanged at `d33a50d43155ea5591ef8f7318dc1452337f19b8`.

Parent-only gates remain: verify and admin-merge this exact repair head and the unchanged changelog head. Only the supervisor may then resume original publish-release run `877a91c7-ed68-4ace-9895-cf2555d9b154` to publish `0.9.18-alpha.6` from versionless `main`. This PR handoff performs no merge, tag, publication, or workflow resume, and does not independently claim the publication run's current persisted status.

## Contract amendments received

None during PR preparation. Inherited scope remains a separate repair PR with parent-only merges and supervisor-only publication resume.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791159010&installation_model_id=10562&pr_number=2863&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2863&signature=9665ca9c7cb45a3248ee992863db3a246e4eaed2175ce1edc92ec7f13fbf0ebf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a shared lifecycle fixture for raw Intercom broker tests, including bounded client cleanup, broker termination escalation, environment restoration, and removal of broker-owned files only after the child process closes.

## T-Rex validation blocked

The focused Intercom lifecycle suites could not start because `@bastani/pi-ai/compat`, required during test initialization, is unavailable in this checkout. No product issue was established.

<h3>Confidence Score: 5/5</h3>

No merge-blocking product issue was established, but the focused broker lifecycle tests remain unexecuted in this checkout.

There are no confirmed review findings.

**Files Needing Attention:** No source file requires changes based on the available evidence; restore the missing internal package before relying on the focused test result.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Prepared the focused Intercom broker fixture, peer-disconnect, and stale-session test scope.
- Ran the focused lifecycle test command against the prepared scope.
- Test initialization stopped before collecting any suite due to an unresolved module '@bastani/pi-ai/compat'.
- Collected evidence artifacts for the lifecycle run, including the exact command script and the complete observed output.

<a href="https://app.greptile.com/trex/runs/22632814/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(intercom): await broker closure bef..."](https://github.com/bastani-inc/atomic/commit/b13c52c3a9e71aeabffcef35c370013f8daab7c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60638279)</sub>

**Context used:**

- Knowledge Base — [Intercom messaging](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/intercom-messaging.md)

<!-- /greptile_comment -->