### PR TITLE
test(workflows): use literal matching for warm-up failure

### DIFF
--- a/test/integration/workflow-stage-pending-delivery-terminal-failure.test.ts
+++ b/test/integration/workflow-stage-pending-delivery-terminal-failure.test.ts
@@ -140,7 +140,7 @@ test("a stage whose pending Intercom delivery fails terminally becomes a failed 
 	assert.equal(stage.modelAttempts?.[0]?.success, false);
 	assert.equal(stage.warnings, undefined, "no [fallback] warning blames a model for a delivery failure");
 	assert.match(String(stage.error), /stage "reviewer"/);
-	assert.match(String(stage.error), new RegExp(WARM_UP_EXHAUSTED.replace(/\./g, "\\.")));
+	assert.ok(String(stage.error).includes(WARM_UP_EXHAUSTED));
 
 	const queued = store.pendingStageMessagesFor(result.runId, "reviewer");
 	assert.equal(queued.length, 1, "the steering is not dropped");


### PR DESCRIPTION
## Summary

Resolve CodeQL alert [194](https://github.com/bastani-inc/atomic/security/code-scanning/194) by removing unnecessary partial regex escaping from the pending-delivery integration assertion.

## Changes

Use literal message matching while preserving the test's failure, attempt-count, fallback and queued-message assertions. The input is a fixed test constant; this is test correctness cleanup, not evidence of a shipped injection vulnerability. No alert suppression or runtime changes.

## Validation

Independent review, focused integration tests and npm run check. Requested as a prerequisite before the next prerelease.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791172771&installation_model_id=10562&pr_number=2867&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2867&signature=95ab19c0154c0faeea515f30e2234b2ef347d849e3c92a152623aaf5a6252973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary

- Replaced a dynamically constructed regular-expression assertion with a literal substring assertion in the pending-delivery terminal-failure integration test.
- The focused terminal-failure flow passed both before and after the change, including the expected warm-up exhaustion message check.
- No issues found; this change is safe to merge.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the focused pending-delivery terminal-failure flow passes with the new literal assertion.

No actionable issues were found. The exact integration test passed with both the prior and updated assertion forms, and the new assertion checks the full expected text literally.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused pending Intercom delivery terminal-failure integration test against both the parent version and the PR change.
- Both test runs completed successfully, each executing the queued pending-stage delivery, warm-up exhaustion error, disconnected delivery cause, terminal stage failure, and the expected error-message assertion.
- The assertion now checks the entire WARM\_UP\_EXHAUSTED string literally using includes, removing prior regex-based semantics.
- Compared before/after runs to verify the PR assertion run passed (1 test, exit 0) and confirmed the parent run's assertion as a baseline.

<a href="https://app.greptile.com/trex/runs/22653341/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["test(workflows): assert warm-up failure ..."](https://github.com/bastani-inc/atomic/commit/3ea0f4177f91651b0f884065a75a419e58718814) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60677963)</sub>

**Context used:**

- Knowledge Base — [Hide Recoverable Intercom Disconnects from Workflow Stages](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/reverts/incident-mitigation_2820-20260903-workflow-stage-intercom-disconnect-0f2b7c5.md)

<!-- /greptile_comment -->