### PR TITLE
docs(changelog): include latest main in alpha.6 recovery

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,10 +4,6 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
-### Added
-
-- Added OpenRouter's `microsoft/mai-image-2.6` and `microsoft/mai-image-2.6-flash` image models from the Pi 0.85.1 catalog.
-
 ## [0.9.18-alpha.6] - 2026-09-04
 
 ### Breaking Changes
@@ -26,6 +22,8 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 - Added `zai-org/GLM-5.3-Fast` to the Baseten catalog from models.dev.
 - Added GPT-6-Astra to the generated OpenAI and OpenAI Codex catalogs with text and image input, 272,000 default input context, 128,000 maximum output, exact `low` through `max` reasoning efforts, tool search, additional tools, and the published $10 input / $1 cache read / $12.50 cache write / $50 output rates per million tokens. Requests above 272,000 aggregate input carry the published $20 / $2 / $25 / $75 request-wide tier. Amazon Bedrock also gains the exact Codex-advertised `openai.gpt-6-astra`, `global.openai.gpt-6-astra`, and `us.openai.gpt-6-astra` IDs, sends the selected reasoning effort through Converse, and uses zero catalog costs until AWS publishes Astra prices. The current OpenRouter catalog contributes `openai/gpt-6-astra` and `openai/gpt-6-astra-pro`; the Vercel AI Gateway contributes `openai/gpt-6-astra` and its provider-owned `openai/gpt-6-astra-fast`. Both dynamic catalogs retain their request-wide long-context prices. Azure OpenAI remains omitted because its authoritative catalog did not advertise Astra.
 - Added a provisional `github-copilot/gpt-6-astra` catalog entry using the Responses API, known Astra capabilities, and zero costs to mark unverified Copilot pricing. Copilot's own models.dev metadata takes precedence when present; account availability and fast sibling entitlement remain controlled by Copilot.
+
+- Added OpenRouter's `microsoft/mai-image-2.6` and `microsoft/mai-image-2.6-flash` image models from the Pi 0.85.1 catalog.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## [Unreleased]
 
-### Added
-
-- Fullscreen mouse-wheel scrolling moves five times as far while Alt is held, through the Pi TUI 0.85.1 update ([upstream #9166](https://github.com/earendil-works/pi/pull/9166)).
-
-### Changed
-
-- Updated Pi runtime dependencies to 0.85.1, preserving Atomic's CLI startup, published client API, and footer watcher behavior.
-
 ## [0.9.18-alpha.6] - 2026-09-04
 
 ### Breaking Changes
@@ -39,6 +31,8 @@
 - GPT-6-Astra is now selectable through OpenAI, OpenAI Codex, Amazon Bedrock, OpenRouter, and the Vercel AI Gateway. Atomic derives distinct `openai/gpt-6-astra-fast` and `openai-codex/gpt-6-astra-fast` identities through the existing fast-model catalog overlay. The Codex fast identity sends upstream model `gpt-6-astra` with `service_tier: priority` while preserving the `codex_cli_rs` originator, the `model=gpt-6-astra;tier=priority` routing hint, session restore identity, usage attribution, and 2× request-time price accounting. Bedrock publishes the direct, global, and US IDs unchanged and sends `low` through `max` reasoning effort. The current dynamic OpenRouter catalog contributes `openai/gpt-6-astra` and `openai/gpt-6-astra-pro`; Vercel contributes `openai/gpt-6-astra` and its own route-less `openai/gpt-6-astra-fast`. Astra accepts text and image input, supports 128,000 output tokens, and retains each provider's long-context pricing above 272,000 aggregate input tokens.
 - Added provisional GitHub Copilot Astra support. `github-copilot/gpt-6-astra-fast` is derived only when the OAuth account catalog advertises that exact ID, and sends the suffixed ID without an OpenAI priority tier. The fallback base entry uses known Astra capabilities and zero costs for unknown Copilot pricing; it does not establish service availability.
 
+- Fullscreen mouse-wheel scrolling moves five times as far while Alt is held, through the Pi TUI 0.85.1 update ([upstream #9166](https://github.com/earendil-works/pi/pull/9166)).
+
 ### Changed
 
 - Updated all upstream Pi runtime dependencies to 0.85.0.
@@ -57,6 +51,8 @@
 - OpenAI Responses models that advertise explicit prompt-cache support, including GPT-5.6 and GPT-6 Astra, now use `prompt_cache_options.ttl: "30m"` for long cache retention. Earlier Responses models retain `prompt_cache_retention: "24h"`; no-cache and short-cache requests continue to omit unsupported fields.
 
 - Interactive model and thinking selections, including cycling shortcuts, now automatically become startup defaults. Scoped-model cycle-list changes also save immediately. Removed the Ctrl+S save-default shortcuts and UI.
+
+- Updated Pi runtime dependencies to 0.85.1, preserving Atomic's CLI startup, published client API, and footer watcher behavior.
 
 ### Fixed
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,15 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-### Fixed
-
-- Pending-stage Intercom settlement now skips unrelated runs with no messages to settle. Genuine sweep failures produce one display-only warning per distinct message in interactive sessions instead of repeated console stack traces; headless sessions retain console diagnostics, and pending messages remain available for recovery.
-
-### Changed
-
-- Updated the bundled prompt-engineering skill with GPT-6 Astra prompting and API migration guidance, plus an attributed instruction audit covering concise skill descriptions, selective reference loading, proportionate testing, permission boundaries, and completion criteria.
-- Split prompt-engineering model advice into individually sourced guides for GPT-5.6, GPT-5.5, Claude Fable 5.1, Fable 5, Opus 5, Opus 4.8, and Sonnet 5, alongside Astra. Shared guidance now routes to each model's distinct effort, verification, delegation, and API migration rules.
-
 ## [0.9.18-alpha.6] - 2026-09-04
 
 ### Breaking Changes
@@ -37,6 +28,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Workflow guidance honors explicit task-scoped inline/no-workflow requests, including safe handoff from active runs without duplicate execution. Default authoring and Goal/Ralph prompts select browser, terminal or desktop/simulator verification by environment, support offline/manual qlty setup, and describe authorized native GitHub media attachments with verified hosted links.
 - Model-pinning guidance now points authored workflows at the measured per-evaluation scores in `packages/coding-agent/docs/models/evals.md` (formerly `artificial-analysis-index.md`), whose task-type picker maps each stage type to the eval that measures it, alongside the role guidance in `model-selection.md`.
 
+- Updated the bundled prompt-engineering skill with GPT-6 Astra prompting and API migration guidance, plus an attributed instruction audit covering concise skill descriptions, selective reference loading, proportionate testing, permission boundaries, and completion criteria.
+- Split prompt-engineering model advice into individually sourced guides for GPT-5.6, GPT-5.5, Claude Fable 5.1, Fable 5, Opus 5, Opus 4.8, and Sonnet 5, alongside Astra. Shared guidance now routes to each model's distinct effort, verification, delegation, and API migration rules.
+
 ### Fixed
 
 - Tool-only workflows no longer emit a `ZERO_STAGES` discovery warning. The static scan now recognizes `ctx.tool()` as tracked graph work without advertising tool nodes as future chat-stage targets.
@@ -49,6 +43,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Tool-frontier resume rejects missing, ambiguous, cyclic, or identity-inconsistent state before replaying unfinished callbacks. Older records recover only when typed persisted checkpoints prove a unique safe frontier, including for multiline tool names; transcript text is not converted into checkpoints.
 - Incremental graph parent replacement now rejects self-edges and back-edges before mutating the workflow DAG.
 - Tool-frontier continuations reject normal returns and explicit completed exits that skip the exact unfinished tool, and reject replacement model/task and child-workflow execution before side effects. Stage/task worktree setup follows replay selection and live admission. The failure names the pending frontier, preserves source recovery evidence, and does not repeat completed callbacks.
+
+- Pending-stage Intercom settlement now skips unrelated runs with no messages to settle. Genuine sweep failures produce one display-only warning per distinct message in interactive sessions instead of repeated console stack traces; headless sessions retain console diagnostics, and pending messages remain available for recovery.
 
 ## [0.9.18-alpha.3] - 2026-09-01
 


### PR DESCRIPTION
## Summary

Include recent origin/main changes in the still-unpublished 0.9.18-alpha.6 release notes. This supplements merged #2862 and #2871 without recreating their PRs.

## Changes

Mechanically move existing Unreleased entries into 0.9.18-alpha.6; retain all older release sections and versionless manifests.

## Validation

Exact transformation comparison, git diff --check, signed commit, repository hooks, and required exact-head CI before merge.

## Recovery authorization

The requesting user explicitly authorized replacing the cancelled, unpublished 0.9.18-alpha.6 tag with a release from latest origin/main. No tag changes occur in this PR. Recovery separately checks every npm payload version is absent, verifies the stamped candidate, and uses an explicit old-SHA lease for the one tag update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791221378&installation_model_id=10562&pr_number=2876&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2876&signature=676f433019b239dbcf79e11209c6355d73e39c614a94dca7fe8b60205913cc3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This changelog-only update moves six completed release-note entries from Unreleased into the 0.9.18-alpha.6 sections for the AI, coding-agent, and workflows packages. The entries are present exactly once under their expected headings, and the changed Markdown has no whitespace errors.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the release notes retain all moved entries exactly once in their intended release sections.

No actionable issues were found. The changed release-note placement and Markdown whitespace were checked across all three affected files.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the contract-validation results and confirmed the per-package changelog updates were moved as described for packages ai, coding-agent, and workflows.
- Verified the checks completed successfully, with exit code 0 for the overall checker and whitespace check reporting no output.

<a href="https://app.greptile.com/trex/runs/22703768/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): include latest main in ..."](https://github.com/bastani-inc/atomic/commit/fa06822214192f538cc5092398cd29be9e8bd382) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60787854)</sub>

<!-- /greptile_comment -->