### PR TITLE
fix(scripts): extract PostgreSQL runtime with tar paths relative to the work dir

### DIFF
--- a/scripts/stage-postgres-runtime.d.mts
+++ b/scripts/stage-postgres-runtime.d.mts
@@ -1,0 +1,39 @@
+export type PostgresRuntimeTarget = "linux-x64-musl" | "linux-arm64-musl" | "windows-arm64";
+
+export interface ZonkyPostgresArtifact {
+	url: string;
+	sha256: string;
+	innerEntry: string;
+	innerSha256: string;
+	version: string;
+	kind: "zonky";
+}
+
+export interface WindowsEmulatedPostgresArtifact {
+	url: string;
+	sha256: string;
+	version: string;
+	kind: "windows-x64-emulated";
+}
+
+export type PostgresRuntimeArtifact = ZonkyPostgresArtifact | WindowsEmulatedPostgresArtifact;
+
+export const POSTGRES_RUNTIME_ARTIFACTS: Record<PostgresRuntimeTarget, PostgresRuntimeArtifact>;
+
+export function download(
+	url: string,
+	destination: string,
+	options?: {
+		fetchImpl?: typeof fetch;
+		delay?: (milliseconds: number) => Promise<void>;
+		timeoutMs?: number;
+	},
+): Promise<void>;
+
+/** Stages one PostgreSQL runtime payload into `<packageRoot>/postgres-runtime` and returns that path. */
+export function stagePostgresRuntime(options: {
+	target: PostgresRuntimeTarget;
+	packageRoot: string;
+	artifactFile?: string;
+	artifact?: PostgresRuntimeArtifact;
+}): Promise<string>;

--- a/scripts/stage-postgres-runtime.mjs
+++ b/scripts/stage-postgres-runtime.mjs
@@ -56,8 +56,8 @@ function digest(path) {
 	return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
-function run(command, args) {
-	const result = spawnSync(command, args, { encoding: "utf8" });
+function run(command, args, { cwd } = {}) {
+	const result = spawnSync(command, args, { encoding: "utf8", cwd });
 	if (result.status !== 0) throw new Error(`${command} ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
 }
 
@@ -236,9 +236,11 @@ export async function stagePostgresRuntime({
 					`inner checksum mismatch for ${target}: expected ${artifact.innerSha256}, received ${innerActual}`,
 				);
 			}
-			run("tar", ["-xJf", inner, "-C", extracted]);
+			// Paths are relative to `work`: GNU tar (Git for Windows) reads an
+			// absolute `C:\...` argument as `host:path` and tries to connect to "C".
+			run("tar", ["-xJf", artifact.innerEntry, "-C", "extracted"], { cwd: work });
 		} else {
-			run("tar", ["-xzf", archive, "-C", work]);
+			run("tar", ["-xzf", basename(archive), "-C", "."], { cwd: work });
 			const packageDirectory = join(work, "package");
 			const native = join(packageDirectory, "native");
 			if (!existsSync(native)) throw new Error("Windows artifact is missing package/native");

--- a/test/unit/stage-postgres-runtime-windows.test.ts
+++ b/test/unit/stage-postgres-runtime-windows.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import { stagePostgresRuntime } from "../../scripts/stage-postgres-runtime.mjs";
+
+/** The smallest buffer `validatePostgresArchitecture` accepts as an x64 PE: MZ, e_lfanew, "PE\0\0", machine. */
+function minimalX64PortableExecutable(): Buffer {
+	const binary = Buffer.alloc(0x48);
+	binary.write("MZ", 0, "ascii");
+	binary.writeUInt32LE(0x40, 0x3c);
+	binary.write("PE\0\0", 0x40, "binary");
+	binary.writeUInt16LE(0x8664, 0x44);
+	return binary;
+}
+
+// Regression: the Windows ARM64 leg of publish.yml ran this under Git Bash, whose
+// GNU tar parsed the absolute `C:\Users\...` archive path as `host:path` and
+// failed with "Cannot connect to C: resolve failed". The archive is now extracted
+// with paths relative to the work directory, which every tar accepts.
+test("stages a Windows-shaped PostgreSQL tarball end to end from a caller-supplied artifact", async () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-stage-postgres-windows-"));
+	try {
+		const source = join(root, "source");
+		const native = join(source, "package", "native", "bin");
+		mkdirSync(native, { recursive: true });
+		for (const binary of ["postgres", "initdb", "pg_ctl"]) {
+			writeFileSync(join(native, `${binary}.exe`), minimalX64PortableExecutable());
+		}
+		writeFileSync(join(source, "package", "LICENSE.md"), "upstream license\n");
+		const archive = join(root, "windows-x64-test.tgz");
+		execFileSync("tar", ["-czf", "windows-x64-test.tgz", "-C", "source", "package"], { cwd: root });
+
+		const packageRoot = join(root, "leaf");
+		mkdirSync(packageRoot);
+		writeFileSync(join(packageRoot, "package.json"), `${JSON.stringify({ name: "leaf", files: ["native"] })}\n`);
+
+		const destination = await stagePostgresRuntime({
+			target: "windows-arm64",
+			packageRoot,
+			artifactFile: archive,
+			artifact: {
+				url: "https://example.invalid/windows-x64-test.tgz",
+				sha256: createHash("sha256").update(readFileSync(archive)).digest("hex"),
+				version: "0.0.0-test",
+				kind: "windows-x64-emulated",
+			},
+		});
+
+		assert.equal(destination, join(packageRoot, "postgres-runtime"));
+		for (const binary of ["postgres", "initdb", "pg_ctl"]) {
+			assert.ok(existsSync(join(destination, "bin", `${binary}.exe`)), `staged bin/${binary}.exe`);
+		}
+		assert.ok(existsSync(join(destination, "runtime-provenance.json")));
+		const manifest = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8")) as { files: string[] };
+		assert.ok(manifest.files.includes("postgres-runtime"));
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/test/unit/stage-postgres-runtime-windows.test.ts
+++ b/test/unit/stage-postgres-runtime-windows.test.ts
@@ -1,11 +1,21 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { test } from "vitest";
+import { basename, join, posix, win32 } from "node:path";
+import { test, vi } from "vitest";
 import { stagePostgresRuntime } from "../../scripts/stage-postgres-runtime.mjs";
+
+// Observe the OS boundaries without replacing real extraction or temporary directories.
+vi.mock("node:child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:child_process")>();
+	return { ...actual, spawnSync: vi.fn(actual.spawnSync) };
+});
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return { ...actual, mkdtempSync: vi.fn(actual.mkdtempSync) };
+});
 
 /** The smallest buffer `validatePostgresArchitecture` accepts as an x64 PE: MZ, e_lfanew, "PE\0\0", machine. */
 function minimalX64PortableExecutable(): Buffer {
@@ -17,7 +27,7 @@ function minimalX64PortableExecutable(): Buffer {
 	return binary;
 }
 
-// Regression: the Windows ARM64 leg of publish.yml ran this under Git Bash, whose
+// Regression for PR #2877: the Windows ARM64 leg of publish.yml ran this under Git Bash, whose
 // GNU tar parsed the absolute `C:\Users\...` archive path as `host:path` and
 // failed with "Cannot connect to C: resolve failed". The archive is now extracted
 // with paths relative to the work directory, which every tar accepts.
@@ -38,6 +48,9 @@ test("stages a Windows-shaped PostgreSQL tarball end to end from a caller-suppli
 		mkdirSync(packageRoot);
 		writeFileSync(join(packageRoot, "package.json"), `${JSON.stringify({ name: "leaf", files: ["native"] })}\n`);
 
+		vi.mocked(spawnSync).mockClear();
+		vi.mocked(mkdtempSync).mockClear();
+		const callerCwd = process.cwd();
 		const destination = await stagePostgresRuntime({
 			target: "windows-arm64",
 			packageRoot,
@@ -49,6 +62,18 @@ test("stages a Windows-shaped PostgreSQL tarball end to end from a caller-suppli
 				kind: "windows-x64-emulated",
 			},
 		});
+
+		const tarCalls = vi.mocked(spawnSync).mock.calls.filter(([command]) => command === "tar");
+		assert.equal(tarCalls.length, 1, "staging must execute the observed tar extraction");
+		const [, args, options] = tarCalls[0]!;
+		assert.deepEqual(args, ["-xzf", basename(archive), "-C", "."]);
+		for (const arg of args) {
+			assert.ok(!posix.isAbsolute(arg) && !win32.isAbsolute(arg), `tar argument must be relative: ${arg}`);
+		}
+		const [work] = vi.mocked(mkdtempSync).mock.results;
+		assert.equal(work?.type, "return");
+		assert.equal(options?.cwd, work?.value, "tar must run inside the staging work directory");
+		assert.equal(process.cwd(), callerCwd, "only the tar child changes working directory");
 
 		assert.equal(destination, join(packageRoot, "postgres-runtime"));
 		for (const binary of ["postgres", "initdb", "pg_ctl"]) {


### PR DESCRIPTION
## Summary

The `0.9.18-alpha.6` publish run failed at **Build Windows arm64 archive** ([run 33982019867](https://github.com/bastani-inc/atomic/actions/runs/33982019867)): `stage-postgres-runtime.mjs` runs under Git Bash there, and GNU tar parsed the absolute `C:\Users\...` archive path as `host:path`, failing with `Cannot connect to C: resolve failed`. This is the first publish since Windows ARM64 PostgreSQL staging landed, so that leg had never run.

## Changes

- `run()` accepts `cwd`; both tar extractions pass the archive and destination relative to the work directory, which GNU tar, bsdtar, and Windows tar all accept.
- `scripts/stage-postgres-runtime.d.mts` declares the module's exports so tests can import it under `tsc`.
- New `test/unit/stage-postgres-runtime-windows.test.ts` stages a Windows-shaped tarball (minimal x64 PE stubs) end to end through `stagePostgresRuntime`, so the Windows path is exercised on every CI platform.

## Notes

Release-pipeline fix; no package changelog entry per AGENTS.md. Unblocks re-cutting the alpha.6 prerelease from latest `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791223268&installation_model_id=10562&pr_number=2877&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2877&signature=419b863c8e66b83e6274155a94b01bd801c40512ed4706acff74edac8497ce67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds coverage for Windows PostgreSQL runtime staging, including assertions that tar runs from the staging directory with relative operands. The test must still be updated to use the repository’s shared runtime helpers before merge.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until the repository requirement for shared root-test runtime helpers is met.

The direct Node filesystem and subprocess imports violate an explicit repository requirement. The earlier tar-contract thread was resolved by greptile-apps[bot] without explanation and is not outstanding.

**Files Needing Attention:** test/unit/stage-postgres-runtime-windows.test.ts

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/unit/stage-postgres-runtime-windows.test.ts:2-5
**Use Shared Runtime Helpers**

This root-suite test imports `node:child_process` and `node:fs` directly. The repository requires root tests to use `test/helpers/runtime.ts` so filesystem and subprocess behavior remains normalized across supported runtimes. Use or extend the shared helpers for these operations. This repository requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(scripts): enforce Windows PostgreSQ..."](https://github.com/bastani-inc/atomic/commit/147fd0069af7d953c5b2432c7522207115471279) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60793142)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))
- Knowledge Base — [Harden Release Artifact Publication](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/reverts/incident-mitigation_1888-20260719-release-artifacts-c94e81d.md)

<!-- /greptile_comment -->