### PR TITLE
perf(ci): reduce durable test setup overhead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,11 @@ on:
     branches: [main]
   pull_request:
 
-# The work runs as four concurrent jobs instead of one sequential per-platform
-# job, so the wall clock is the longest *dependent* chain rather than the sum of
-# every step. Steps stay together only when one consumes another's build output:
+# The work runs as five independent jobs. Root suites duplicate setup so neither
+# waits for the other; no shared producer sits on their critical path.
 #
-#   suites          build package -> unit -> integration
+#   unit-tests      build package -> unit
+#   integration-tests build package -> integration
 #   agent-suite     build native bindings -> coding-agent vitest
 #   release-archive build package -> build-binaries.sh -> archive smoke
 #   static-checks   typecheck, docs, Mintlify, CI contracts (Linux)
@@ -38,8 +38,8 @@ on:
 # Nothing is passed between jobs as an artifact: waiting for a producer job
 # adds a serial dependency, regardless of how cheaply its output transfers.
 jobs:
-  suites:
-    name: suites (${{ matrix.os }}, ${{ matrix.binary_platform }})
+  unit-tests:
+    name: unit-tests (${{ matrix.os }}, ${{ matrix.binary_platform }})
     strategy:
       matrix:
         include:
@@ -51,30 +51,8 @@ jobs:
             timeout_minutes: 28
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # This job owns TWO retryable steps -- unit and integration each run behind
-    # the bounded flake-retry wrapper -- so its cap must cover a replay of both,
-    # not just one pass. The retry replays only those steps, so the budget is
-    # `setup + 2 x (unit + integration)` rather than 2x the whole job.
-    #
-    # Recent observed per-step costs:
-    #   run 33858796656 Windows  setup 140s, unit 475s, integration 75s
-    #   run 33864468533 Windows  setup 103s, unit 511s + 494s retry,
-    #                               integration >92s (41/42 files completed)
-    # The remaining integration file is the structural packed-package install
-    # and typecheck, so the cancelled partial duration is a lower bound rather
-    # than a completed sample.
-    #
-    # Sizing from the pessimistic observed setup, unit, and partial integration
-    # gives 140 + 2*(511 + 92) = 1346s (22.4 min). Both legs take 28 min, 1.25x
-    # that lower bound and effectively the same headroom as the former 20 min
-    # cap's 1.24x Windows ratio. One shared number remains deliberate: these are
-    # shared 4-vCPU runners, so a per-platform split would encode precision the
-    # measurements do not support and invite one leg to decay independently.
-    #
-    # The former 20 min cap expired after the unit retry passed and cancelled
-    # integration, turning an ordinary flake into an opaque required-job
-    # cancellation. This remains a hang detector, not a performance budget;
-    # shortening the ~8.5 min unit step is still what would buy headroom back.
+    # Retain the combined suites job's 28-minute cap conservatively. This is an
+    # inherited hang detector with retry headroom, not a measured split-job budget.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       # Sticky disks are Blacksmith-Linux-only; Windows takes a standard clone.
@@ -129,10 +107,7 @@ jobs:
       # Measured at 42s Linux / 86s Windows, both inside the existing caps.
       - name: Build native bindings for the root suites
         run: npm run build --workspace=@bastani/atomic-natives
-      # Both suites below consume this build. test/unit/pi-0.82.1-artifacts.test.ts
-      # silently degrades to test.skip when packages/coding-agent/dist is absent,
-      # so moving the unit suite out of this job would lose coverage without
-      # failing anything.
+      # Unit artifact tests require dist/ to retain their full coverage.
       - name: Build @bastani/atomic package
         working-directory: packages/coding-agent
         run: npm run build
@@ -141,21 +116,86 @@ jobs:
           bun run scripts/run-flaky-test-suite.ts --label "unit tests (${{ matrix.binary_platform }})"
           --no-retry-file flaky-test-suite-runner.test.ts
           -- npm run test:unit
-      - name: Integration tests (one bounded flake retry)
-        run: >-
-          bun run scripts/run-flaky-test-suite.ts --label "integration tests (${{ matrix.binary_platform }})"
-          -- npm run test:integration
-        env:
-          # Hard-require the installed-package Node smoke where the package
-          # build above guarantees dist/ exists on both supported hosts.
-          ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE: "1"
       - name: Upload flaky-test diagnostics
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Artifact names must be unique across every job in the run:
           # actions/upload-artifact@v4+ fails the whole run on a duplicate.
-          name: test-diagnostics-suites-${{ matrix.binary_platform }}
+          name: test-diagnostics-unit-tests-${{ matrix.binary_platform }}
+          path: .ci-diagnostics/
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 14
+
+  integration-tests:
+    name: integration-tests (${{ matrix.os }}, ${{ matrix.binary_platform }})
+    strategy:
+      matrix:
+        include:
+          - os: blacksmith-4vcpu-ubuntu-2404
+            binary_platform: linux-x64
+            timeout_minutes: 28
+          - os: blacksmith-4vcpu-windows-2025
+            binary_platform: windows-x64
+            timeout_minutes: 28
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    # Inherited hang detector, not a measured split-job budget. Keep retry headroom.
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    steps:
+      - uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1.1
+        if: runner.os == 'Linux'
+        with:
+          lfs: true
+          fetch-depth: 0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: runner.os != 'Linux'
+        with:
+          lfs: true
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+      - id: rust
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        continue-on-error: true
+        timeout-minutes: 4
+        with:
+          toolchain: stable
+      - name: Retry Rust toolchain install
+        if: steps.rust.outcome == 'failure'
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        timeout-minutes: 4
+        with:
+          toolchain: stable
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Alias @earendil-works/pi-ai onto the workspace package
+        run: node scripts/alias-pi-ai.mjs
+      - name: Build @bastani/pi-ai
+        run: npm run build --workspace=@bastani/pi-ai
+      - name: Build native bindings for the root suites
+        run: npm run build --workspace=@bastani/atomic-natives
+      - name: Build @bastani/atomic package
+        working-directory: packages/coding-agent
+        run: npm run build
+      - name: Integration tests (one bounded flake retry)
+        run: >-
+          bun run scripts/run-flaky-test-suite.ts --label "integration tests (${{ matrix.binary_platform }})"
+          -- npm run test:integration
+        env:
+          # Hard-require the installed-package Node smoke on both supported hosts.
+          ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE: "1"
+      - name: Upload flaky-test diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-diagnostics-integration-tests-${{ matrix.binary_platform }}
           path: .ci-diagnostics/
           include-hidden-files: true
           if-no-files-found: ignore
@@ -484,7 +524,7 @@ jobs:
   # meaning this context had before.
   test:
     name: test (${{ matrix.os }}, ${{ matrix.binary_platform }})
-    needs: [suites, agent-suite, release-archive, static-checks]
+    needs: [unit-tests, integration-tests, agent-suite, release-archive, static-checks]
     if: always()
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ on:
 #   static-checks   typecheck, docs, Mintlify, CI contracts (Linux)
 #   test            result gate; carries the two required check contexts
 #
-# Nothing is passed between jobs as an artifact: rebuilding in parallel is
-# cheaper in wall clock than serializing on an upload/download pair.
+# Nothing is passed between jobs as an artifact: waiting for a producer job
+# adds a serial dependency, regardless of how cheaply its output transfers.
 jobs:
   suites:
     name: suites (${{ matrix.os }}, ${{ matrix.binary_platform }})
@@ -157,6 +157,7 @@ jobs:
           # actions/upload-artifact@v4+ fails the whole run on a duplicate.
           name: test-diagnostics-suites-${{ matrix.binary_platform }}
           path: .ci-diagnostics/
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 14
 
@@ -178,16 +179,15 @@ jobs:
     # SHA; the first split run measured 138s / 349s. Linux moves 6 -> 8 min
     # (480s, 2.17x of the 221s worst observation) because 6 min had decayed to
     # 1.6x, the same drift that cancelled `suites`. Windows stays at 12 min
-    # (720s), still 2.06x the 349s worst case this job has ever produced. This
-    # is the critical path of the whole workflow, so it is the chain to shard
-    # first if a further cut is wanted.
+    # (720s), 2.06x that historical 349s observation. Current PR samples put
+    # the critical path on `suites`, usually its Windows unit step. Keep these
+    # retry-inclusive caps; sharding is prohibited by the testing contract.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       - uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1.1
         if: runner.os == 'Linux'
         with:
-          # The only LFS fixtures in the repository live under
-          # packages/coding-agent/test/fixtures, so this job genuinely needs them.
+          # Package LFS assets include session fixtures and the runtime PNG.
           lfs: true
           fetch-depth: 0
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -239,6 +239,7 @@ jobs:
         with:
           name: test-diagnostics-agent-suite-${{ matrix.binary_platform }}
           path: .ci-diagnostics/
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 14
 
@@ -411,8 +412,8 @@ jobs:
 
   static-checks:
     name: static-checks (linux-x64)
-    # Platform-independent checks. They need no Rust toolchain, so they run once
-    # on Linux instead of twice.
+    # Platform-independent checks run once on Linux. The CI project's native
+    # global setup still builds a missing binding, so a cold job needs Rust.
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 6
     steps:

--- a/.qlty/.gitignore
+++ b/.qlty/.gitignore
@@ -1,0 +1,7 @@
+*
+!configs
+!configs/**
+!hooks
+!hooks/**
+!qlty.toml
+!.gitignore

--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -1,0 +1,5 @@
+config_version = "0"
+
+# Supplemental built-in analysis; npm run check remains the lint/typecheck gate.
+exclude_patterns = ["**/node_modules/**", "**/dist/**", "**/target/**", "**/binaries/**"]
+test_patterns = ["**/test/**", "**/*.test.*"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ everywhere. Where the split differs from pi, the reason is written down.
 | Registry publish | `npm publish --provenance` | npm's OIDC-signed provenance lives in the npm CLI, and npm trusted publishing requires a GitHub-hosted runner |
 
 **Where this repository deliberately declines pi's shape:** pi's CI is one `ubuntu-latest`
-job with no matrix and no `timeout-minutes`. Do not copy it. This workflow produces nine
+job with no matrix and no `timeout-minutes`. Do not copy it. This workflow produces eleven
 check contexts including full Windows coverage, runs on Blacksmith runners, and carries
 per-job timeout budgets that `test/ci/test-workflow-topology.test.ts` asserts. Adopting pi's
 topology would delete Windows coverage and orphan the two required check contexts. Parity is

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,7 +8,7 @@ Atomic publishes `@bastani/atomic` from `packages/coding-agent`, `@bastani/atomi
 Pull request / selected branch push
 └─ test.yml (four concurrent work jobs + one result gate)
    ├─ suites (Linux, Windows): build package -> unit -> integration
-   ├─ agent-suite (Linux, Windows): native bindings -> coding-agent vitest (Node, then Bun)
+   ├─ agent-suite (Linux, Windows): native bindings -> coding-agent vitest (Node)
    ├─ release-archive (Linux, Windows): build package -> binaries -> smoke
    ├─ static-checks (Linux): typecheck, docs, installer container smoke, contracts
    └─ test (2 legs): result gate carrying both required contexts
@@ -58,6 +58,66 @@ failure above, not a fix for it.
 
 Its work runs as four independent jobs so the wall clock is one job's longest dependent chain rather than the sum of every step in file order.
 
+### Current critical path, measured September 5, 2026
+
+A sample of 32 completed PR-triggered `Tests` runs created September 4–5 puts
+the critical path on `suites`, usually Windows. These job execution times retain
+failed, retried and cancelled runs; they are not sums of concurrent jobs:
+
+| Job | Linux p50 / p90 | Windows p50 / p90 |
+| --- | ---: | ---: |
+| `suites` | 475 / 779.9 s | 726 / 1202.8 s |
+| `agent-suite` | 217.5 / 264.6 s | 340 / 472.9 s |
+| `release-archive` | 77 / 90.9 s | 142.5 / 188.2 s |
+| `static-checks` | 94 / 104.8 s | not run |
+
+Creation-to-result-gate wall time was 737 s median and 840.2 s p90 for the 15
+successful runs without internal retry. The 14 completed runs classified as
+retried measured 1131 / 1401.8 s; two failed and one cancelled run remain in
+the sample separately. There were 21 wrapper retry events across 15 runs,
+including the cancelled run. These include four coding-agent retries omitted by
+the original root-suite-only summary. Three older whole-workflow reruns were
+collected separately, not pooled into these PR-run distributions. Queue-to-first-work was
+10 s median; the gate tail was 13.5 s. Retry and unit execution dominate, not npm
+installation. The Windows unit step measured 493 s median across 31 executed
+primary-sample steps, including retries and failed attempts.
+
+The per-file durable setup now imports the in-memory backend and process owner
+directly instead of eagerly loading the DBOS factory and its aliased host graph.
+It still installs a fresh backend before every test, preserves other owner state,
+and leaves both global setups and test isolation unchanged. Tests needing host
+prototype installers import those real modules explicitly. The import-graph
+guard follows the actual Vitest aliases and compiler setting: statement-level
+`import type` erases, but `import { type T }` still evaluates its dependency under
+`verbatimModuleSyntax`. A real Vite transform/runtime regression covers that distinction.
+
+Local full-unit measurements on macOS arm64, Node 22.23.2 and Bun 1.4.2 were
+137.08 s before and 118.61 s after, a 13.5% wall reduction and 14.8% CPU reduction.
+A reverse-order runtime comparison on the same updated test inventory measured
+140.00 s for the original setup versus 119.53 s for the new setup, reducing wall
+time by 14.6% and CPU by 14.9%. Every original case identity, multiplicity and
+status was retained; those timing runs included four new regression cases. Both retained
+23 existing skips and the same pre-existing `extension.test.ts` validation-warning
+failure; they are performance measurements, not an all-green suite claim.
+A fifth regression covering actual transform/runtime behavior was added during review.
+Current local validation with a fresh, command-scoped `ATOMIC_CODING_AGENT_DIR`
+passed all 7,589 active tests with the same 23 skips. This excludes ambient personal
+resources while retaining project, bundled and explicit package fixtures; the
+pre-existing one-second polling assumption remains unfixed. That environment's
+timing must not be mixed into the before/after comparison. Most of the apparent
+setup-phase reduction moves to test-module import; only the whole-run wall and
+CPU differences above are claimed as savings.
+
+Applying the local wall range to the 493 s Windows unit median projects roughly
+66–72 s saved per attempt, not a measured hosted gain. Linux/Windows A/B timing
+and the restored artifact upload still need a normal authorized CI run. The
+fastest successful sampled gate was 687 s: this change does not demonstrate
+sub-five-minute CI. Investigating recurring retry causes is the next priority;
+native caching needs a deliberate cache-policy amendment and trust validation,
+and larger runners need measured billing tradeoffs rather than linear vCPU claims.
+
+### Historical split-job estimates
+
 | Job | Platforms | Chain | Linux | Windows |
 | --- | --- | --- | ---: | ---: |
 | `suites` | both | build `@bastani/atomic` -> unit -> integration | 121 s | 195 s |
@@ -106,19 +166,19 @@ The saving is nevertheless about 15 s, not the estimated 205 s, because the sequ
 
 On both runs the critical path was Windows `agent-suite`, whose real cost is 349–380 s rather than the 232 s the estimate assumed. Run 1 also fired the unit step's one bounded flake retry on both platforms, from two different pre-existing flakes that each passed on the retry.
 
-The structural result still stands and is what matters for the next decision: wall clock is now dominated by **two** steps instead of fourteen. Sharding `coding-agent vitest` therefore has a direct effect where before the split it would have been diluted by everything else in the job. Each shard must repeat the native binding build, so the arithmetic to beat is `setup + native build + vitest/2`. Confirm the steady-state numbers over more runs first.
+These initial split-run samples explain the topology change, not today's bottleneck. The current critical-path measurements above supersede the earlier recommendation to shard `agent-suite`; sharding is not permitted by the current testing contract.
 
 ### Why steps are grouped this way
 
-Steps stay in one job only when one consumes another's build output. Nothing is passed between jobs as an artifact, because rebuilding in parallel is cheaper in wall clock than serializing on an upload/download pair.
+Steps stay in one job only when one consumes another's build output. Nothing is passed between jobs as an artifact because waiting for a producer job introduces a serial dependency. The dependency edge can lengthen the critical path; this is not a claim that uploading and downloading the bytes costs more than recompiling.
 
 - `test/unit/pi-0.82.1-artifacts.test.ts` gates its assertions on `packages/coding-agent/dist` and degrades to `test.skip` with a warning when the build has not run, so the unit suite must stay behind the package build. Moving it into a build-less job would lose coverage without failing anything.
-- `test/integration/installed-package-node-extensions.test.ts` needs `dist/` and Node and is hard-required by `ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE=1`, so `suites` is the only job that installs Node.
+- `test/integration/installed-package-node-extensions.test.ts` needs `dist/` and Node and is hard-required by `ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE=1`. All four work-job definitions install Node; `suites` owns this package smoke.
 - `packages/coding-agent/test/native-binding-exports.test.ts` is hard-required by `ATOMIC_REQUIRE_NATIVE_BINDING_SMOKE=1`, so the vitest suite stays behind `npm run build --workspace=@bastani/atomic-natives`.
-- `scripts/build-binaries.sh` reuses `packages/natives/native/*.node` when present and otherwise builds them, so `release-archive` carries its own Rust toolchain and pays that build again rather than waiting on `agent-suite`. `suites` and `static-checks` need no Rust at all.
+- `scripts/build-binaries.sh` reuses `packages/natives/native/*.node` when present and otherwise builds them, so `release-archive` carries its own Rust toolchain and pays that build again rather than waiting on `agent-suite`. `suites` also builds native bindings explicitly. The CI project's native global setup builds a missing binding in `static-checks`, so a cold static job needs Rust despite having no explicit toolchain step.
 - `agent-suite` runs the coding-agent package in one step; its SQLite selectors resolve `node:sqlite` on both runtimes (Bun ships it from 1.4.0, the repository's Bun floor).
 
-No suite uses `--parallel`, `--shard`, `--concurrent`, or `--max-concurrency`. `--parallel` implies `--isolate`, and 20 files in `test/unit` import 108 sibling `*.test.ts` files, so a fresh module registry per file re-executes those tests: 5407 executions against 4426 distinct tests, with the duplicates scored twice by the duration guard, once under contention. `--shard` is deterministic and roughly 1.85x faster locally, but it buys no wall clock while Windows `agent-suite` is the critical path. If a further cut is wanted, shard vitest first, then unit; that is worth roughly 70 s for a 60 % increase in runner count.
+No suite uses `--parallel`, `--shard`, `--concurrent`, or `--max-concurrency`. Twenty unit files still import 108 sibling `*.test.ts` files, so an isolated module registry executes those registrations again. Those executions and their per-attempt diagnostics are intentional retained coverage here. Keep default isolation and worker sizing; do not remove duplicate executions, serialize suites or introduce worker caps to manufacture a timing improvement.
 
 ### The `test` job is a result gate
 
@@ -176,7 +236,7 @@ These caps are wall-clock ceilings, not performance budgets. Shortening the
 with fresh measurements, and the contract test bounds every cap at 28 minutes
 so that stays a deliberate decision.
 
-Every job that runs a suite through `scripts/run-flaky-test-suite.ts` uploads `.ci-diagnostics/` under a job-unique artifact name (`test-diagnostics-<job>-<binary_platform>`). `actions/upload-artifact@v4+` fails the entire run when two jobs upload the same name.
+Every job that runs a suite through `scripts/run-flaky-test-suite.ts` uploads `.ci-diagnostics/` under a job-unique artifact name (`test-diagnostics-<job>-<binary_platform>`). `actions/upload-artifact@v4+` fails the entire run when two jobs upload the same name. Both upload steps explicitly set `include-hidden-files: true`: files inside a dot-prefixed directory are hidden on Linux and Windows, and the default previously excluded every diagnostic. Keep `path: .ci-diagnostics/` narrow rather than enabling hidden uploads across the workspace. The `always()` condition, 14-day retention and `if-no-files-found: ignore` remain, so a job failing before test execution need not produce an artifact. Restoring uploads may add a small upload cost; it is an observability fix, not a speedup.
 
 Archive smoke tests verify bundled builtins, native modules, runtime dependencies, `--version`, and startup far enough to reject extension-load failures.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,8 +6,9 @@ Atomic publishes `@bastani/atomic` from `packages/coding-agent`, `@bastani/atomi
 
 ```text
 Pull request / selected branch push
-└─ test.yml (four concurrent work jobs + one result gate)
-   ├─ suites (Linux, Windows): build package -> unit -> integration
+└─ test.yml (five concurrent work jobs + one result gate)
+   ├─ unit-tests (Linux, Windows): build package -> unit
+   ├─ integration-tests (Linux, Windows): build package -> integration
    ├─ agent-suite (Linux, Windows): native bindings -> coding-agent vitest (Node)
    ├─ release-archive (Linux, Windows): build package -> binaries -> smoke
    ├─ static-checks (Linux): typecheck, docs, installer container smoke, contracts
@@ -56,12 +57,12 @@ in-flight run can kill a run that has already published `test (...)`, leaving a
 cancelled required context on a SHA with no superseding successful run — the
 failure above, not a fix for it.
 
-Its work runs as four independent jobs so the wall clock is one job's longest dependent chain rather than the sum of every step in file order.
+Its work runs as five independent job definitions (nine work-job instances plus two result gates). Unit and integration tests each build their own prerequisites and run on separate Linux/Windows VMs, so integration no longer waits for unit tests or their retries. This adds two VM jobs and duplicates setup/build cost; it does not shard or remove tests. Removing the roughly 1–2-minute Windows integration tail is a projection dependent on runner availability, not a measured gain from this split.
 
 ### Current critical path, measured September 5, 2026
 
-A sample of 32 completed PR-triggered `Tests` runs created September 4–5 puts
-the critical path on `suites`, usually Windows. These job execution times retain
+A pre-split sample of 32 completed PR-triggered `Tests` runs created September 4–5 puts
+the critical path on the former combined `suites` job, usually Windows. These job execution times retain
 failed, retried and cancelled runs; they are not sums of concurrent jobs:
 
 | Job | Linux p50 / p90 | Windows p50 / p90 |
@@ -173,9 +174,9 @@ These initial split-run samples explain the topology change, not today's bottlen
 Steps stay in one job only when one consumes another's build output. Nothing is passed between jobs as an artifact because waiting for a producer job introduces a serial dependency. The dependency edge can lengthen the critical path; this is not a claim that uploading and downloading the bytes costs more than recompiling.
 
 - `test/unit/pi-0.82.1-artifacts.test.ts` gates its assertions on `packages/coding-agent/dist` and degrades to `test.skip` with a warning when the build has not run, so the unit suite must stay behind the package build. Moving it into a build-less job would lose coverage without failing anything.
-- `test/integration/installed-package-node-extensions.test.ts` needs `dist/` and Node and is hard-required by `ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE=1`. All four work-job definitions install Node; `suites` owns this package smoke.
+- `test/integration/installed-package-node-extensions.test.ts` needs `dist/` and Node and is hard-required by `ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE=1`. All five work-job definitions install Node; `integration-tests` owns this package smoke.
 - `packages/coding-agent/test/native-binding-exports.test.ts` is hard-required by `ATOMIC_REQUIRE_NATIVE_BINDING_SMOKE=1`, so the vitest suite stays behind `npm run build --workspace=@bastani/atomic-natives`.
-- `scripts/build-binaries.sh` reuses `packages/natives/native/*.node` when present and otherwise builds them, so `release-archive` carries its own Rust toolchain and pays that build again rather than waiting on `agent-suite`. `suites` also builds native bindings explicitly. The CI project's native global setup builds a missing binding in `static-checks`, so a cold static job needs Rust despite having no explicit toolchain step.
+- `scripts/build-binaries.sh` reuses `packages/natives/native/*.node` when present and otherwise builds them, so `release-archive` carries its own Rust toolchain and pays that build again rather than waiting on `agent-suite`. Both root-suite jobs also build native bindings explicitly. The CI project's native global setup builds a missing binding in `static-checks`, so a cold static job needs Rust despite having no explicit toolchain step.
 - `agent-suite` runs the coding-agent package in one step; its SQLite selectors resolve `node:sqlite` on both runtimes (Bun ships it from 1.4.0, the repository's Bun floor).
 
 No suite uses `--parallel`, `--shard`, `--concurrent`, or `--max-concurrency`. Twenty unit files still import 108 sibling `*.test.ts` files, so an isolated module registry executes those registrations again. Those executions and their per-attempt diagnostics are intentional retained coverage here. Keep default isolation and worker sizing; do not remove duplicate executions, serialize suites or introduce worker caps to manufacture a timing improvement.
@@ -200,14 +201,14 @@ If maintainers later prefer real per-job required contexts, that is a separate d
 ### Per-job time limits
 
 The blanket 10/15-minute pair is gone. Each job declares its own cap as a hang
-detector with room for the bounded flake retries it owns: `suites` 28/28,
-`agent-suite` 8/12, `release-archive` 5/9, `static-checks` 6, gate 5. The
-contract test in `test/ci/test-workflow-topology.test.ts` pins every value.
+detector with room for the bounded flake retries it owns: `unit-tests` and
+`integration-tests` each retain 28/28, `agent-suite` 8/12, `release-archive` 5/9,
+`static-checks` 6, gate 5. Root-suite caps conservatively retain the former combined job's headroom; they are not newly measured split-job budgets. The topology contract pins every value.
 
 A cap has to cover the retries its job owns. `scripts/run-flaky-test-suite.ts`
 replays only the step it wraps, so the budget is `setup + 2 × (retryable steps)`
-rather than 2× the whole job — and `suites` wraps **two** steps, unit and
-integration, so a legitimate retried run is close to double its test time.
+rather than 2× the whole job. The former `suites` job wrapped **two** steps;
+each new root-suite job now owns one independently retryable step.
 
 Recent Windows observations show why the old value no longer covered that
 contract. Run `33858796656` used 140 s before its suites, 475 s for unit, and
@@ -218,7 +219,7 @@ file was the structural packed-package install and typecheck, so 92 s is a lower
 bound rather than a completed integration sample.
 
 Using the pessimistic observed values, the retry-inclusive floor is
-`140 + 2 × (511 + 92) = 1346 s` (22.4 min). Both `suites` legs therefore share
+`140 + 2 × (511 + 92) = 1346 s` (22.4 min). Both former `suites` legs therefore received
 one 28-minute cap: 1.25× that floor, effectively the same headroom as the old
 cap's 1.24× Windows ratio when it was introduced. A per-platform split would
 again encode precision these shared 4-vCPU runners do not support and invite one
@@ -236,7 +237,7 @@ These caps are wall-clock ceilings, not performance budgets. Shortening the
 with fresh measurements, and the contract test bounds every cap at 28 minutes
 so that stays a deliberate decision.
 
-Every job that runs a suite through `scripts/run-flaky-test-suite.ts` uploads `.ci-diagnostics/` under a job-unique artifact name (`test-diagnostics-<job>-<binary_platform>`). `actions/upload-artifact@v4+` fails the entire run when two jobs upload the same name. Both upload steps explicitly set `include-hidden-files: true`: files inside a dot-prefixed directory are hidden on Linux and Windows, and the default previously excluded every diagnostic. Keep `path: .ci-diagnostics/` narrow rather than enabling hidden uploads across the workspace. The `always()` condition, 14-day retention and `if-no-files-found: ignore` remain, so a job failing before test execution need not produce an artifact. Restoring uploads may add a small upload cost; it is an observability fix, not a speedup.
+Every job that runs a suite through `scripts/run-flaky-test-suite.ts` uploads `.ci-diagnostics/` under a job-unique artifact name (`test-diagnostics-<job>-<binary_platform>`). `actions/upload-artifact@v4+` fails the entire run when two jobs upload the same name. All three upload steps explicitly set `include-hidden-files: true`, producing six platform-specific artifacts: files inside a dot-prefixed directory are hidden on Linux and Windows, and the default previously excluded every diagnostic. Keep `path: .ci-diagnostics/` narrow rather than enabling hidden uploads across the workspace. The `always()` condition, 14-day retention and `if-no-files-found: ignore` remain, so a job failing before test execution need not produce an artifact. Restoring uploads may add a small upload cost; it is an observability fix, not a speedup.
 
 Archive smoke tests verify bundled builtins, native modules, runtime dependencies, `--version`, and startup far enough to reject extension-load failures.
 

--- a/packages/coding-agent/docs/development.md
+++ b/packages/coding-agent/docs/development.md
@@ -96,6 +96,17 @@ npm run test:scripts              # Run the repository script tests under node -
 npm run test --workspace=@bastani/atomic -- test/specific.test.ts
 ```
 
+Root Vitest projects install a fresh in-memory durable backend before every test.
+Durability initialization imports the backend and its process owner rather than
+preloading the DBOS factory or the Atomic host. A test that needs host prototype
+installers must import those real modules explicitly rather than depend on a
+side effect of shared setup. Test-local backend overrides still use the factory's
+injection seam, and the next test receives a fresh backend without resetting
+unrelated initialization or warning state. Keep the global artifact/native setups,
+default isolation, worker sizing and timeout budgets unchanged when measuring
+test cost. See the [CI measurements](https://github.com/bastani-inc/atomic/blob/main/docs/ci.md#current-critical-path-measured-september-5-2026)
+for local gains and the remaining hosted Linux/Windows validation.
+
 ## Deterministic installs
 
 `@bastani/atomic` ships `packages/coding-agent/npm-shrinkwrap.json` so package-manager installs resolve the same dependency tree every time. Contributors working from a source checkout can validate that the checked-in shrinkwrap is up to date with:

--- a/packages/coding-agent/docs/development.md
+++ b/packages/coding-agent/docs/development.md
@@ -107,6 +107,12 @@ default isolation, worker sizing and timeout budgets unchanged when measuring
 test cost. See the [CI measurements](https://github.com/bastani-inc/atomic/blob/main/docs/ci.md#current-critical-path-measured-september-5-2026)
 for local gains and the remaining hosted Linux/Windows validation.
 
+CI runs the complete root unit and integration suites in independent Linux and
+Windows jobs. Each builds its own native and package prerequisites; both required
+result gates wait for every work job and reject failures, cancellations and skips.
+This trades duplicated setup for earlier integration feedback without changing
+test isolation, coverage or retries.
+
 ## Deterministic installs
 
 `@bastani/atomic` ships `packages/coding-agent/npm-shrinkwrap.json` so package-manager installs resolve the same dependency tree every time. Contributors working from a source checkout can validate that the checked-in shrinkwrap is up to date with:

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -29,7 +29,7 @@ const warmPath = join(root, ".github/workflows/warm-toolchain-cache.yml");
 
 /**
  * The `test` job's own topology contracts live in test-workflow-topology.test.ts.
- * It is now a result gate over four concurrent work jobs, and the
+ * It is now a result gate over five concurrent work jobs, and the
  * anti-un-protection assertions belong beside the ones describing that split.
  */
 /**
@@ -811,7 +811,7 @@ test("sticky-disk checkout stays on Blacksmith Linux runners", async () => {
 	assert.doesNotMatch(jobBlock(publish, "windows-binary-smoke", "alpine-binary-smoke"), /useblacksmith/u);
 	// Every cross-platform job in test.yml now checks out for itself, so each one
 	// must keep the Linux/non-Linux checkout pair.
-	const crossPlatformJobs = ["suites", "agent-suite", "release-archive"] as const;
+	const crossPlatformJobs = ["unit-tests", "integration-tests", "agent-suite", "release-archive"] as const;
 	const testJobs = new Map(jobBlocks(testWorkflow));
 	for (const block of [
 		jobBlock(publish, "native-artifacts", "linux-binary-smoke"),

--- a/test/ci/test-workflow-topology.test.ts
+++ b/test/ci/test-workflow-topology.test.ts
@@ -266,11 +266,19 @@ test("every work job installs with npm ci and sets up both runtimes it uses", as
  * same artifact name, and three jobs previously emitted the identical
  * `test-diagnostics-<platform>` name.
  */
+function assertDiagnosticsPath(step: string): void {
+	assert.match(step, /^\s+path: \.ci-diagnostics\/\s*$/mu);
+	assert.match(step, /^\s+include-hidden-files: true\s*$/mu);
+}
+
 test("every diagnostics upload has a job-unique artifact name", async () => {
 	const uploads = [...(await jobs())].flatMap(([job, block]) =>
 		jobSteps(block)
 			.filter((step) => step.includes("actions/upload-artifact@"))
 			.map((step) => {
+				assertDiagnosticsPath(step);
+				assert.throws(() => assertDiagnosticsPath(step.replace(/^\s+include-hidden-files: true\s*$/mu, "")));
+				assert.throws(() => assertDiagnosticsPath(step.replace("path: .ci-diagnostics/", "path: .")));
 				const name = /^\s+name: (.+)$/mu.exec(step);
 				assert.ok(name, `${job}: upload-artifact step declares no artifact name`);
 				return (name[1] as string).trim();

--- a/test/ci/test-workflow-topology.test.ts
+++ b/test/ci/test-workflow-topology.test.ts
@@ -9,7 +9,7 @@ const root = fileURLToPath(new URL("../..", import.meta.url));
 const testPath = join(root, ".github/workflows/test.yml");
 
 /** The work jobs the result gate must depend on, in file and `needs` order. */
-const WORK_JOBS = ["suites", "agent-suite", "release-archive", "static-checks"] as const;
+const WORK_JOBS = ["unit-tests", "integration-tests", "agent-suite", "release-archive", "static-checks"] as const;
 
 /** Job blocks keyed by job id, in file order. */
 async function jobs(): Promise<Map<string, string>> {
@@ -112,44 +112,13 @@ test("every work job the gate names exists and is otherwise independent", async 
 	}
 });
 
-/**
- * Per-job wall-clock caps replace the blanket 10/15 minute pair. A cap is a hang
- * detector, and it decays into a false-failure generator as the suites grow: the
- * 8-minute `suites` Linux cap was sized against a 230 s measurement, the job now
- * measures 400 s, and it cancelled a healthy run at 497 s on 31047506585 while
- * the same SHA passed on the pull_request event.
- *
- * A cap must cover the retries its job owns, because a retry replays only the
- * retryable steps: the budget is `setup + 2 x (retryable steps)`, not 2x the
- * whole job. `suites` owns TWO retryable steps (unit and integration), so its
- * worst legitimate run is roughly double its test time.
- *
- * Recent observed per-step costs:
- *   run 33858796656 Windows setup 140 s, unit 475 s, integration 75 s
- *   run 33864468533 Windows setup 103 s, unit 511 s + 494 s retry,
- *                              integration >92 s (41/42 files completed)
- * The remaining integration file is the structural packed-package install and
- * typecheck, so the cancelled partial duration is a lower bound rather than a
- * completed sample. The retry-inclusive calculation is therefore at least
- * 140 + 2*(511 + 92) = 1346 s (22.4 min).
- *
- * The former 20-minute cap expired after the unit retry passed and cancelled
- * integration. Both `suites` legs now share a 28-minute cap: 1.25x that lower
- * bound and effectively the same headroom as the former cap's 1.24x Windows
- * ratio. A single value still avoids encoding per-platform precision these
- * shared 4-vCPU runners do not support.
- *
- * `agent-suite` and `release-archive` keep their pairs: agent-suite still
- * clears its retry-inclusive observations, and release-archive runs no
- * retryable step at all. The Windows `release-archive` cap is 9 minutes because
- * cold setup observed 152 s for `rust-toolchain` and 71 s for checkout,
- * followed by roughly 110 s native build and 40 s archive smoke.
- */
-test("each split job declares its own measured timeout", async () => {
+/** Root-suite caps retain the combined job's headroom, not measured split-job budgets. */
+test("each split job retains its timeout hang detector", async () => {
 	const workflow = await readText(testPath);
 	const blocks = await jobs();
 	const caps: Record<string, [number, number]> = {
-		suites: [28, 28],
+		"unit-tests": [28, 28],
+		"integration-tests": [28, 28],
 		"agent-suite": [8, 12],
 		"release-archive": [5, 9],
 	};
@@ -189,16 +158,40 @@ test("each split job declares its own measured timeout", async () => {
 test("build-consuming steps stay in the job that produced the build", async () => {
 	const blocks = await jobs();
 
-	const suites = jobSteps(blocks.get("suites") as string);
-	assert.ok(stepIndex(suites, "Build @bastani/atomic package") < stepIndex(suites, "Unit tests"));
-	assert.ok(stepIndex(suites, "Unit tests") < stepIndex(suites, "Integration tests"));
-	assert.match(namedStep(suites, "Integration tests"), /ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE: "1"/u);
-	assert.match(blocks.get("suites") as string, /uses: actions\/setup-node@/u);
-	// The bundled subagent extension loads the Rust control plane at import, so
-	// both root suites are build-consuming steps for the native binding too.
-	assert.ok(stepIndex(suites, "Build native bindings for the root suites") < stepIndex(suites, "Unit tests"));
-	assert.ok(stepIndex(suites, "Build native bindings for the root suites") < stepIndex(suites, "Integration tests"));
-	assert.match(blocks.get("suites") as string, /uses: dtolnay\/rust-toolchain@/u);
+	for (const [job, suite] of [
+		["unit-tests", "Unit tests"],
+		["integration-tests", "Integration tests"],
+	]) {
+		const block = blocks.get(job) as string;
+		const steps = jobSteps(block);
+		assert.ok(stepIndex(steps, "Build @bastani/atomic package") < stepIndex(steps, suite));
+		assert.ok(stepIndex(steps, "Build native bindings for the root suites") < stepIndex(steps, suite));
+		assert.match(block, /uses: actions\/setup-node@/u);
+		assert.match(block, /uses: dtolnay\/rust-toolchain@/u);
+	}
+	const unit = blocks.get("unit-tests") as string;
+	const integration = blocks.get("integration-tests") as string;
+	assert.match(unit, /--no-retry-file flaky-test-suite-runner\.test\.ts/u);
+	assert.match(unit, /-- npm run test:unit/u);
+	assert.doesNotMatch(unit, /npm run test:integration/u);
+	assert.match(integration, /-- npm run test:integration/u);
+	assert.doesNotMatch(integration, /npm run test:unit/u);
+	for (const block of [unit, integration]) {
+		assert.equal(block.split("run-flaky-test-suite.ts").length - 1, 1);
+		const setup = jobSteps(block);
+		for (const [before, after] of [
+			["Install dependencies", "Alias @earendil-works/pi-ai"],
+			["Alias @earendil-works/pi-ai", "Build @bastani/pi-ai"],
+			["Build @bastani/pi-ai", "Build native bindings"],
+			["Build native bindings", "Build @bastani/atomic package"],
+		]) {
+			assert.ok(stepIndex(setup, before) < stepIndex(setup, after));
+		}
+	}
+	assert.match(
+		namedStep(jobSteps(blocks.get("integration-tests") as string), "Integration tests"),
+		/ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE: "1"/u,
+	);
 
 	const agent = jobSteps(blocks.get("agent-suite") as string);
 	assert.ok(
@@ -242,7 +235,7 @@ test("build-consuming steps stay in the job that produced the build", async () =
 /**
  * Dependencies install with `npm ci --ignore-scripts` everywhere, so every work
  * job needs Node. Bun is still set up wherever a `scripts/*.ts`, the release
- * binary compiler, or a Bun-hosted test fixture runs -- which is all four. A job
+ * binary compiler, or a Bun-hosted test fixture runs -- which is all five. A job
  * that installs with npm but never sets Node up would fall back to whatever the
  * runner image happens to ship, which is the drift this guards against.
  */
@@ -276,6 +269,9 @@ test("every diagnostics upload has a job-unique artifact name", async () => {
 		jobSteps(block)
 			.filter((step) => step.includes("actions/upload-artifact@"))
 			.map((step) => {
+				assert.match(step, /if: always\(\)/u);
+				assert.match(step, /retention-days: 14/u);
+				assert.match(step, /if-no-files-found: ignore/u);
 				assertDiagnosticsPath(step);
 				assert.throws(() => assertDiagnosticsPath(step.replace(/^\s+include-hidden-files: true\s*$/mu, "")));
 				assert.throws(() => assertDiagnosticsPath(step.replace("path: .ci-diagnostics/", "path: .")));
@@ -284,7 +280,7 @@ test("every diagnostics upload has a job-unique artifact name", async () => {
 				return (name[1] as string).trim();
 			}),
 	);
-	assert.ok(uploads.length >= 2, "the flaky-suite jobs must still preserve their diagnostics");
+	assert.equal(uploads.length, 3, "unit, integration and package jobs must each preserve diagnostics");
 	assert.equal(new Set(uploads).size, uploads.length, `duplicate artifact names: ${uploads.join(", ")}`);
 	for (const name of uploads) assert.match(name, /^test-diagnostics-[a-z-]+-\$\{\{ matrix\.binary_platform \}\}$/u);
 });

--- a/test/setup-workflow-durability.ts
+++ b/test/setup-workflow-durability.ts
@@ -2,7 +2,8 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach } from "vitest";
-import { createInMemoryTestBackend, setDurableBackend } from "../packages/workflows/src/durable/factory.js";
+import { InMemoryDurableBackend } from "../packages/workflows/src/durable/backend.js";
+import { getDurableBackendProcessOwner } from "../packages/workflows/src/durable/backend-process-owner.js";
 import { ENV_WORKFLOW_ARTIFACT_DIR } from "../packages/workflows/src/shared/workflow-artifact-env.js";
 
 /**
@@ -46,5 +47,7 @@ if (process.env[ENV_WORKFLOW_ARTIFACT_DIR] === undefined) {
  * DBOS adapter.
  */
 beforeEach(() => {
-	setDurableBackend(createInMemoryTestBackend());
+	// Match the factory's injection seam without eagerly loading DBOS and the host
+	// into every isolated test file. Do not reset initialized/pending/warning state.
+	getDurableBackendProcessOwner().injectedBackend = new InMemoryDurableBackend();
 });

--- a/test/unit/interactive-submit-send-failure.test.ts
+++ b/test/unit/interactive-submit-send-failure.test.ts
@@ -3,6 +3,7 @@ import { test } from "vitest";
 import { InteractiveModeBase } from "../../packages/coding-agent/src/modes/interactive/interactive-mode-base.ts";
 import "../../packages/coding-agent/src/modes/interactive/interactive-input-handling.ts";
 import "../../packages/coding-agent/src/modes/interactive/interactive-process-lifecycle.ts";
+import "../../packages/coding-agent/src/modes/interactive/interactive-extension-runtime.ts";
 import "../../packages/coding-agent/src/modes/interactive/interactive-bash-compact.ts";
 import "../../packages/coding-agent/src/modes/interactive/interactive-prompt-turn.ts";
 import { initTheme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.ts";

--- a/test/unit/module-graph-walker.ts
+++ b/test/unit/module-graph-walker.ts
@@ -135,8 +135,10 @@ function stringLiteralValue(node: unknown): string | undefined {
 	return undefined;
 }
 
-function isTypeOnlyImport(node: BabelNode): boolean {
+function isTypeOnlyImport(node: BabelNode, verbatimModuleSyntax: boolean): boolean {
 	if (node.importKind === "type") return true;
+	// Verbatim emit keeps `import { type T }` as a side-effect import.
+	if (verbatimModuleSyntax) return false;
 	const specifiers = (node.specifiers as BabelNode[] | undefined) ?? [];
 	if (specifiers.length === 0) return false;
 	return specifiers.every((specifier) => specifier.importKind === "type");
@@ -200,8 +202,11 @@ const SCOPE_NODE_TYPES = new Set([
 	"StaticBlock",
 ]);
 
-/** Every runtime module request a file makes, with type-only edges already removed. */
-export function runtimeRequestsOf(filePath: string): RuntimeRequest[] {
+/** Runtime requests; opt into verbatim import retention for consumers using that emit policy. */
+export function runtimeRequestsOf(
+	filePath: string,
+	options: { readonly verbatimModuleSyntax?: boolean } = {},
+): RuntimeRequest[] {
 	const ast = parseFile(filePath);
 	const requests: RuntimeRequest[] = [];
 
@@ -418,7 +423,7 @@ export function runtimeRequestsOf(filePath: string): RuntimeRequest[] {
 					else if (imported === "default") scope.bindings.set(local, { kind: "module-object" });
 					else scope.bindings.set(local, { kind: "other" });
 				}
-				if (!isTypeOnlyImport(node)) record("import", node.source);
+				if (!isTypeOnlyImport(node, options.verbatimModuleSyntax === true)) record("import", node.source);
 				return;
 			}
 			case "ExportNamedDeclaration":

--- a/test/unit/test-setup-import-graph.test.ts
+++ b/test/unit/test-setup-import-graph.test.ts
@@ -1,104 +1,74 @@
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, join, normalize } from "node:path";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { test } from "vitest";
-import { repositoryRoot } from "../../vitest.base.js";
+import tsconfig from "../../tsconfig.json";
+import { atomicSrcIndex, repositoryRoot, sharedAliases } from "../../vitest.base.js";
+import { runtimeRequestsOf } from "./module-graph-walker.js";
 
 /**
- * vitest runs `setupFiles` once per test file, each with a fresh module
- * registry. Every relative import reachable from the setup file is therefore
- * transformed and instantiated ~600 times per unit run, whether or not the test
- * under it touches workflows.
- *
- * This guard exists because that cost is invisible at the call site: adding one
- * `import { SOME_CONSTANT } from "…/workflow-artifacts.js"` to the setup file
- * looks free and silently drags fifty modules — including `@bastani/atomic`
- * itself — into every test process. Measured before that import was removed:
- * a single trivial test file cost 28.37s, of which 27.79s was setup.
- *
- * The bound is deliberately close to the current graph rather than generous. It
- * is a ratchet: if a change legitimately needs a larger graph, re-measure the
- * per-file cost first and move the number with the evidence in the commit
- * message. Do not raise it to make a red test green.
+ * Isolated test files each evaluate the setup's runtime graph. Vite can share
+ * transforms, but an eager host-barrel import still instantiates that graph in
+ * every worker, even for tests that never use workflows. Follow Vitest aliases
+ * as well as relative imports: the old regex missed the @bastani/atomic edge.
  */
 const SETUP_FILE = "test/setup-workflow-durability.ts";
-
-/**
- * Current reachable count is 39, dominated by `durable/factory.ts` pulling the
- * DBOS backend. 45 leaves headroom for incidental churn inside that existing
- * subsystem while still failing loudly if another hub module is imported.
- */
-// Re-measured at 47 when the intercom-stage-paths slices added stage-target modules to
-// the durable/shared graph (workflow-stage-target, possible-stages, path matching).
-// Re-measured at 49 after embedded Postgres target policy and durability warnings joined the graph.
-// Each branch independently reached 48; the merged graph adds both leaves. The process-owner leaf's only
-// import is type-only and erased at runtime; a trivial file's setup was 1.76–2.38s with that leaf versus
-// 1.83–2.21s without it.
+// Preserve the existing ceiling; only imports erased by the configured emit are excluded.
 const MAX_REACHABLE_MODULES = 49;
 
-/**
- * Every static and dynamic import form that can pull a module into the graph.
- *
- * A guard that only recognizes `from "…"` can be walked straight past: a
- * side-effect import or a dynamic `import()` is a real edge that costs the same
- * transform, and matching one narrow source form would let an expensive module
- * in without tripping the ceiling. Biome enforces double quotes repo-wide, but
- * single quotes are matched too so the guard does not depend on lint ordering.
- */
-const RELATIVE_SPECIFIER_PATTERNS: readonly RegExp[] = [
-	/\bfrom\s*["'](\.[^"']+)["']/g, // import … from "x" / export … from "x"
-	/^\s*import\s+["'](\.[^"']+)["']/gm, // side effect: import "x"
-	/\bimport\s*\(\s*["'](\.[^"']+)["']/g, // dynamic: import("x")
-];
-
-/** Relative specifiers in a TypeScript source, as written (`.js` per ESM convention). */
-function relativeImports(source: string): string[] {
-	const found = new Set<string>();
-	for (const pattern of RELATIVE_SPECIFIER_PATTERNS) {
-		for (const match of source.matchAll(pattern)) {
-			const specifier = match[1];
-			if (specifier !== undefined) found.add(specifier);
-		}
+function runtimeImports(file: string): string[] {
+	try {
+		return runtimeRequestsOf(file, tsconfig.compilerOptions).flatMap((request) =>
+			request.specifier === undefined ? [] : [request.specifier],
+		);
+	} catch (cause) {
+		throw new Error(`Cannot inspect runtime imports in ${file}`, { cause });
 	}
-	return [...found];
 }
 
-/** Every repository module transitively reachable from `entry` through relative imports. */
+function resolveImport(importer: string, specifier: string): string | undefined {
+	const alias = sharedAliases.find(({ find }) =>
+		typeof find === "string" ? specifier === find || specifier.startsWith(`${find}/`) : find.test(specifier),
+	);
+	const target = alias === undefined ? specifier : specifier.replace(alias.find, alias.replacement);
+	if (!target.startsWith(".") && !isAbsolute(target)) return undefined;
+	const absolute = resolve(dirname(importer), target);
+	return [absolute.replace(/\.js$/u, ".ts"), absolute].find((candidate) => existsSync(candidate));
+}
+
 function reachableModules(entry: string): Set<string> {
 	const seen = new Set<string>();
-	const pending = [entry];
-
-	while (pending.length > 0) {
+	const pending = [resolve(repositoryRoot, entry)];
+	// Once over budget, the guard already has a counterexample; do not parse the whole host.
+	while (pending.length > 0 && seen.size <= MAX_REACHABLE_MODULES) {
 		const current = pending.pop();
 		if (current === undefined || seen.has(current)) continue;
-
-		const absolute = join(repositoryRoot, current);
-		if (!existsSync(absolute)) continue;
-
 		seen.add(current);
-		for (const specifier of relativeImports(readFileSync(absolute, "utf8"))) {
-			const resolved = normalize(join(dirname(current), specifier.replace(/\.js$/, ".ts")));
-			pending.push(resolved);
+		for (const specifier of runtimeImports(current)) {
+			const resolved = resolveImport(current, specifier);
+			if (resolved !== undefined && /\.[cm]?[jt]sx?$/u.test(resolved)) pending.push(resolved);
 		}
 	}
-
 	return seen;
 }
 
 test("the vitest setup file's import graph stays small", () => {
 	const reachable = reachableModules(SETUP_FILE);
-
 	assert.ok(
 		reachable.size <= MAX_REACHABLE_MODULES,
 		`${SETUP_FILE} reaches ${reachable.size} modules, above the ${MAX_REACHABLE_MODULES} ceiling. ` +
-			"Every one is transformed once per test file. Import a dependency-free leaf instead of a hub " +
-			`module, or re-measure and move the ceiling deliberately. Reachable:\n${[...reachable].sort().join("\n")}`,
+			"Every one is evaluated once per isolated test file. Import a leaf instead of a hub. Reachable:\n" +
+			[...reachable]
+				.map((file) => relative(repositoryRoot, file))
+				.sort()
+				.join("\n"),
 	);
 });
 
 test("the setup file does not import the workflow-artifacts hub", () => {
 	const source = readFileSync(join(repositoryRoot, SETUP_FILE), "utf8");
-
 	assert.ok(
 		!source.includes("shared/workflow-artifacts.js"),
 		`${SETUP_FILE} imports shared/workflow-artifacts.js, which reaches ~50 modules including ` +
@@ -108,20 +78,87 @@ test("the setup file does not import the workflow-artifacts hub", () => {
 
 test("the workflow-artifact-env leaf has no relative imports", () => {
 	const leaf = "packages/workflows/src/shared/workflow-artifact-env.ts";
-	const imports = relativeImports(readFileSync(join(repositoryRoot, leaf), "utf8"));
-
-	assert.deepEqual(
-		imports,
-		[],
-		`${leaf} must stay dependency-free: it exists so the vitest setup file can read constants ` +
-			`without transforming a module graph. Found: ${imports.join(", ")}`,
-	);
+	assert.deepEqual(runtimeImports(join(repositoryRoot, leaf)), [], `${leaf} must stay dependency-free`);
 });
 
 test("the leaf and the hub agree on the constants", async () => {
 	const leaf = await import("../../packages/workflows/src/shared/workflow-artifact-env.js");
 	const hub = await import("../../packages/workflows/src/shared/workflow-artifacts.js");
-
 	assert.equal(hub.ENV_WORKFLOW_ARTIFACT_DIR, leaf.ENV_WORKFLOW_ARTIFACT_DIR);
 	assert.equal(hub.WORKFLOW_ARTIFACT_RETENTION_MS, leaf.WORKFLOW_ARTIFACT_RETENTION_MS);
+});
+
+test("the setup graph resolves the same host alias and relative source paths as Vitest", () => {
+	const importer = join(repositoryRoot, SETUP_FILE);
+	assert.equal(resolveImport(importer, "@bastani/atomic"), atomicSrcIndex);
+	assert.equal(resolveImport(importer, "node:fs"), undefined);
+	assert.equal(resolveImport(importer, "vitest"), undefined);
+	assert.equal(
+		resolveImport(importer, "../packages/workflows/src/durable/backend.js"),
+		join(repositoryRoot, "packages/workflows/src/durable/backend.ts"),
+	);
+});
+
+test("the setup graph follows runtime imports and exports but erases type-only edges", () => {
+	const root = mkdtempSync(join(tmpdir(), "atomic-setup-graph-"));
+	try {
+		const entry = join(root, "entry.ts");
+		writeFileSync(
+			entry,
+			[
+				'import { value } from "./leaf.js";',
+				'import { type Shape, mixed } from "./mixed.js";',
+				'import type { OnlyType } from "./missing-type.js";',
+				'import { type InlineType } from "./inline-type.js";',
+				'export { value as exported } from "./export.js";',
+				'export { type Shape, mixed } from "./mixed-export.js";',
+				'export type * from "./missing-export-type.js";',
+				'export { type InlineType } from "./missing-export-inline.js";',
+				'export * from "./star.js";',
+				'import "./side.js";',
+				'async function load() { return import("./dynamic.js"); }',
+				"const comment = 'import \"./not-an-import.js\"';",
+			].join("\n"),
+		);
+		const expected = ["leaf", "mixed", "inline-type", "export", "mixed-export", "star", "side", "dynamic"];
+		for (const name of expected) writeFileSync(join(root, `${name}.ts`), 'import "./entry.js";');
+		assert.deepEqual(
+			runtimeImports(entry),
+			expected.map((name) => `./${name}.js`),
+		);
+		assert.deepEqual(reachableModules(entry), new Set([entry, ...expected.map((name) => join(root, `${name}.ts`))]));
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("the setup graph matches Vite's executed inline-type import side effects", async () => {
+	const { transformWithOxc } = await import("vite");
+	const root = mkdtempSync(join(tmpdir(), "atomic-setup-type-effects-"));
+	try {
+		writeFileSync(join(root, "side.mjs"), 'console.log("side-effect");');
+		for (const statement of [
+			'import { type Shape } from "./side.mjs";',
+			'import type { Shape } from "./side.mjs";',
+			'export { type Shape } from "./side.mjs";',
+			'export type { Shape } from "./side.mjs";',
+		]) {
+			const entry = join(root, "entry.ts");
+			writeFileSync(entry, statement);
+			// Resolve the real repository tsconfig, rather than the temp directory's defaults.
+			const { code } = await transformWithOxc(statement, join(repositoryRoot, "test/unit/type-effects.ts"));
+			const runtime = join(root, "entry.mjs");
+			writeFileSync(runtime, code);
+			const result = spawnSync(process.execPath, [runtime], { encoding: "utf8" });
+			assert.equal(result.status, 0, result.stderr);
+			const executes = result.stdout.trim() === "side-effect";
+			assert.equal(executes, statement.startsWith("import {"), `${statement}\n${code}`);
+			assert.deepEqual(runtimeImports(entry), executes ? ["./side.mjs"] : [], `${statement}\n${code}`);
+			assert.deepEqual(runtimeRequestsOf(entry), [], "non-verbatim callers retain type erasure");
+			assert.deepEqual(runtimeRequestsOf(entry, { verbatimModuleSyntax: false }), []);
+			assert.equal(reachableModules(entry).has(join(root, "side.mjs")), executes);
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
 });

--- a/test/unit/test-setup-workflow-durability.test.ts
+++ b/test/unit/test-setup-workflow-durability.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { afterAll, test } from "vitest";
+import { InMemoryDurableBackend } from "../../packages/workflows/src/durable/backend.js";
+import { getDurableBackendProcessOwner } from "../../packages/workflows/src/durable/backend-process-owner.js";
+import { getDurableBackend, setDurableBackend } from "../../packages/workflows/src/durable/factory.js";
+
+const owner = getDurableBackendProcessOwner();
+const original = { ...owner };
+const initialized = new InMemoryDurableBackend();
+const initializing = Promise.resolve(initialized);
+const warningSink = (_message: string): void => {};
+let previousInjected: InMemoryDurableBackend | undefined;
+let previousOverride: InMemoryDurableBackend | undefined;
+let completed = 0;
+
+afterAll(() => {
+	Object.assign(owner, original);
+});
+
+// These ordinary, ordered tests exercise the real configured beforeEach twice.
+// The second verifies the transition from an explicit override to a fresh backend.
+for (const ordinal of [0, 1]) {
+	test(`durable setup installs a fresh factory-visible backend before test ${ordinal + 1}`, () => {
+		assert.equal(completed, ordinal);
+		const injected = getDurableBackend();
+		assert.ok(injected instanceof InMemoryDurableBackend);
+		assert.equal(injected, owner.injectedBackend);
+		assert.notEqual(injected, previousInjected);
+		assert.notEqual(injected, previousOverride);
+		assert.equal(injected.persistent, false);
+		if (ordinal === 1) {
+			assert.equal(owner.initializedBackend, initialized);
+			assert.equal(owner.initializing, initializing);
+			assert.equal(owner.warningSink, warningSink);
+			assert.equal(owner.warningReported, true);
+		}
+		owner.initializedBackend = initialized;
+		owner.initializing = initializing;
+		owner.warningSink = warningSink;
+		owner.warningReported = true;
+		const override = new InMemoryDurableBackend();
+		setDurableBackend(override);
+		assert.equal(getDurableBackend(), override);
+		previousInjected = injected;
+		previousOverride = override;
+		completed++;
+	});
+}


### PR DESCRIPTION
## Summary

Reduce root unit-test setup overhead without changing test isolation, worker sizing, retries, timeouts, or existing test coverage. Restore the CI diagnostics uploads that were silently excluding the hidden directory.

## Changes

- Initialize each test's in-memory durable backend through the backend and process-owner leaves instead of eagerly loading the DBOS factory and Atomic host graph.
- Make the interactive fixture's real prototype-installer dependency explicit.
- Strengthen the setup import-graph guard to follow Vitest aliases and actual verbatim-module emit semantics, including a Vite transform/runtime regression. Preserve the existing graph ceiling and default behavior for other walker consumers.
- Enable hidden-file uploads only for the existing narrow `.ci-diagnostics/` paths. Preserve all nine check contexts and result-gate behavior.
- Document historical CI timings, measured local gains, rejected assumptions and remaining hosted validation. Add minimal supplemental qlty configuration used during verification.

## Performance evidence

Matched local full-unit runs on macOS arm64, Node 22.23.2 and Bun 1.4.2:

| Comparison | Original setup | Lean setup | Wall reduction |
| --- | ---: | ---: | ---: |
| Initial pair | 137.08 s | 118.61 s | 13.47% |
| Reverse-order pair | 140.00 s | 119.53 s | 14.62% |

CPU time fell 14.81–14.90%. Original case identities, multiplicities and outcomes were preserved. Both timing variants retained the same existing personal-configuration timeout and 23 existing skips; these are controlled timing comparisons, not all-green claims. Five additional regression cases cover the patch.

**Hosted Windows/Linux speedup is not yet measured.** Applying the local improvement to the sampled Windows unit step projects roughly 66–72 seconds saved per attempt, not verified CI savings. The current patch does not establish sub-five-minute CI. Diagnostics repair is an observability fix, not a speedup.

## Validation

Independent implementation/evidence/risk review approved the repaired patch. A separate deterministic verification run passed every gate with the exact unchanged patch fingerprint:

- `npm run build`
- `npm run check`
- `npm run test:ci-contracts` — 87 tests
- `npm run test:scripts`
- Root unit, integration and coding-agent package suites through the existing bounded flake/duration wrapper, including its no-retry exception for `flaky-test-suite-runner.test.ts`.
- Hard-required installed-package and native-binding smoke flags remained enabled.

Final local checks used Node 22 and fresh command-scoped `ATOMIC_CODING_AGENT_DIR` directories to exclude ambient personal workflows. Project, bundled and explicit package fixtures still ran. Full unit validation passed 7,589 tests with the same 23 pre-existing skips. Isolated correctness-run timings are not mixed into the A/B benchmark. Focused regressions, docs validation and supplemental qlty checks also ran; qlty's pre-existing walker-complexity finding is not presented as a clean-smells result.

## Notes

No runner-size, cache policy, topology, branch-protection or release-pipeline changes. No package changelog entry because this is test/CI infrastructure. The PR's normal CI run should establish hosted compatibility and confirm that all four diagnostic artifacts now upload. See `docs/ci.md` for the sample, limitations and follow-up measurement plan.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791239012&installation_model_id=10562&pr_number=2879&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2879&signature=2fe879d58d5da97e559704fed8252d002314c35d967884165bfd87ef49b04e3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary

- The changes reduce durable-test setup cost, strengthen import-graph coverage, restore diagnostics uploads, and separate root unit and integration CI work.
- No new actionable issues remain.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

There are no outstanding actionable findings.

<sub>Reviews (2): Last reviewed commit: ["perf(ci): run unit and integration jobs ..."](https://github.com/bastani-inc/atomic/commit/431cc18e3da075b555d84730a1b1884eab62d0c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60834613)</sub>

**Context used:**

- Knowledge Base — [Workflow engine and durable runs](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/workflow-engine-and-durability.md)
- Knowledge Base — [Coding agent application](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/coding-agent.md)

<!-- /greptile_comment -->