### PR TITLE
fix(coding-agent): restore automatic model defaults and remove shortcuts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Interactive model and thinking selections, including cycling shortcuts, now automatically become startup defaults. Scoped-model cycle-list changes also save immediately. Removed the Ctrl+S save-default shortcuts and UI.
+
+### Removed
+
+- Removed the Ctrl+X copy-message/selection action to avoid confusion with workflow navigation. `/copy` and automatic mouse-selection copying remain available.
+
 ### Fixed
 
 - Resumed workflows can no longer report completion after changed control flow omits their unfinished durable tool. Normal returns and explicit completed exits require exact frontier consumption. New model/task and child-workflow execution, including stage/task worktree setup, is rejected while that frontier is pending; completed work stays cached and cancellation controls retain precedence.

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -176,8 +176,8 @@ Type `/` in the editor to trigger commands. [Extensions](#extensions) can regist
 | Command | Description |
 |---------|-------------|
 | `/login`, `/logout` | OAuth authentication |
-| `/model` | Switch models; Ctrl+S in the picker saves the startup default |
-| `/thinking` | Switch thinking level; Ctrl+S in the picker saves the startup default |
+| `/model` | Switch models and automatically save the startup default |
+| `/thinking` | Switch thinking level and automatically save the startup default |
 | `/scoped-models` | Enable/disable models for CTRL+P cycling |
 | `/settings` | Theme, message delivery, transport, and other preferences |
 | `/resume` | Pick from previous sessions |

--- a/packages/coding-agent/docs/keybindings.md
+++ b/packages/coding-agent/docs/keybindings.md
@@ -84,7 +84,7 @@ The dedicated history actions always change history entries, regardless of the c
 
 ### TUI Fullscreen Viewport
 
-Interactive sessions always use this fullscreen viewport for the primary transcript scroll region. Mouse-wheel input scrolls the region under the pointer, falling back to the transcript over the fixed editor/status/footer dock. While the main transcript is scrolled up, a clickable "Jump to latest message" label on its bottom row shows the `tui.altScreen.bottom` shortcut; clicking it returns that transcript to its live end. An attached workflow stage chat keeps its own "Jump to latest message" OSC 8 link with the same shortcut, which returns the stage chat to its live end. Clicking other OSC 8 hyperlinks opens them in the default handler. Dragging with the primary mouse button selects text and, by default, copies it to the clipboard. Set `fullscreenCopyOnSelect` to `false` to retain selections for explicit Ctrl+X copying. See [Terminal setup](/terminal-setup) for terminal-specific mouse and trackpad behavior.
+Interactive sessions always use this fullscreen viewport for the primary transcript scroll region. Mouse-wheel input scrolls the region under the pointer, falling back to the transcript over the fixed editor/status/footer dock. While the main transcript is scrolled up, a clickable "Jump to latest message" label on its bottom row shows the `tui.altScreen.bottom` shortcut; clicking it returns that transcript to its live end. An attached workflow stage chat keeps its own "Jump to latest message" OSC 8 link with the same shortcut, which returns the stage chat to its live end. Clicking other OSC 8 hyperlinks opens them in the default handler. Dragging with the primary mouse button selects text and, by default, copies it to the clipboard. Set `fullscreenCopyOnSelect` to `false` to highlight text without copying. See [Terminal setup](/terminal-setup) for terminal-specific mouse and trackpad behavior.
 
 
 Fullscreen text selection comes from the installed pi-tui 0.85.0 renderer. Drag with the primary button to select characters; double-click selects a word, including complete slash-delimited paths and kebab-case names, and triple-click selects a line. Focus changes and non-drag clicks clear transient selection state, preventing a stale highlight from appearing. A drag release reported with the generic SGR button code also ends the selection. The renderer also reduces mouse tracking in tmux, Zellij, and GNU Screen.
@@ -128,7 +128,6 @@ On Windows, pressing the secondary mouse button in fullscreen pastes text from t
 | `app.suspend` | `ctrl+z` (none on Windows) | Suspend to background |
 | `app.editor.external` | `ctrl+g` | Open in external editor (`$VISUAL` or `$EDITOR`) |
 | `app.clipboard.pasteImage` | `ctrl+v` (`alt+v` on Windows) | Paste image or text from clipboard |
-| `app.message.copy` | `ctrl+x` | When `fullscreenCopyOnSelect` is `false`, copy the active fullscreen selection; otherwise copy the last assistant message |
 
 When `app.clipboard.pasteImage` finds text rather than an image, Atomic inserts that clipboard text into the editor instead of reporting an image-paste failure.
 
@@ -138,7 +137,7 @@ Inside tmux on macOS, `Ctrl+V` is the reliable image-paste shortcut; native `Cmd
 
 When the clipboard has both text and an image, behavior depends on the terminal: empty-paste terminals may insert the text on `Cmd+V`, while Kitty-protocol terminals that deliver `super+v` go through the image path (same preference as `Ctrl+V`). `Ctrl+V` always prefers the image. Apple Terminal may send nothing for image-only paste; use Ghostty/iTerm/Kitty or `Ctrl+V` in that case.
 
-Ctrl+X keeps Atomic's hierarchy precedence. A workflow tool-detail view closes to its graph; the scoped-model selector clears its local selection; an attached workflow stage chat returns to its graph; and a workflow graph returns to main chat. Only the main editor then runs `app.message.copy`. Workflow surfaces recognize the physical Ctrl+X chord directly, including CSI variants, rather than the configurable application action. `/copy` is separate and always copies the last assistant message.
+Ctrl+X does not copy messages or selections. A workflow tool-detail view closes to its graph; the scoped-model selector clears its local selection; an attached workflow stage chat returns to its graph; and a workflow graph returns to main chat. Workflow surfaces recognize the physical Ctrl+X chord directly, including CSI variants. `/copy` always copies the last assistant message.
 
 A held paused queue by itself is idle for Ctrl+C handling. After an interruption settles, the next Ctrl+C clears the editor without releasing or dequeuing the hold, and a second quick idle press exits normally.
 
@@ -176,10 +175,10 @@ Ctrl+C is the host's escape hatch whenever an engine-owned `ctx.ui.custom()` com
 | `app.model.select` | `ctrl+l` | Open model selector |
 | `app.model.cycleForward` | `ctrl+p` | Cycle to next model |
 | `app.model.cycleBackward` | `shift+ctrl+p` | Cycle to previous model |
-| `app.models.save` | `ctrl+s` | Save the selected default model or scoped model configuration to settings |
 | `app.thinking.cycle` | `shift+tab` | Cycle thinking level |
-| `app.thinking.save` | `ctrl+s` | Save current thinking level to settings |
 | `app.thinking.toggle` | `ctrl+t` | Collapse or expand thinking blocks |
+
+Interactive model and thinking choices automatically become startup defaults. There is no save-default shortcut.
 
 ### Display and Message Queue
 
@@ -207,11 +206,10 @@ Ctrl+C is the host's escape hatch whenever an engine-owned `ctx.ui.custom()` com
 
 ### Scoped Models Selector
 
-Used inside the scoped models selector (opened via `/scoped-models`).
+Used inside the scoped models selector (opened via `/scoped-models`). Changes are saved automatically.
 
 | Keybinding id | Default | Description |
 |--------|---------|-------------|
-| `app.models.save` | `ctrl+s` | Save current model selection to settings |
 | `app.models.enableAll` | `ctrl+a` | Enable all models (or all matching the current search) |
 | `app.models.clearAll` | `ctrl+x` | Clear all models (or all matching the current search) |
 | `app.models.toggleProvider` | `ctrl+p` | Toggle all models for the current provider |

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -243,7 +243,7 @@ Messages are `AgentMessage` objects (see [Types](#types)).
 
 #### set_model
 
-Switch to a specific model. Omit `persist` (or set it false) to change only the current session. Set `"persist": true` to also write `defaultProvider`/`defaultModel` in settings, matching Ctrl+S in the interactive `/model` picker.
+Switch to a specific model. Omit `persist` (or set it false) to change only the current session. Set `"persist": true` to also save `defaultProvider`, `defaultModel`, and the effective thinking level in settings, matching an interactive `/model` selection.
 
 ```json
 {"type": "set_model", "provider": "anthropic", "modelId": "claude-sonnet-4-20250514"}
@@ -349,7 +349,7 @@ Response:
 
 #### set_thinking_level
 
-Set the reasoning/thinking level for models that support it. Omit `persist` (or set it false) to change only the current session. Set `"persist": true` to also save the startup thinking default, matching Ctrl+S in the interactive `/thinking` picker. When a model is active, that writes the per-model override; otherwise it writes `defaultThinkingLevel`.
+Set the reasoning/thinking level for models that support it. Omit `persist` (or set it false) to change only the current session. Set `"persist": true` to also save `defaultThinkingLevel` and, when a model is active, its per-model override. Interactive `/thinking` choices request persistence automatically.
 
 ```json
 {"type": "set_thinking_level", "level": "high"}

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -7,7 +7,7 @@ Atomic uses JSON settings files with project settings overriding global settings
 | `~/.atomic/agent/settings.json` | Global (all projects) |
 | `.atomic/settings.json` | Project (current directory) |
 
-Edit directly or use `/settings` for common options. To save startup model defaults interactively, use `/model` and press Ctrl+S on the desired model; to save the startup thinking level, use `/thinking` and press Ctrl+S. Atomic also reads legacy `~/.pi/agent/settings.json` and `.pi/settings.json` as compatibility fallbacks, with `.atomic` paths taking precedence.
+Edit directly or use `/settings` for common options. Choosing a model or thinking level with `/model`, `/thinking`, or their cycling shortcuts automatically saves it as the startup default. Thinking choices also update the active model's saved thinking level. `/scoped-models` saves cycle-list changes automatically. SDK calls, session restoration, and automatic fallbacks do not overwrite these defaults unless persistence is explicitly requested. Atomic also reads legacy `~/.pi/agent/settings.json` and `.pi/settings.json` as compatibility fallbacks, with `.atomic` paths taking precedence.
 
 ## Project Trust
 
@@ -31,10 +31,10 @@ Settings and trust JSON files may start with a UTF-8 BOM, as commonly written by
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `defaultProvider` | string | - | Startup provider (e.g., `"anthropic"`, `"openai"`; saved with Ctrl+S in `/model`, or edited manually) |
-| `defaultModel` | string | - | Startup model ID (saved with Ctrl+S in `/model`, or edited manually) |
-| `defaultThinkingLevel` | string | - | Startup thinking level (saved with Ctrl+S in `/thinking`, or edited manually): `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`; the active model must support the selected level |
-| `modelThinkingLevels` | object | - | Per-model startup thinking levels keyed by `"provider/modelId"`; configure from `/settings` → Default thinking level per model, or edit manually |
+| `defaultProvider` | string | - | Startup provider, saved automatically when you switch models interactively |
+| `defaultModel` | string | - | Startup model ID, saved automatically when you switch models interactively |
+| `defaultThinkingLevel` | string | - | Startup thinking level, saved automatically on interactive model/thinking changes: `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`; clamped to the active model's supported levels |
+| `modelThinkingLevels` | object | - | Per-model startup thinking levels keyed by `"provider/modelId"`; updated automatically on interactive model/thinking changes, or configured from `/settings` → Default thinking level per model |
 | `hideThinkingBlock` | boolean | `false` | Hide thinking blocks in output |
 | `thinkingBudgets` | object | - | Custom token budgets per thinking level. Anthropic, Google, and Bedrock use these natively. OpenAI-compatible models use them when `compat.thinkingTokenBudgetField` (or `supportsThinkingTokenBudget`) is set. |
 | `showCacheMissNotices` | boolean | `false` | Show transcript notices for significant prompt-cache misses, billed compaction or branch-summary usage, and provider recovery diagnostics such as dropped Anthropic thinking blocks, including when a persisted transcript is resumed |
@@ -109,7 +109,7 @@ See [Providers](/providers#fast-models) for which providers publish fast variant
 | `theme` | string | `"dark"` | Theme name (`"dark"`, `"light"`, a Catppuccin built-in, or custom) |
 | `fullscreenScrollbar` | string | `"auto"` | Fullscreen transcript scrollbar: `"auto"` shows it temporarily while scrolling, `"always"` reserves the rightmost transcript column and keeps it visible, and `"hidden"` hides it. The thumb can be dragged when shown. |
 | `fullscreenExitOutput` | string | `"transcript"` | Fullscreen exit output: `"transcript"` prints the final transcript and session resume hint, while `"resume-hint"` restores the terminal's previous screen and prints only the resume hint. Settable from `/settings` |
-| `fullscreenCopyOnSelect` | boolean | `true` | Copy fullscreen text selections automatically on mouse release. When `false`, the selection remains highlighted and main-editor Ctrl+X copies it; Ctrl+X falls back to the last assistant message when there is no selection. Settable from `/settings` |
+| `fullscreenCopyOnSelect` | boolean | `true` | Copy fullscreen text selections automatically on mouse release. When `false`, selection only highlights text. Ctrl+X does not copy; `/copy` copies the last assistant message. Settable from `/settings` |
 | `quietStartup` | boolean | `false` | Hide startup header |
 | `defaultProjectTrust` | string | `"ask"` | Fallback project trust behavior: `"ask"`, `"always"`, or `"never"`. Global setting only |
 | `collapseChangelog` | boolean | `false` | Show condensed changelog after updates |

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -34,7 +34,6 @@ While ordinary agent work is active, the exact one-cell `∀` remains visible an
 | Shell command | `!command` runs and sends output to the model |
 | Hidden shell command | `!!command` runs without sending output to the model |
 | External editor | CTRL+G opens `$VISUAL` or `$EDITOR` |
-| Copy selection/message | Ctrl+X copies a retained fullscreen selection when `fullscreenCopyOnSelect` is disabled; otherwise it copies the last assistant message |
 
 See [Keybindings](/keybindings) for all shortcuts and customization.
 
@@ -45,8 +44,8 @@ Type `/` in the editor to open command completion. Extensions can register custo
 | Command | Description |
 |---------|-------------|
 | `/login`, `/logout` | Manage OAuth or API-key credentials |
-| `/model` | Switch models; Ctrl+S in the picker saves the startup default |
-| `/thinking` | Switch thinking level; Ctrl+S in the picker saves the startup default |
+| `/model` | Switch models and automatically save the startup default |
+| `/thinking` | Switch thinking level and automatically save the startup default |
 | `/scoped-models` | Enable/disable models for CTRL+P cycling |
 | `/workflow` | List/run workflows; manage runs (connect/inspect/pause/interrupt/quit/resume); reload workflow resources |
 | `/settings` | Theme, message delivery, transport, and other preferences |
@@ -233,7 +232,7 @@ For raw credential exports, stdout is empty on every non-zero exit but one. Once
 | `--mode rpc` | RPC mode over stdin/stdout; see [RPC mode](/rpc) |
 | `--export <in> [out]` | Export a session to HTML |
 
-Interactive sessions always use fullscreen: the transcript scrolls independently above a sticky dock containing the editor, status line, usage meter, extension widgets, and footer. Wheel and trackpad gestures go first to a focused workflow graph or stage chat overlay; events those overlays do not consume fall through to the alternate-screen viewport. Non-overlay focused components do not block pi-tui's mouse path, so transcript scrolling, scrollbar interaction, and drag selection still work. Selection copies automatically by default; disable `fullscreenCopyOnSelect` to retain it for Ctrl+X. Ctrl+X closes workflow tool detail to the graph, clears a scoped-model selection, returns stage chat to its graph, or returns a workflow graph to main chat before the main editor may copy. `/copy` always copies the last assistant message. The `fullscreenExitOutput` setting controls what exiting prints: `"transcript"` (the default) paints the final transcript plus a session resume hint on the main screen, while `"resume-hint"` restores the previous screen and prints only the resume hint. See [Settings](/settings) and [Terminal setup](/terminal-setup).
+Interactive sessions always use fullscreen: the transcript scrolls independently above a sticky dock containing the editor, status line, usage meter, extension widgets, and footer. Wheel and trackpad gestures go first to a focused workflow graph or stage chat overlay; events those overlays do not consume fall through to the alternate-screen viewport. Non-overlay focused components do not block pi-tui's mouse path, so transcript scrolling, scrollbar interaction, and drag selection still work. Selection copies automatically by default; disable `fullscreenCopyOnSelect` to highlight text without copying. Ctrl+X closes workflow tool detail to the graph, clears a scoped-model selection, returns stage chat to its graph, or returns a workflow graph to main chat. It does not copy. `/copy` always copies the last assistant message. The `fullscreenExitOutput` setting controls what exiting prints: `"transcript"` (the default) paints the final transcript plus a session resume hint on the main screen, while `"resume-hint"` restores the previous screen and prints only the resume hint. See [Settings](/settings) and [Terminal setup](/terminal-setup).
 
 In print mode, Atomic also reads piped stdin and merges it into the initial prompt:
 

--- a/packages/coding-agent/src/core/agent-session-models.ts
+++ b/packages/coding-agent/src/core/agent-session-models.ts
@@ -126,7 +126,7 @@ export async function setModel(
 	}
 
 	// Re-clamp thinking level for new model's capabilities
-	this.setThinkingLevel(thinkingLevel);
+	this.setThinkingLevel(thinkingLevel, options);
 	this._refreshBaseSystemPromptFromActiveTools();
 
 	this._emitModelChanged(nextModel, previousModel, "set");
@@ -184,7 +184,7 @@ export async function _cycleScopedModel(
 	// - Explicit scoped model thinking level overrides current session level
 	// - Undefined scoped model thinking level inherits the current session preference
 	// setThinkingLevel clamps to model capabilities.
-	this.setThinkingLevel(thinkingLevel);
+	this.setThinkingLevel(thinkingLevel, options);
 	this._refreshBaseSystemPromptFromActiveTools();
 
 	this._emitModelChanged(nextModel, currentModel, "cycle");
@@ -220,7 +220,7 @@ export async function _cycleAvailableModel(
 	}
 
 	// Re-clamp thinking level for new model's capabilities
-	this.setThinkingLevel(thinkingLevel);
+	this.setThinkingLevel(thinkingLevel, options);
 	this._refreshBaseSystemPromptFromActiveTools();
 
 	this._emitModelChanged(selectedModel, currentModel, "cycle");
@@ -242,7 +242,6 @@ export async function _cycleAvailableModel(
 function persistThinkingLevel(session: AgentSession, level: ThinkingLevel): void {
 	if (session.model) {
 		session.settingsManager.setModelThinkingLevel(session.model.provider, session.model.id, level);
-		return;
 	}
 	session.settingsManager.setDefaultThinkingLevel(level);
 }

--- a/packages/coding-agent/src/core/extensions/runner-shortcuts.ts
+++ b/packages/coding-agent/src/core/extensions/runner-shortcuts.ts
@@ -18,7 +18,6 @@ const RESERVED_KEYBINDINGS_FOR_EXTENSION_CONFLICTS = [
 	"app.thinking.toggle",
 	"app.editor.external",
 	"app.message.followUp",
-	"app.message.copy",
 	"tui.input.submit",
 	"tui.select.confirm",
 	"tui.select.cancel",

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -17,7 +17,6 @@ export interface AppKeybindings {
 	"app.exit": true;
 	"app.suspend": true;
 	"app.thinking.cycle": true;
-	"app.thinking.save": true;
 	"app.model.cycleForward": true;
 	"app.model.cycleBackward": true;
 	"app.model.select": true;
@@ -27,7 +26,6 @@ export interface AppKeybindings {
 	"app.editor.external": true;
 	"app.message.followUp": true;
 	"app.message.dequeue": true;
-	"app.message.copy": true;
 	"app.clipboard.pasteImage": true;
 	"app.session.new": true;
 	"app.session.tree": true;
@@ -42,7 +40,6 @@ export interface AppKeybindings {
 	"app.session.rename": true;
 	"app.session.delete": true;
 	"app.session.deleteNoninvasive": true;
-	"app.models.save": true;
 	"app.models.enableAll": true;
 	"app.models.clearAll": true;
 	"app.models.toggleProvider": true;
@@ -103,10 +100,6 @@ export const KEYBINDINGS = {
 		defaultKeys: "shift+tab",
 		description: "Cycle thinking level",
 	},
-	"app.thinking.save": {
-		defaultKeys: "ctrl+s",
-		description: "Save thinking level",
-	},
 	"app.model.cycleForward": {
 		defaultKeys: "ctrl+p",
 		description: "Cycle to next model",
@@ -136,10 +129,6 @@ export const KEYBINDINGS = {
 	"app.message.dequeue": {
 		defaultKeys: windowsKeybindings ? "alt+q" : "alt+up",
 		description: "Restore queued messages",
-	},
-	"app.message.copy": {
-		defaultKeys: "ctrl+x",
-		description: "Copy fullscreen selection or last agent message",
 	},
 	"app.clipboard.pasteImage": {
 		defaultKeys: windowsKeybindings ? "alt+v" : "ctrl+v",
@@ -184,10 +173,6 @@ export const KEYBINDINGS = {
 	"app.session.deleteNoninvasive": {
 		defaultKeys: "ctrl+backspace",
 		description: "Delete session when query is empty",
-	},
-	"app.models.save": {
-		defaultKeys: "ctrl+s",
-		description: "Save model selection",
 	},
 	"app.models.enableAll": {
 		defaultKeys: "ctrl+a",

--- a/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts
@@ -55,7 +55,6 @@ function applyPersistedThinkingDefault(
 ): void {
 	if (target) {
 		session.settingsManager.setModelThinkingLevel(target.provider, target.modelId, level);
-		return;
 	}
 	session.settingsManager.setDefaultThinkingLevel(level);
 }
@@ -832,6 +831,10 @@ export class IsolatedInteractiveRuntime extends AgentSessionRuntime {
 		const catalog = await this.client.requestInternal<RpcModelCatalog>({ type: "get_available_models" });
 		this.remoteModelCatalog.apply(catalog);
 		applyPersistedModelDefault(session, model, alreadyInScope);
+		const state = await this.client.getState();
+		if (state.model?.provider === model.provider && state.model.id === model.id) {
+			applyPersistedThinkingDefault(session, state.thinkingLevel, { provider: model.provider, modelId: model.id });
+		}
 	}
 
 	private refreshSessionView(): void {

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -55,7 +55,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private currentModel?: Model<Api>;
 	private defaultModelKey?: string;
 	private modelRuntime: ModelRuntime;
-	private onSelectCallback: (model: Model<Api>, persist: boolean) => void;
+	private onSelectCallback: (model: Model<Api>) => void;
 	private onCancelCallback: () => void;
 	private errorMessage?: string;
 	private tui: TUI;
@@ -74,7 +74,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		_settingsManager: SettingsManager,
 		modelRuntime: ModelRuntime,
 		scopedModels: ReadonlyArray<ScopedModelItem>,
-		onSelect: (model: Model<Api>, persist: boolean) => void,
+		onSelect: (model: Model<Api>) => void,
 		onCancel: () => void,
 		initialSearchInput?: string,
 	) {
@@ -115,7 +115,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		this.searchInput.onSubmit = () => {
 			// Enter on search input selects the first filtered item
 			if (this.filteredModels[this.selectedIndex]) {
-				this.handleSelect(this.filteredModels[this.selectedIndex].model, false);
+				this.handleSelect(this.filteredModels[this.selectedIndex].model);
 			}
 		};
 		this.addChild(this.searchInput);
@@ -129,7 +129,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		this.addChild(new Spacer(1));
 		this.addChild(
 			new Text(
-				`${keyHint("tui.select.confirm", "select")} ${theme.fg("muted", "·")} ${keyHint("app.models.save", "set as default")} ${theme.fg("muted", "·")} ${keyHint("tui.select.cancel", "cancel")}`,
+				`${keyHint("tui.select.confirm", "select")} ${theme.fg("muted", "·")} ${keyHint("tui.select.cancel", "cancel")}`,
 				1,
 				0,
 			),
@@ -339,16 +339,11 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			this.selectedIndex = this.selectedIndex === this.filteredModels.length - 1 ? 0 : this.selectedIndex + 1;
 			this.updateList();
 		}
-		// Ctrl+S persists the selected model as the startup default
-		else if (kb.matches(keyData, "app.models.save")) {
-			const selectedModel = this.filteredModels[this.selectedIndex];
-			if (selectedModel) this.handleSelect(selectedModel.model, true);
-		}
 		// Enter
 		else if (kb.matches(keyData, "tui.select.confirm")) {
 			const selectedModel = this.filteredModels[this.selectedIndex];
 			if (selectedModel) {
-				this.handleSelect(selectedModel.model, false);
+				this.handleSelect(selectedModel.model);
 			}
 		}
 		// Escape or Ctrl+C
@@ -364,9 +359,9 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		return true;
 	}
 
-	private handleSelect(model: Model<Api>, persist: boolean): void {
+	private handleSelect(model: Model<Api>): void {
 		this.dispose();
-		this.onSelectCallback(model, persist);
+		this.onSelectCallback(model);
 	}
 
 	getSearchInput(): Input {

--- a/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/scoped-models-selector.ts
@@ -83,16 +83,14 @@ export interface ModelsConfig {
 }
 
 export interface ModelsCallbacks {
-	/** Called whenever the enabled model set or order changes (session-only, no persist) */
+	/** Called whenever the enabled model set or order changes. */
 	onChange: (enabledModelIds: string[] | null) => void | Promise<void>;
-	/** Called when user wants to persist current selection to settings */
-	onPersist: (enabledModelIds: string[] | null) => void | Promise<void>;
 	onCancel: () => void;
 }
 
 /**
  * Component for enabling/disabling models for Ctrl+P cycling.
- * Changes are session-only until explicitly persisted with Ctrl+S.
+ * Changes are saved automatically by the caller.
  */
 export class ScopedModelsSelectorComponent extends Container implements Focusable {
 	private modelsById: Map<string, Model<Api>> = new Map();
@@ -115,7 +113,6 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 	private footerText: Text;
 	private callbacks: ModelsCallbacks;
 	private maxVisible = 8;
-	private isDirty = false;
 	private refreshStatusText?: Text;
 	constructor(config: ModelsConfig, callbacks: ModelsCallbacks) {
 		super();
@@ -134,7 +131,7 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
 		this.addChild(new Text(theme.fg("accent", theme.bold("Model Configuration")), 0, 0));
-		this.addChild(new Text(theme.fg("muted", `Session-only. ${keyText("app.models.save")} Save Settings.`), 0, 0));
+		this.addChild(new Text(theme.fg("muted", "Changes are saved automatically."), 0, 0));
 		this.addChild(new Spacer(1));
 
 		// Search input
@@ -202,12 +199,9 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 			`${keyText("app.models.clearAll")} Clear`,
 			`${keyText("app.models.toggleProvider")} Provider`,
 			`${keyText("app.models.reorderUp")}/${keyText("app.models.reorderDown")} Reorder`,
-			`${keyText("app.models.save")} Save`,
 			countText,
 		];
-		return this.isDirty
-			? theme.fg("dim", `  ${parts.join(" · ")} `) + theme.fg("warning", "(unsaved)")
-			: theme.fg("dim", `  ${parts.join(" · ")}`);
+		return theme.fg("dim", `  ${parts.join(" · ")}`);
 	}
 
 	private refresh(): void {
@@ -304,7 +298,6 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 				// Only move if within bounds
 				if (newIndex >= 0 && newIndex < this.enabledIds.length) {
 					this.enabledIds = move(this.enabledIds, item.fullId, delta);
-					this.isDirty = true;
 					this.selectedIndex += delta;
 					this.refresh();
 					this.notifyChange();
@@ -318,7 +311,6 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 			const item = this.filteredItems[this.selectedIndex];
 			if (item) {
 				this.enabledIds = toggle(this.enabledIds, this.allIds, item.fullId);
-				this.isDirty = true;
 				this.refresh();
 				this.notifyChange();
 			}
@@ -329,7 +321,6 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 		if (kb.matches(data, "app.models.enableAll")) {
 			const targetIds = this.searchInput.getValue() ? this.filteredItems.map((i) => i.fullId) : undefined;
 			this.enabledIds = enableAll(this.enabledIds, this.allIds, targetIds);
-			this.isDirty = true;
 			this.refresh();
 			this.notifyChange();
 			return true;
@@ -339,7 +330,6 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 		if (kb.matches(data, "app.models.clearAll")) {
 			const targetIds = this.searchInput.getValue() ? this.filteredItems.map((i) => i.fullId) : undefined;
 			this.enabledIds = clearAll(this.enabledIds, this.allIds, targetIds);
-			this.isDirty = true;
 			this.refresh();
 			this.notifyChange();
 			return true;
@@ -355,18 +345,9 @@ export class ScopedModelsSelectorComponent extends Container implements Focusabl
 				this.enabledIds = allEnabled
 					? clearAll(this.enabledIds, this.allIds, providerIds)
 					: enableAll(this.enabledIds, this.allIds, providerIds);
-				this.isDirty = true;
 				this.refresh();
 				this.notifyChange();
 			}
-			return true;
-		}
-
-		// Save/persist to settings
-		if (kb.matches(data, "app.models.save")) {
-			this.callbacks.onPersist(this.enabledIds === null ? null : [...this.enabledIds]);
-			this.isDirty = false;
-			this.footerText.setText(this.getFooterText());
 			return true;
 		}
 

--- a/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/thinking-selector.ts
@@ -33,7 +33,6 @@ export class ThinkingSelectorComponent extends Container implements Focusable {
 	private allItems: SelectItem[];
 	private readonly onSelectLevel: (level: ThinkingLevel) => void;
 	private readonly onCancelSelect: () => void;
-	private readonly onSelectAsDefault?: (level: ThinkingLevel) => void;
 	private _focused = false;
 
 	get focused(): boolean {
@@ -49,13 +48,11 @@ export class ThinkingSelectorComponent extends Container implements Focusable {
 		availableLevels: ThinkingLevel[],
 		onSelectLevel: (level: ThinkingLevel) => void,
 		onCancelSelect: () => void,
-		onSelectAsDefault?: (level: ThinkingLevel) => void,
 		defaultThinkingLevel?: ThinkingLevel,
 	) {
 		super();
 		this.onSelectLevel = onSelectLevel;
 		this.onCancelSelect = onCancelSelect;
-		this.onSelectAsDefault = onSelectAsDefault;
 		this.allItems = availableLevels.map((level) => ({
 			value: level,
 			label: `${level === currentLevel ? "✓ " : "  "}${level}`,
@@ -65,7 +62,7 @@ export class ThinkingSelectorComponent extends Container implements Focusable {
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
 		this.addChild(new Text("Thinking Level", 0, 0));
-		this.addChild(new Text(`${keyDisplayText("app.thinking.cycle")} cycles thinking levels in-session`, 0, 0));
+		this.addChild(new Text(`${keyDisplayText("app.thinking.cycle")} cycles thinking levels`, 0, 0));
 		this.addChild(new Spacer(1));
 		this.searchInput = new Input();
 		this.searchInput.onSubmit = () => this.selectList.handleInput("\r");
@@ -78,7 +75,7 @@ export class ThinkingSelectorComponent extends Container implements Focusable {
 			new Text(
 				theme.fg(
 					"dim",
-					`  ${keyDisplayText("tui.select.confirm")} to select · ${keyDisplayText("app.thinking.save")} to set as default · ${keyDisplayText("tui.select.cancel")} to cancel`,
+					`  ${keyDisplayText("tui.select.confirm")} to select · ${keyDisplayText("tui.select.cancel")} to cancel`,
 				),
 				0,
 				0,
@@ -108,11 +105,6 @@ export class ThinkingSelectorComponent extends Container implements Focusable {
 
 	handleInput(keyData: string): void {
 		const kb = getKeybindings();
-		if (kb.matches(keyData, "app.thinking.save") && this.onSelectAsDefault) {
-			const item = this.selectList.getSelectedItem();
-			if (item) this.onSelectAsDefault(item.value as ThinkingLevel);
-			return;
-		}
 		if (
 			kb.matches(keyData, "tui.select.up") ||
 			kb.matches(keyData, "tui.select.down") ||

--- a/packages/coding-agent/src/modes/interactive/interactive-editor-actions.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-editor-actions.ts
@@ -32,7 +32,7 @@ InteractiveModeBase.prototype.updateEditorBorderColor = function (this: Interact
 };
 
 InteractiveModeBase.prototype.cycleThinkingLevel = function (this: InteractiveModeBase): void {
-	const newLevel = this.session.cycleThinkingLevel();
+	const newLevel = this.session.cycleThinkingLevel({ persist: true });
 	if (newLevel === undefined) {
 		this.showStatus("Current model does not support thinking");
 	} else {
@@ -47,7 +47,7 @@ InteractiveModeBase.prototype.cycleModel = async function (
 	direction: "forward" | "backward",
 ): Promise<void> {
 	try {
-		const result = await this.session.cycleModel(direction);
+		const result = await this.session.cycleModel(direction, { persist: true });
 		if (result === undefined) {
 			const msg = this.session.scopedModels.length > 0 ? "Only one model in scope" : "Only one model available";
 			this.showStatus(msg);

--- a/packages/coding-agent/src/modes/interactive/interactive-input-handling.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-input-handling.ts
@@ -118,9 +118,6 @@ InteractiveModeBase.prototype.setupKeyHandlers = function (this: InteractiveMode
 	});
 	this.defaultEditor.onAction("app.message.followUp", () => this.handleFollowUp());
 	this.defaultEditor.onAction("app.message.dequeue", () => this.handleDequeue());
-	this.defaultEditor.onAction("app.message.copy", () => {
-		void this.handleCopyCommand({ preferSelection: true });
-	});
 	this.defaultEditor.onAction("app.session.new", () => this.handleClearCommand());
 	this.defaultEditor.onAction("app.session.tree", () => this.showTreeSelector());
 	this.defaultEditor.onAction("app.session.fork", () => this.showUserMessageSelector());

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-base.ts
@@ -239,15 +239,6 @@ export class InteractiveModeBase {
 		if (this.renderer.mode === "fullscreen") this.renderer.setCopyOnSelect(enabled);
 	}
 
-	getFullscreenCopyOnSelect(): boolean | undefined {
-		return this.renderer.mode === "fullscreen" ? this.renderer.getCopyOnSelect() : undefined;
-	}
-
-	async copyActiveFullscreenSelection(): Promise<boolean | undefined> {
-		if (this.renderer.mode !== "fullscreen" || !this.renderer.hasActiveSelection()) return undefined;
-		return this.renderer.copyActiveSelectionToClipboard();
-	}
-
 	private readonly onRightClickPaste = (): void => {
 		void this.handleRightClickPaste();
 	};

--- a/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode-surface.ts
@@ -332,7 +332,7 @@ declare module "./interactive-mode-base.ts" {
 		showSettingsSelector(): void;
 		handleModelCommand(searchTerm?: string): Promise<void>;
 		handleThinkingCommand(searchTerm?: string): void;
-		selectThinkingLevel(level: ThinkingLevel, persist: boolean): void;
+		selectThinkingLevel(level: ThinkingLevel): void;
 		showThinkingSelector(): void;
 		findExactModelMatch(searchTerm: string): Promise<Model<Api> | undefined>;
 		getModelCandidates(): Promise<Model<Api>[]>;
@@ -376,7 +376,7 @@ declare module "./interactive-mode-base.ts" {
 		getPathCommandArgument(text: string, command: "/export" | "/import"): string | undefined;
 		handleImportCommand(text: string): Promise<void>;
 		handleShareCommand(): Promise<void>;
-		handleCopyCommand(options?: { preferSelection?: boolean }): Promise<void>;
+		handleCopyCommand(): Promise<void>;
 		handleNameCommand(text: string): void;
 		handleSessionCommand(): void;
 		handleChangelogCommand(): void;
@@ -384,8 +384,6 @@ declare module "./interactive-mode-base.ts" {
 		getEditorKeyDisplay(action: Keybinding): string;
 		jumpToTranscriptEnd(): void;
 		setFullscreenCopyOnSelect(enabled: boolean): void;
-		getFullscreenCopyOnSelect(): boolean | undefined;
-		copyActiveFullscreenSelection(): Promise<boolean | undefined>;
 		handleHotkeysCommand(): void;
 		handleClearCommand(): Promise<void>;
 		handleDebugCommand(): void;

--- a/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-model-routing.ts
@@ -62,7 +62,7 @@ InteractiveModeBase.prototype.handleModelCommand = async function (
 	const model = await this.findExactModelMatch(searchTerm);
 	if (model) {
 		try {
-			await this.session.setModel(model);
+			await this.session.setModel(model, { persist: true });
 			this.footer.invalidate();
 			this.updateEditorBorderColor();
 			this.showStatus(`Model: ${model.id}`);
@@ -171,9 +171,9 @@ InteractiveModeBase.prototype.showModelSelector = function (
 			this.settingsManager,
 			this.session.modelRuntime,
 			this.session.scopedModels,
-			async (model, persist) => {
+			async (model) => {
 				try {
-					await this.session.setModel(model, { persist });
+					await this.session.setModel(model, { persist: true });
 					await this.updateAvailableProviderCount();
 					this.footer.invalidate();
 					this.updateEditorBorderColor();
@@ -255,15 +255,12 @@ InteractiveModeBase.prototype.showModelsSelector = function (this: InteractiveMo
 				onChange: (enabledIds) => {
 					selectionChanged = true;
 					updateSessionModels(enabledIds);
-				},
-				onPersist: (enabledIds) => {
 					const allEnabled =
 						enabledIds !== null &&
 						enabledIds.length === availableModels.length &&
 						enabledIds.every((id) => availableModelIds.has(id));
 					const newPatterns = enabledIds === null || allEnabled ? undefined : enabledIds;
 					this.settingsManager.setEnabledModels(newPatterns ? [...newPatterns] : undefined);
-					this.showStatus("Model selection saved to settings");
 				},
 				onCancel: () => {
 					done();
@@ -387,24 +384,20 @@ InteractiveModeBase.prototype.handleThinkingCommand = function (this: Interactiv
 		this.showError(`Unknown thinking level "${searchTerm}". Available levels: ${levels.join(", ")}.`);
 		return;
 	}
-	this.selectThinkingLevel(level, false);
+	this.selectThinkingLevel(level);
 };
 
-InteractiveModeBase.prototype.selectThinkingLevel = function (
-	this: InteractiveModeBase,
-	level: ThinkingLevel,
-	persist: boolean,
-): void {
-	this.session.setThinkingLevel(level, { persist });
+InteractiveModeBase.prototype.selectThinkingLevel = function (this: InteractiveModeBase, level: ThinkingLevel): void {
+	this.session.setThinkingLevel(level, { persist: true });
 	this.footer.invalidate();
 	this.updateEditorBorderColor();
-	this.showStatus(persist ? `Default thinking level: ${level}` : `Thinking level: ${level}`);
+	this.showStatus(`Thinking level: ${level}`);
 };
 
 InteractiveModeBase.prototype.showThinkingSelector = function (this: InteractiveModeBase): void {
 	this.showSelector((done) => {
-		const select = (level: ThinkingLevel, persist: boolean) => {
-			this.selectThinkingLevel(level, persist);
+		const select = (level: ThinkingLevel) => {
+			this.selectThinkingLevel(level);
 			done();
 		};
 		const model = this.session.model;
@@ -413,9 +406,8 @@ InteractiveModeBase.prototype.showThinkingSelector = function (this: Interactive
 		const selector = new ThinkingSelectorComponent(
 			this.session.thinkingLevel,
 			availableLevels,
-			(level) => select(level, false),
+			select,
 			() => done(),
-			(level) => select(level, true),
 			resolveThinkingSelectorDefault(rawDefault, availableLevels, model),
 		);
 		return { component: selector, focus: selector };

--- a/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-selectors.ts
@@ -135,7 +135,7 @@ InteractiveModeBase.prototype.showSettingsSelector = function (this: Interactive
 					this.settingsManager.setBashInterceptorEnabled(enabled);
 				},
 				onThinkingLevelChange: (level) => {
-					this.session.setThinkingLevel(level);
+					this.session.setThinkingLevel(level, { persist: true });
 					this.footer.invalidate();
 					this.updateEditorBorderColor();
 				},

--- a/packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-slash-commands.ts
@@ -310,15 +310,7 @@ InteractiveModeBase.prototype.handleShareCommand = async function (this: Interac
 	}
 };
 
-InteractiveModeBase.prototype.handleCopyCommand = async function (
-	this: InteractiveModeBase,
-	options: { preferSelection?: boolean } = {},
-): Promise<void> {
-	if (options.preferSelection && this.getFullscreenCopyOnSelect() === false) {
-		const selectionCopied = await this.copyActiveFullscreenSelection();
-		if (selectionCopied !== undefined) return;
-	}
-
+InteractiveModeBase.prototype.handleCopyCommand = async function (this: InteractiveModeBase): Promise<void> {
 	const text = this.session.getLastAssistantText();
 	if (!text) {
 		this.showError("No agent messages to copy yet.");

--- a/packages/coding-agent/test/interactive-automatic-model-defaults.test.ts
+++ b/packages/coding-agent/test/interactive-automatic-model-defaults.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeAll, test, vi } from "vitest";
+import { KEYBINDINGS } from "../src/core/keybindings.js";
+import { InteractiveModeBase } from "../src/modes/interactive/interactive-mode-base.js";
+import "../src/modes/interactive/interactive-model-routing.js";
+import "../src/modes/interactive/interactive-editor-actions.js";
+import { initTheme } from "../src/modes/interactive/theme/theme.js";
+import { createHarness, type Harness } from "./suite/harness.js";
+
+let harness: Harness;
+beforeAll(() => initTheme("dark"));
+afterEach(() => harness?.cleanup());
+
+async function createMode() {
+	harness = await createHarness({
+		models: [
+			{ id: "first", reasoning: true },
+			{ id: "second", reasoning: true },
+			{ id: "plain", reasoning: false },
+		],
+	});
+	return {
+		session: harness.session,
+		footer: { invalidate: () => {} },
+		updateEditorBorderColor: () => {},
+		showStatus: () => {},
+		showError: vi.fn(),
+		maybeWarnAboutAnthropicSubscriptionAuth: async () => {},
+		checkDaxnutsEasterEgg: () => {},
+		findExactModelMatch: async (id: string) => harness.getModel(id),
+		selectThinkingLevel: InteractiveModeBase.prototype.selectThinkingLevel,
+	};
+}
+
+function assertDefaults(modelId: string, level: string) {
+	assert.equal(harness.settingsManager.getDefaultProvider(), harness.session.model?.provider);
+	assert.equal(harness.settingsManager.getDefaultModel(), modelId);
+	assert.equal(harness.settingsManager.getDefaultThinkingLevel(), level);
+	assert.equal(harness.settingsManager.getModelThinkingLevel(harness.session.model!.provider, modelId), level);
+}
+
+test("removed actions are absent from the keybinding registry", () => {
+	for (const action of ["app.message.copy", "app.models.save", "app.thinking.save"]) {
+		assert.equal(Object.hasOwn(KEYBINDINGS, action), false);
+	}
+});
+
+test("model and thinking commands automatically persist the last user choices", async () => {
+	const mode = await createMode();
+	await InteractiveModeBase.prototype.handleModelCommand.call(mode as never, "second");
+	InteractiveModeBase.prototype.handleThinkingCommand.call(mode as never, "high");
+	assertDefaults("second", "high");
+	InteractiveModeBase.prototype.handleThinkingCommand.call(mode as never, "low");
+	assertDefaults("second", "low");
+	assert.equal(mode.showError.mock.calls.length, 0);
+});
+
+test("available and scoped model cycling persist the model and effective thinking level", async () => {
+	const mode = await createMode();
+	harness.session.setThinkingLevel("high");
+	await InteractiveModeBase.prototype.cycleModel.call(mode as never, "forward");
+	assertDefaults("second", "high");
+	harness.session.setScopedModels([
+		{ model: harness.getModel("first")!, thinkingLevel: "low" },
+		{ model: harness.getModel("second")!, thinkingLevel: "high" },
+	]);
+	await InteractiveModeBase.prototype.cycleModel.call(mode as never, "backward");
+	assertDefaults("first", "low");
+	InteractiveModeBase.prototype.cycleThinkingLevel.call(mode as never);
+	assertDefaults("first", harness.session.thinkingLevel);
+});
+
+test("model switching saves the capability-clamped thinking level", async () => {
+	const mode = await createMode();
+	harness.session.setThinkingLevel("high");
+	await InteractiveModeBase.prototype.handleModelCommand.call(mode as never, "plain");
+	assertDefaults("plain", "off");
+});
+
+test("programmatic changes do not replace the user's defaults", async () => {
+	const mode = await createMode();
+	await InteractiveModeBase.prototype.handleModelCommand.call(mode as never, "second");
+	InteractiveModeBase.prototype.handleThinkingCommand.call(mode as never, "high");
+	await harness.session.setModel(harness.getModel("first")!);
+	harness.session.setThinkingLevel("low");
+	assert.equal(harness.settingsManager.getDefaultModel(), "second");
+	assert.equal(harness.settingsManager.getDefaultThinkingLevel(), "high");
+});
+
+test("failed user model selection leaves defaults unchanged", async () => {
+	const mode = await createMode();
+	await InteractiveModeBase.prototype.handleModelCommand.call(mode as never, "second");
+	vi.spyOn(harness.session.modelRuntime, "hasConfiguredAuth").mockReturnValue(false);
+	await InteractiveModeBase.prototype.handleModelCommand.call(mode as never, "first");
+	assert.equal(harness.settingsManager.getDefaultModel(), "second");
+	assert.equal(mode.showError.mock.calls.length, 1);
+});

--- a/packages/coding-agent/test/interactive-scoped-models-refresh.test.ts
+++ b/packages/coding-agent/test/interactive-scoped-models-refresh.test.ts
@@ -145,17 +145,28 @@ describe("scoped models cache-first refresh", () => {
 
 	it("uses settings saved while refresh is in flight", async () => {
 		const cached = model("cached", "Cached");
+		const otherCached = model("other", "Other Cached");
 		const refreshed = model("refreshed", "Refreshed");
-		const refresh = await openSelector([cached], { configuredPatterns: ["cached-provider/*"] });
+		const refresh = await openSelector([cached, otherCached], {
+			configuredPatterns: ["cached-provider/cached"],
+		});
+		expect(stripAnsi(refresh.selector.render(100).join("\n"))).toContain("1/2 enabled");
+		expect(refresh.setEnabledModels).not.toHaveBeenCalled();
 
-		refresh.selector.handleInput("\x13");
-		expect(refresh.setEnabledModels).toHaveBeenCalledWith(undefined);
+		// Enable all while the refresh is pending; the change saves automatically.
+		refresh.selector.handleInput("\x01");
+		expect(refresh.setEnabledModels).toHaveBeenCalledExactlyOnceWith(undefined);
+		expect(refresh.setScopedModels).toHaveBeenCalledExactlyOnceWith([]);
 
-		refresh.complete([cached, refreshed], { aborted: false, errors: new Map() });
+		refresh.complete([cached, otherCached, refreshed], { aborted: false, errors: new Map() });
 		await vi.waitFor(() => {
 			const rendered = stripAnsi(refresh.selector.render(100).join("\n"));
+			expect(rendered).toContain("Model catalogs refreshed.");
+			expect(rendered).toContain("✓ refreshed [cached-provider]");
 			expect(rendered).toContain("all enabled");
 		});
+		expect(refresh.setEnabledModels).toHaveBeenCalledExactlyOnceWith(undefined);
+		expect(refresh.setScopedModels).toHaveBeenCalledExactlyOnceWith([]);
 	});
 
 	it("keeps a user-selected cached scope when refresh drops its model", async () => {

--- a/packages/coding-agent/test/interactive-tui.test.ts
+++ b/packages/coding-agent/test/interactive-tui.test.ts
@@ -556,8 +556,6 @@ interface CopyCommandContext {
 	ui: ReturnType<typeof createInteractiveTui>;
 	showStatus(message: string): void;
 	showError(message: string): void;
-	getFullscreenCopyOnSelect(): boolean | undefined;
-	copyActiveFullscreenSelection(): Promise<boolean | undefined>;
 }
 
 type CopyCommandPrototype = Pick<InteractiveMode, "handleCopyCommand">;
@@ -630,58 +628,12 @@ describe("InteractiveMode /copy confirmation", () => {
 			}),
 			showStatus: vi.fn(),
 			showError: vi.fn(),
-			getFullscreenCopyOnSelect: () => true,
-			copyActiveFullscreenSelection: vi.fn(async () => undefined),
 		};
 		await copyCommandPrototype.handleCopyCommand.call(context);
 
 		expect(context.showStatus).toHaveBeenCalledWith("Copied last agent message to clipboard");
 		expect(clipboardMocks.copyToClipboard).toHaveBeenCalledWith("assistant response");
 		expect(context.showError).not.toHaveBeenCalled();
-	});
-
-	test("main-editor copy prefers a retained selection only when automatic copy is disabled", async () => {
-		const selectionCopy = vi.fn(async () => true);
-		const context: CopyCommandContext = {
-			session: { getLastAssistantText: () => "assistant response" },
-			ui: createInteractiveTui({
-				showHardwareCursor: false,
-				logDirectory: "/tmp",
-				terminal: new RecordingTerminal(),
-			}),
-			showStatus: vi.fn(),
-			showError: vi.fn(),
-			getFullscreenCopyOnSelect: () => false,
-			copyActiveFullscreenSelection: selectionCopy,
-		};
-
-		await copyCommandPrototype.handleCopyCommand.call(context, { preferSelection: true });
-
-		expect(selectionCopy).toHaveBeenCalledOnce();
-		expect(clipboardMocks.copyToClipboard).not.toHaveBeenCalled();
-	});
-
-	test("enabled copy-on-select and absent selections fall back to the last assistant message", async () => {
-		for (const { copyOnSelect, selectionResult } of [
-			{ copyOnSelect: true, selectionResult: true },
-			{ copyOnSelect: false, selectionResult: undefined },
-		]) {
-			clipboardMocks.copyToClipboard.mockClear();
-			const context: CopyCommandContext = {
-				session: { getLastAssistantText: () => "assistant response" },
-				ui: createInteractiveTui({
-					showHardwareCursor: false,
-					logDirectory: "/tmp",
-					terminal: new RecordingTerminal(),
-				}),
-				showStatus: vi.fn(),
-				showError: vi.fn(),
-				getFullscreenCopyOnSelect: () => copyOnSelect,
-				copyActiveFullscreenSelection: vi.fn(async () => selectionResult),
-			};
-			await copyCommandPrototype.handleCopyCommand.call(context, { preferSelection: true });
-			expect(clipboardMocks.copyToClipboard).toHaveBeenCalledWith("assistant response");
-		}
 	});
 });
 type WorkingLoaderStopContext = {

--- a/packages/coding-agent/test/model-selector.test.ts
+++ b/packages/coding-agent/test/model-selector.test.ts
@@ -59,8 +59,7 @@ describe("model selector", () => {
 		selector.dispose();
 	});
 
-	it("uses the configured save binding", async () => {
-		setKeybindings(new KeybindingsManager({ "app.models.save": "ctrl+r" }));
+	it("has no save-default shortcut or hint", async () => {
 		harness = await createHarness();
 		const currentModel = harness.getModel()!;
 		const saveDefault = vi.fn();
@@ -74,11 +73,11 @@ describe("model selector", () => {
 			() => {},
 		);
 
-		expect(stripAnsi(selector.render(120).join("\n"))).toContain("ctrl+r set as default");
+		expect(stripAnsi(selector.render(120).join("\n"))).not.toContain("set as default");
 		selector.handleInput("\x13");
 		expect(saveDefault).not.toHaveBeenCalled();
-		selector.handleInput("\x12");
-		expect(saveDefault).toHaveBeenCalledWith(currentModel, true);
+		selector.handleInput("\r");
+		expect(saveDefault).toHaveBeenCalledWith(currentModel);
 		selector.dispose();
 	});
 });

--- a/packages/coding-agent/test/rpc-model-persist-boundary.test.ts
+++ b/packages/coding-agent/test/rpc-model-persist-boundary.test.ts
@@ -320,6 +320,9 @@ describe("RPC persist boundary", () => {
 		assert.equal(engine.settingsManager.getDefaultModel(), "faux-2");
 		assert.equal(host.settingsManager.getDefaultProvider(), next.provider);
 		assert.equal(host.settingsManager.getDefaultModel(), "faux-2");
+		assert.equal(engine.settingsManager.getDefaultThinkingLevel(), engine.session.thinkingLevel);
+		assert.equal(host.settingsManager.getDefaultThinkingLevel(), engine.session.thinkingLevel);
+		assert.equal(host.settingsManager.getModelThinkingLevel(next.provider, next.id), engine.session.thinkingLevel);
 	});
 
 	it("does not save settings defaults when the isolated engine proxy setModel omits persist", async () => {
@@ -532,5 +535,7 @@ describe("RPC persist boundary", () => {
 		assert.equal(engine.session.model?.id, "faux-2");
 		assert.equal(engine.settingsManager.getDefaultModel(), "faux-2");
 		assert.equal(host.settingsManager.getDefaultModel(), "faux-2");
+		assert.equal(host.settingsManager.getDefaultThinkingLevel(), result?.thinkingLevel);
+		assert.equal(engine.settingsManager.getDefaultThinkingLevel(), result?.thinkingLevel);
 	});
 });

--- a/packages/coding-agent/test/scoped-models-selector.test.ts
+++ b/packages/coding-agent/test/scoped-models-selector.test.ts
@@ -51,7 +51,6 @@ describe("scoped models selector", () => {
 						model.enabled = enabledModelIds === null || enabledModelIds.includes(`${provider}/${model.id}`);
 					}
 				},
-				onPersist: () => {},
 				onCancel: () => {},
 			},
 		);

--- a/packages/coding-agent/test/suite/regressions/3217-scoped-model-order.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3217-scoped-model-order.test.ts
@@ -56,7 +56,6 @@ describe("issue #3217 scoped model ordering", () => {
 				onChange: (enabledModelIds) => {
 					changes.push(enabledModelIds);
 				},
-				onPersist: () => {},
 				onCancel: () => {},
 			},
 		);
@@ -114,7 +113,6 @@ describe("issue #3217 scoped model ordering", () => {
 				onChange: (enabledModelIds) => {
 					changes.push(enabledModelIds);
 				},
-				onPersist: () => {},
 				onCancel: () => {},
 			},
 		);

--- a/packages/coding-agent/test/thinking-selector-default.test.ts
+++ b/packages/coding-agent/test/thinking-selector-default.test.ts
@@ -62,13 +62,11 @@ test("selector badges the clamped default rather than leaving no item marked", (
 		available,
 		() => {},
 		() => {},
-		() => {},
 		rawDefault,
 	);
 	const clamped = new ThinkingSelectorComponent(
 		"off",
 		available,
-		() => {},
 		() => {},
 		() => {},
 		resolveThinkingSelectorDefault(rawDefault, available, model),
@@ -140,20 +138,13 @@ test("keeps the current thinking level marked while browsing", () => {
 	expect(getLevelRow("high")?.startsWith("→   high")).toBe(true);
 });
 
-test("uses the configured save binding", () => {
-	setKeybindings(new KeybindingsManager({ "app.thinking.save": "ctrl+r" }));
-	const saveDefault = vi.fn();
-	const selector = new ThinkingSelectorComponent(
-		"medium",
-		["medium", "high"],
-		() => {},
-		() => {},
-		saveDefault,
-	);
-
-	expect(stripAnsi(selector.render(120).join("\n"))).toContain("ctrl+r to set as default");
+test("has no save-default shortcut or hint", () => {
+	setKeybindings(new KeybindingsManager());
+	const select = vi.fn();
+	const selector = new ThinkingSelectorComponent("medium", ["medium", "high"], select, () => {});
+	expect(stripAnsi(selector.render(120).join("\n"))).not.toContain("set as default");
 	selector.handleInput("\x13");
-	expect(saveDefault).not.toHaveBeenCalled();
-	selector.handleInput("\x12");
-	expect(saveDefault).toHaveBeenCalledWith("medium");
+	expect(select).not.toHaveBeenCalled();
+	selector.handleInput("\r");
+	expect(select).toHaveBeenCalledWith("medium");
 });


### PR DESCRIPTION
## Summary

Restore automatic saving of user-selected models and thinking levels, and remove the copy shortcut that conflicts with workflow Ctrl+X navigation.

## Changes

- Remove the Ctrl+X copy-message/selection action and its handler. Preserve workflow hierarchy navigation, `/copy`, and automatic mouse-selection copying.
- Remove Ctrl+S save-default shortcuts, callbacks, and UI from model and thinking selectors.
- Persist interactive model/thinking choices automatically through commands, selectors, `/settings`, and cycling shortcuts. Save capability-clamped thinking levels and keep isolated host settings synchronized with the engine.
- Save scoped-model cycle-list changes immediately, without a separate save action.
- Keep SDK/RPC mutations session-only unless persistence is explicitly requested. Automatic fallback and restoration paths remain non-persisting.
- Update documentation, changelog, and regression tests.

## Compatibility

The `app.message.copy`, `app.models.save`, and `app.thinking.save` actions are removed. Ctrl+X no longer copies retained fullscreen selections; `/copy` still copies the last assistant message. Ctrl+S session sorting and Ctrl+X scoped-model clearing are unrelated and unchanged.

## Validation

- 99 focused coding-agent tests passed across 15 files.
- 36 workflow-navigation and model-fallback tests passed across 3 files.
- Root and coding-agent typechecks passed.
- All applicable pre-commit hooks passed, including `npm run check` and Biome.
- Shrinkwrap validation and `git diff --check` passed.

Root tests reused the original checkout's unchanged native binding after the fresh worktree's native setup failed. No native source changes are included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791177703&installation_model_id=10562&pr_number=2870&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2870&signature=93a88aaee683b67d675b1b4bd4cdef96863ef466ed43f43c29389724d2a16757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores automatic persistence for interactive model, thinking-level, and scoped-model choices while keeping SDK/RPC mutations session-only unless persistence is requested. It also removes the Ctrl+S save actions and the Ctrl+X copy action, retaining `/copy` and mouse-selection copying.

- Propagates explicit persistence through model switching, model cycling, thinking selection, and thinking cycling.
- Synchronizes persisted model and effective thinking defaults across the isolated interactive-engine boundary.
- Saves scoped-model changes immediately and removes dirty/save UI state.
- Updates user documentation and regression coverage for the revised behavior.

<h3>Confidence Score: 4/5</h3>

The behavioral changes appear sound, but the explicit coding-agent test convention must be satisfied before merging.

Model and thinking persistence boundaries, clamping, isolated synchronization, scoped-model autosave, and shortcut removal are consistently implemented and covered; the only accepted issue is the new test’s violation of required package-specific conventions.

**Files Needing Attention:** packages/coding-agent/test/interactive-automatic-model-defaults.test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/coding-agent/src/core/agent-session-models.ts | Propagates persistence through model changes and saves both global and per-model effective thinking defaults. |
| packages/coding-agent/src/modes/interactive-engine/isolated-runtime.ts | Mirrors persisted model and capability-clamped thinking state from the isolated engine to host settings. |
| packages/coding-agent/src/modes/interactive/interactive-model-routing.ts | Makes interactive model, thinking, and scoped-model choices persist automatically. |
| packages/coding-agent/src/core/keybindings.ts | Removes the obsolete copy and explicit save-default action registrations. |
| packages/coding-agent/test/interactive-automatic-model-defaults.test.ts | Adds broad automatic-default regression coverage but violates the coding-agent test assertion and import conventions. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  User[Interactive user choice] --> Surface{Interactive surface}
  Surface -->|Model command, selector, or cycle| ModelMutation[Model mutation with persist=true]
  Surface -->|Thinking command, selector, settings, or cycle| ThinkingMutation[Thinking mutation with persist=true]
  Surface -->|Scoped-model edit| ScopeMutation[Update session scope]
  ModelMutation --> Clamp[Resolve and clamp effective thinking level]
  Clamp --> ModelDefaults[Save provider and model defaults]
  Clamp --> ThinkingDefaults[Save global and per-model thinking defaults]
  ThinkingMutation --> ThinkingDefaults
  ScopeMutation --> ScopeDefaults[Save enabled-model patterns immediately]
  ModelMutation -->|Isolated runtime| Engine[Persist in engine]
  Engine --> HostSync[Mirror catalog and defaults to host]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/test/interactive-automatic-model-defaults.test.ts:1-8
**Test conventions are violated**

This new coding-agent test uses `node:assert/strict`, `assert.equal`, and `.js` relative import specifiers. Tests under `packages/coding-agent/test/` are required to use Vitest `expect` assertions and `.ts` relative import specifiers. This repository requirement must be satisfied before merging; the same pattern continues through the assertions on lines 35–97.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(coding-agent): restore automatic mod..."](https://github.com/bastani-inc/atomic/commit/b904230a0dcb5c1988700bfcd728795d912209a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60689288)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - For tests under packages/coding-agent/test/, follo... ([source](https://app.greptile.com/bastani-inc/github/bastani-inc/atomic/-/custom-context?memory=be6d0f11-42ea-4577-b84f-332cded4f9a9))
- Knowledge Base — [Coding agent application](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/coding-agent.md)
- Knowledge Base — [Coding agent startup and sessions](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/coding-agent-startup-and-sessions.md)
</details>


<!-- /greptile_comment -->