### PR TITLE
fix(ci): list release tarballs to a file before grepping payload paths

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -556,19 +556,24 @@ jobs:
           test "$(find npm-packages -name '*.tgz' -type f | wc -l | tr -d ' ')" = 11
           for file in npm-packages/*.tgz; do
             name=$(tar -xOf "$file" package/package.json | jq -r .name)
+            # List once into a file: `tar -tzf | grep -q` closes the pipe on the first
+            # match, tar dies with "stdout: write error", and pipefail fails the step.
+            listing=$(mktemp)
+            tar -tzf "$file" > "$listing"
             case "$name" in
               @bastani/atomic-natives-linux-x64-musl|@bastani/atomic-natives-linux-arm64-musl|@bastani/atomic-natives-win32-arm64-msvc)
-                tar -tzf "$file" | grep -q '^package/postgres-runtime/bin/'
-                tar -tzf "$file" | grep -q '^package/postgres-runtime/POSTGRESQL-LICENSE$'
-                tar -tzf "$file" | grep -q '^package/postgres-runtime/runtime-provenance.json$'
+                grep -q '^package/postgres-runtime/bin/' "$listing"
+                grep -q '^package/postgres-runtime/POSTGRESQL-LICENSE$' "$listing"
+                grep -q '^package/postgres-runtime/runtime-provenance.json$' "$listing"
                 ;;
               @bastani/atomic-natives-*)
-                if tar -tzf "$file" | grep -q '^package/postgres-runtime/'; then
+                if grep -q '^package/postgres-runtime/' "$listing"; then
                   echo "Unexpected PostgreSQL payload in $name" >&2
                   exit 1
                 fi
                 ;;
             esac
+            rm -f "$listing"
           done
           bun -e '
             const expected = new Set(["@bastani/atomic-natives-darwin-arm64","@bastani/atomic-natives-darwin-x64","@bastani/atomic-natives-linux-arm64-gnu","@bastani/atomic-natives-linux-arm64-musl","@bastani/atomic-natives-linux-x64-gnu","@bastani/atomic-natives-linux-x64-musl","@bastani/atomic-natives-win32-arm64-msvc","@bastani/atomic-natives-win32-x64-msvc"]);


### PR DESCRIPTION
## Summary

The second `0.9.18-alpha.6` publish attempt failed at **Build release payload → Validate package metadata and prepare payload** ([run 33984856687](https://github.com/bastani-inc/atomic/actions/runs/33984856687)) with `tar: stdout: write error`, exit 2. All 11 tarballs packed correctly; the failure is in the payload check that follows.

`tar -tzf "$file" | grep -q '^package/postgres-runtime/bin/'` runs under `set -o pipefail`. `grep -q` exits on the first match and closes the pipe, GNU tar takes SIGPIPE while still listing the several-thousand-entry PostgreSQL payload, and pipefail fails the step. This is the first publish where the PostgreSQL payload check has had a non-empty payload to list.

## Changes

- List each tarball once into a temp file and run the `grep -q` assertions against that file, so no `tar` process is ever on the writing end of an early-closed pipe. Behavior of the checks is unchanged.

## Validation

- Reproduced under GNU tar in `debian:bookworm-slim`: the old pipeline exits 141 on a 20k-entry tarball; the new shape exits 0.
- `vitest --project ci` (16 files, 87 tests) passes with the edited `publish.yml`.

## Notes

Release-pipeline fix; no package changelog entry per AGENTS.md. Unblocks the alpha.6 prerelease.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791226452&installation_model_id=10562&pr_number=2878&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2878&signature=f984abd8766c8bf3c1415f3e149d0fe65cc8e60f3f7b3315fee1c912acd93568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

No issues found. The release payload check now reads each package archive listing before verifying its PostgreSQL contents, preventing strict-shell failures on large archives while retaining the required and forbidden payload checks.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the changed release validation accepts a valid large package archive and still rejects incomplete or misplaced PostgreSQL payloads.

No actionable findings remain. The exercised release-validation behavior completed successfully for the intended archive and failed as expected for both invalid archive variants.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the publish-payload-validation-harness.sh to run payload validation checks.
- Verified that the original tar-based form exits with code 141 under set -euo pipefail for a 50,005-entry archive.
- Validated that the changed list-file form exits 0 for a valid intended package and exits 1 for missing-required and forbidden-payload cases.

<a href="https://app.greptile.com/trex/runs/22710483/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): list release tarballs to a file..."](https://github.com/bastani-inc/atomic/commit/00025793ebeaf51c8f9bdcc24dd1d6ef444c68fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60801611)</sub>

<!-- /greptile_comment -->