### PR TITLE
fix(workflows): stop pending-stage warnings corrupting the UI

### DIFF
--- a/packages/coding-agent/docs/workflows/operations.md
+++ b/packages/coding-agent/docs/workflows/operations.md
@@ -561,6 +561,8 @@ The supported explicit recovery route is operator reconciliation followed, if au
 
 Set `ATOMIC_POSTGRES_RUNTIME_DIR` to a complete extracted runtime containing `bin/initdb`, `bin/pg_ctl`, and `bin/postgres` to override packaged runtime discovery, including in air-gapped deployments. Otherwise DBOS/Postgres durability requires no setup on supported local platforms. To use an existing Postgres database, set `DBOS_SYSTEM_DATABASE_URL` before starting Atomic; that explicit URL retains precedence over embedded provisioning. Atomic provisions embedded Postgres next (with drop-privilege support when running as root on Linux), then Docker as a platform fallback. The DBOS SDK ships with `@bastani/atomic`. If no durable backend can be provisioned, workflows run on a process-local in-memory backend with a loud non-durable warning — never on the legacy per-workflow file store under `~/.atomic/workflow-durable` — and cross-process resume is unavailable until Postgres provisioning is fixed. Interactive and RPC actions show the warning as a display-only notification that is not added to agent/model context. Print and other headless actions, where no usable UI exists, write the actionable diagnostic to the console instead.
 
+Pending-stage Intercom cleanup checks durable ownership only for runs with messages that need settlement. Repeated failures with the same message produce one warning per extension instance. Interactive hosts receive a display-only notification, never a console stack trace, even if notification delivery fails; headless hosts retain a console diagnostic. Pending messages are not discarded when cleanup fails.
+
 ```bash
 export DBOS_SYSTEM_DATABASE_URL="postgresql://user:password@localhost:5432/atomic_dbos_sys"
 ```

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Pending-stage Intercom settlement now skips unrelated runs with no messages to settle. Genuine sweep failures produce one display-only warning per distinct message in interactive sessions instead of repeated console stack traces; headless sessions retain console diagnostics, and pending messages remain available for recovery.
+
 ## [0.9.18-alpha.6] - 2026-09-04
 
 ### Breaking Changes

--- a/packages/workflows/src/extension/pending-stage-intercom.ts
+++ b/packages/workflows/src/extension/pending-stage-intercom.ts
@@ -26,6 +26,8 @@ import {
 	parseWorkflowStageTarget,
 	type WorkflowStageTarget,
 } from "../shared/workflow-stage-target.js";
+import type { ExtensionAPI } from "./public-types.js";
+import { createWorkflowBackgroundWarningReporter } from "./workflow-background-warning.js";
 
 const PENDING_STAGE_ROUTE_EVENT = "atomic:workflow-pending-stage-route";
 const PENDING_STAGE_MESSAGE_EVENT = "atomic:workflow-pending-stage-message";
@@ -40,7 +42,7 @@ interface WorkflowEventSurface {
 		emit?(event: string, payload: Record<string, unknown>): void;
 		on?(event: string, listener: (payload: unknown) => void): unknown;
 	};
-	on?(event: "session_shutdown", listener: () => void): void;
+	on?: ExtensionAPI["on"];
 }
 
 interface PendingStageMessageEvent {
@@ -80,6 +82,7 @@ interface PendingStageUndeliverableEvent extends Record<string, unknown> {
 export function registerPendingStageIntercomBridge(pi: WorkflowEventSurface, activeStore: Store): () => void {
 	let disposed = false;
 	let sweepPromise: Promise<void> = Promise.resolve();
+	const reportWarning = createWorkflowBackgroundWarningReporter(pi);
 	const notifyUndeliverable = async (
 		entry: PendingStageMessage,
 		reason: string,
@@ -137,7 +140,9 @@ export function registerPendingStageIntercomBridge(pi: WorkflowEventSurface, act
 		sweepPromise = sweepPromise
 			.then(() => settleUndeliverablePendingStageMessages(activeStore, notifyUndeliverable))
 			.then(() => undefined)
-			.catch((error: Error) => console.warn("atomic-workflows: pending stage delivery sweep failed", error));
+			.catch((error: Error) =>
+				reportWarning(`atomic-workflows: pending stage delivery sweep failed: ${error.message}`),
+			);
 	};
 	const unsubscribeStore = activeStore.subscribeInvalidation(announceRoutes);
 	announceRoutes();
@@ -758,6 +763,8 @@ export async function settleUndeliverablePendingStageMessages(
 	let settled = 0;
 	const rootBackend = getDurableBackend();
 	for (const run of runs) {
+		// Retained/partial runs with no settlement work need no durable owner.
+		if (!run.pendingStageMessages?.some((entry) => needsUndeliverableSettlement(run, entry))) continue;
 		const backend = durableBackendForRun(rootBackend, runs, run.id);
 		if (backend === undefined) {
 			throw new Error(`atomic-workflows: workflow run ${run.id} has no durable owner for pending-stage settlement`);

--- a/packages/workflows/src/extension/workflow-background-warning.ts
+++ b/packages/workflows/src/extension/workflow-background-warning.ts
@@ -1,0 +1,34 @@
+import type { ExtensionAPI, PiCommandContext } from "./public-types.js";
+
+/** Background failures must never write over an interactive host's terminal. */
+export function createWorkflowBackgroundWarningReporter(pi: Pick<ExtensionAPI, "on">): (message: string) => void {
+	let context: PiCommandContext | undefined;
+	const pending = new Set<string>();
+	const reported = new Set<string>();
+	const report = (message: string): void => {
+		if (reported.has(message)) return;
+		// Extension registration precedes session_start. Wait for the host mode,
+		// rather than treating the engine child's non-TTY stdout as headless.
+		if (context === undefined && pi.on !== undefined) {
+			pending.add(message);
+			return;
+		}
+		reported.add(message);
+		if (context?.hasUI !== false && typeof context?.ui?.notify === "function") {
+			try {
+				context.ui.notify(message, "warning");
+			} catch {
+				// A broken UI sink does not authorize writing to its terminal transport.
+			}
+			return;
+		}
+		if (context?.hasUI === true) return;
+		console.warn(message);
+	};
+	pi.on?.("session_start", (_event, ctx) => {
+		context = ctx;
+		for (const message of pending) report(message);
+		if (ctx !== undefined) pending.clear();
+	});
+	return report;
+}

--- a/test/unit/workflow-background-warning.test.ts
+++ b/test/unit/workflow-background-warning.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { afterEach, test, vi } from "vitest";
+import type { ExtensionAPI, PiCommandContext } from "../../packages/workflows/src/extension/public-types.js";
+import { createWorkflowBackgroundWarningReporter } from "../../packages/workflows/src/extension/workflow-background-warning.js";
+
+const WARNING = "atomic-workflows: pending stage delivery sweep failed: missing durable owner";
+
+afterEach(() => vi.restoreAllMocks());
+
+function fixture() {
+	const handlers = new Map<string, Parameters<NonNullable<ExtensionAPI["on"]>>[1]>();
+	const report = createWorkflowBackgroundWarningReporter({ on: (event, handler) => handlers.set(event, handler) });
+	const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+	const error = vi.spyOn(console, "error").mockImplementation(() => {});
+	const log = vi.spyOn(console, "log").mockImplementation(() => {});
+	return { report, warn, error, log, start: (ctx: PiCommandContext) => handlers.get("session_start")?.({}, ctx) };
+}
+
+test("defers startup diagnostics until host context and deduplicates interactive UI warnings", () => {
+	const f = fixture();
+	const notifications: string[] = [];
+	f.report(WARNING);
+	f.report(WARNING);
+	assert.equal(f.warn.mock.calls.length, 0);
+	f.start({ hasUI: true, ui: { notify: (message) => notifications.push(message) } });
+	f.report(WARNING);
+	assert.deepEqual(notifications, [WARNING]);
+	assert.equal(f.warn.mock.calls.length, 0);
+	assert.equal(f.error.mock.calls.length, 0);
+	assert.equal(f.log.mock.calls.length, 0);
+});
+
+test("headless mode retains one console diagnostic even with a notify stub", () => {
+	const f = fixture();
+	const notify = vi.fn();
+	f.start({ hasUI: false, ui: { notify } });
+	f.report(WARNING);
+	f.report(WARNING);
+	assert.deepEqual(f.warn.mock.calls, [[WARNING]]);
+	assert.equal(notify.mock.calls.length, 0);
+});
+
+test("RPC/UI notification capability is used without relying on local TTY state", () => {
+	const f = fixture();
+	const notify = vi.fn();
+	f.start({ ui: { notify } });
+	f.report(WARNING);
+	assert.deepEqual(notify.mock.calls, [[WARNING, "warning"]]);
+	assert.equal(f.warn.mock.calls.length, 0);
+});
+
+test("a failing interactive notification sink never falls back to console", () => {
+	const f = fixture();
+	f.start({
+		hasUI: true,
+		ui: {
+			notify: () => {
+				throw new Error("UI disconnected");
+			},
+		},
+	});
+	assert.doesNotThrow(() => f.report(WARNING));
+	assert.equal(f.warn.mock.calls.length, 0);
+	assert.equal(f.error.mock.calls.length, 0);
+	assert.equal(f.log.mock.calls.length, 0);
+});

--- a/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
+++ b/test/unit/workflow-pending-stage-delivery-lifecycle.test.ts
@@ -207,8 +207,47 @@ describe("pending workflow stage delivery lifecycle", () => {
 			dispose = registerPendingStageIntercomBridge({}, activeStore);
 			await new Promise((resolve) => setImmediate(resolve));
 			assert.equal(warnings.length, 1);
-			assert.equal(warnings[0]?.[0], "atomic-workflows: pending stage delivery sweep failed");
-			assert.equal((warnings[0]?.[1] as Error | undefined)?.name, "DbosNotReadyError");
+			assert.match(String(warnings[0]?.[0]), /atomic-workflows: pending stage delivery sweep failed: /);
+			assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "queued");
+		} finally {
+			dispose();
+			console.warn = originalWarn;
+		}
+	});
+
+	test("ignores unrelated orphan runs when settling eligible messages", async () => {
+		const { activeStore, runId } = await lifecycleFixture("completed");
+		activeStore.recordRunStart({
+			id: testRunId("unrelated-orphan-with-no-pending-messages"),
+			name: "orphan",
+			inputs: {},
+			status: "completed",
+			stages: [],
+			startedAt: 0,
+			parentRunId: testRunId("missing-parent"),
+			parentStageId: "missing-boundary",
+		});
+		assert.equal(await settleUndeliverablePendingStageMessages(activeStore, async () => true), 1);
+		const entry = activeStore.runs().find((run) => run.id === runId)?.pendingStageMessages?.[0];
+		assert.equal(entry?.status, "undeliverable");
+		assert.equal(typeof entry?.undeliverableNotifiedAt, "string");
+	});
+
+	test("deduplicates repeated sweep failures without discarding pending work", async () => {
+		const { activeStore, runId } = await lifecycleFixture("completed");
+		setDurableBackend(undefined);
+		resetDbosLifecycleForTests();
+		const warnings: string[] = [];
+		const originalWarn = console.warn;
+		console.warn = (message: string) => {
+			warnings.push(message);
+		};
+		const dispose = registerPendingStageIntercomBridge({}, activeStore);
+		try {
+			await new Promise((resolve) => setImmediate(resolve));
+			activeStore.recordRunEnd(runId, "failed");
+			await new Promise((resolve) => setImmediate(resolve));
+			assert.equal(warnings.length, 1);
 			assert.equal(activeStore.runs()[0]?.pendingStageMessages?.[0]?.status, "queued");
 		} finally {
 			dispose();


### PR DESCRIPTION
## Summary

Fix repeated pending-stage Intercom cleanup warnings printing stack traces over the interactive UI.

## Changes

- Check each run for eligible settlement work before resolving its durable owner, so unrelated retained/orphan runs cannot fail the sweep.
- Route genuine failures through a host-context-aware display-only notification. Wait for session_start rather than inferring headless mode from the isolated engine stdout.
- Deduplicate identical warnings and never fall back to console when an interactive UI sink fails. Headless execution retains a console diagnostic.
- Preserve pending messages on genuine failures and document the behavior.

## Validation

- 95 focused tests passed across pending routing, lifecycle, sticky delivery, UI/headless warning policy, durability, status listing, and import graph tests.
- npm run check passed, including both typecheck passes and shrinkwrap validation.
- Normal commit hooks passed; signed commit.
- Independent read-only debugger review found no blocking issues.

This is the requested prerequisite fix before publishing the corrected prerelease. The earlier alpha.6 publisher was cancelled; this PR does not move or publish tags.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791185360&installation_model_id=10562&pr_number=2872&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2872&signature=8a9097c88b1c834d32f06275f74864dd52a15ee2d8e6749eeca530667739d6bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change prevents pending-stage settlement warnings from corrupting interactive terminal output while retaining durable queued messages for recovery. It skips durable-owner resolution when no settlement work exists and routes genuine interactive failures through display-only notifications while preserving deduplicated diagnostics for headless sessions.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the exercised warning-routing and durable-settlement paths behaved as intended, with no issues found.

Direct runtime checks confirmed that interactive warnings are deferred to the host notification surface without console output, headless warnings remain deduplicated, and settlement retains queued work when durable ownership cannot be resolved.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the pending-stage-intercom runtime harness for baseline and current revision, confirming the baseline emitted a durable-owner settlement warning while the current revision deferred the warning and produced exactly one interactive warning plus one headless warning after repeated invalidations.
- T-Rex performed an in-memory durable-backend check for pending-stage settlement, showing zero settlement when there is no eligible work and no installed durable backend, and safe failure with a queued message when a durable owner cannot be resolved.
- T-Rex ran the baseline and HEAD sources through the Vite SSR harness and observed a before/after log sequence, four passing reporter tests, and a focused test attempt blocked by a missing local AI compatibility build.
- T-Rex confirmed that no eligible settlement work skips the durable-owner lookup and that eligible work requires a resolvable durable owner, with a queued message preserved after resolution failure, while a focused lifecycle test collection was safely blocked by the missing build.

<a href="https://app.greptile.com/trex/runs/22667245/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): stop pending-stage warni..."](https://github.com/bastani-inc/atomic/commit/89518de65d97b250853d410b03723b334edf3c10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60705592)</sub>

**Context used:**

- Knowledge Base — [Workflow system](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/workflow-system.md)
- Knowledge Base — [Intercom messaging](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/intercom-messaging.md)

<!-- /greptile_comment -->