### PR TITLE
fix(intercom): preserve workflow authority across group reconnects

### DIFF
--- a/packages/coding-agent/docs/intercom.md
+++ b/packages/coding-agent/docs/intercom.md
@@ -169,6 +169,15 @@ intercom({ action: "join", group: "api-review" })
 
 Joining is additive: existing memberships remain active, and the broker updates presence without changing the session ID. Use `intercom({ action: "groups" })` to discover all available names and membership markers. `intercom({ action: "leave", group: "api-review" })` removes only that membership; `intercom({ action: "leave" })` resets to the home group resolved at startup. Rejected or unacknowledged changes leave client and inheritance state unchanged. Ordinary delivery requires a shared membership, while `contact_supervisor` retains its capability-based cross-group path.
 
+An ordinary host session can join several workflow invocation groups and send to
+each group's `workflow:<rootRunId>/**` target, including after a broker reconnect.
+Reconnection preserves the session's startup identity separately from its joined
+memberships; joining a workflow does not turn the host into a workflow worker.
+Groups explicitly left stay absent after reconnect; the startup identity is not
+automatically added back to the membership list.
+Actual workflow workers retain their original invocation boundary across reconnects:
+joining another group does not grant that invocation's parent-control authority.
+
 Sent and received messages are recorded in session history as `intercom_sent` / `intercom_received` entries.
 
 ### Targeting Sessions and Pending Workflow Stages

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Fixed
+
+- Host sessions that join multiple workflow groups retain workflow broadcast and pending-stage routing after reconnecting. Registration now preserves the startup home group instead of treating the most recently joined group as the session's origin; workflow workers still cannot gain another invocation's control authority through joins or reconnects.
+
 ## [0.9.18-alpha.6] - 2026-09-04
 
 ### Breaking Changes

--- a/packages/intercom/README.md
+++ b/packages/intercom/README.md
@@ -184,6 +184,11 @@ intercom({
 
 To coordinate two plain chat sessions without changing startup config, have each call `intercom({ action: "join", group: "NAME" })`. Joining adds a membership without changing the session ID or removing existing memberships. Calls to `list`, `send`, and `ask` can then reach any session sharing at least one membership. Use `intercom({ action: "groups" })` to discover every available name, connected-session count, and membership marker. Call `intercom({ action: "leave", group: "NAME" })` to remove one membership while keeping the others, or bare `leave` to reset to the original home group. `contact_supervisor` keeps its dedicated capability-based cross-group behavior.
 
+Joined memberships survive broker reconnects without replacing the session's
+startup identity. An ordinary host can therefore control several joined workflow
+invocations, while a workflow worker cannot gain another invocation's parent-control
+authority by joining its group and reconnecting.
+
 **Worker finds something unexpected — escalates and waits:**
 ```typescript
 intercom({

--- a/packages/intercom/broker/broker.ts
+++ b/packages/intercom/broker/broker.ts
@@ -1183,6 +1183,10 @@ class IntercomBroker {
         if (!isSessionRegistration(clientMessage.session)) {
           throw new Error("Invalid register message");
         }
+		if (clientMessage.registrationGroup !== undefined &&
+			(typeof clientMessage.registrationGroup !== "string" || clientMessage.registrationGroup.trim().length === 0)) {
+			throw new Error("Invalid registration group");
+		}
 		if (clientMessage.returnAddress !== undefined &&
 			(typeof clientMessage.returnAddress !== "string" || clientMessage.returnAddress.length === 0)) {
 			throw new Error("Invalid return address");
@@ -1222,7 +1226,8 @@ class IntercomBroker {
         this.sessions.set(id, {
           socket,
           info,
-          registrationGroup: legacyGroup,
+          registrationGroup: typeof clientMessage.registrationGroup === "string"
+            ? normalizeGroup(clientMessage.registrationGroup) : legacyGroup,
 			...(typeof info.name === "string" && info.name.trim().length > 0
 				? { registrationName: info.name.trim() }
 				: {}),

--- a/packages/intercom/broker/client.ts
+++ b/packages/intercom/broker/client.ts
@@ -231,6 +231,7 @@ export class IntercomClient extends EventEmitter {
     supervisor?: SupervisorRegistration,
     supervisorOwnerToken?: string,
     messageSource?: Message["source"],
+    registrationGroup?: string,
   ): Promise<void> {
     if (this.socket) {
       return Promise.reject(new Error("Already connected"));
@@ -360,6 +361,7 @@ export class IntercomClient extends EventEmitter {
         writeMessage(socket, {
           type: "register",
           session,
+          ...(registrationGroup !== undefined ? { registrationGroup } : {}),
 			returnAddress: this.returnAddress,
           ...(supervisor ? { supervisor } : {}),
           ...(supervisorOwnerToken ? { supervisorOwnerToken } : {}),

--- a/packages/intercom/index-heavy.ts
+++ b/packages/intercom/index-heavy.ts
@@ -847,8 +847,10 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
           childMetadata?.supervisor,
           supervisorAuthorizations.ownerToken,
           readSubagentMessageSource(runtimeContext?.subagentPolicy),
+          // Origin controls workflow authority, not membership or child inheritance.
+          resolveSessionHomeGroup(),
         );
-        clientRegistrationGroup = normalizeGroup(registration.group);
+        clientRegistrationGroup = resolveSessionHomeGroup();
         await supervisorAuthorizations.restore(nextClient);
         for (const [runId, route] of pendingStageRoutes) {
           await registerPendingStageRoute(nextClient, runId, route);

--- a/packages/intercom/types.ts
+++ b/packages/intercom/types.ts
@@ -100,6 +100,8 @@ export type ClientMessage =
 			session: Omit<SessionInfo, "id">;
 			/** Internal host-owned identity retained across broker reconnects. */
 			returnAddress?: string;
+			/** Immutable session origin; separate from mutable group memberships. Legacy clients use session.group. */
+			registrationGroup?: string;
 			supervisor?: SupervisorRegistration;
 			supervisorOwnerToken?: string;
 	  }

--- a/test/integration/intercom-reconnect-recovery.test.ts
+++ b/test/integration/intercom-reconnect-recovery.test.ts
@@ -18,6 +18,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterAll, test, vi } from "vitest";
+import type { PendingStageMessageRequest } from "../../packages/intercom/broker/client.js";
 import { sleep } from "../helpers/runtime.ts";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
@@ -343,6 +344,175 @@ afterAll(() => {
 	else process.env.PI_CODING_AGENT_DIR = previousLegacyAgentDir;
 	rmSync(agentDir, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
 });
+
+test("an ordinary host controls a second invocation after joining the first and re-registering", async () => {
+	const groupA = "workflow:16adff11-b761-44b7-b265-cd84e5e89b20";
+	const runB = "f5f1d680-cfc0-429e-a511-a6c5f0029dc4";
+	const groupB = `workflow:${runB}`;
+	const stageTarget = `${groupB}/reviewer`;
+	const host = extensionFixture("multigroup-host-session", "multigroup-host", { intercomGroup: "default" });
+	intercomHeavy(host.pi as never);
+	const owner = new IntercomClient();
+	const stage = new IntercomClient();
+	const sessionInfo = { cwd: repoRoot, model: "test", pid: process.pid, startedAt: 1, lastActivity: 1 };
+	const requests: PendingStageMessageRequest[] = [];
+	const received = Promise.withResolvers<void>();
+	stage.on("message", () => received.resolve());
+	owner.on("pending_stage_message", (request: PendingStageMessageRequest) => {
+		requests.push(request);
+		owner.respondPendingStageMessage(
+			request.requestId,
+			request.live
+				? { outcome: "forward", target: request.target }
+				: { outcome: "queued", position: requests.length },
+		);
+	});
+	try {
+		await host.start();
+		assert.equal((await host.execute({ action: "join", group: groupA })).isError, false);
+		const firstPid = await waitForBrokerPid();
+		killBroker(firstPid);
+		await waitForBrokerPid(firstPid);
+		await waitFor("the multigroup host to re-register without a tool call", async () =>
+			(await probeSessionNames()).includes("multigroup-host") ? true : undefined,
+		);
+
+		await owner.connect({ ...sessionInfo, name: "invocation-b-owner", group: groupB });
+		owner.registerPendingStageRoute(runB, groupB, "multigroup-capability", [
+			{
+				stageId: "reviewer",
+				stageName: "reviewer",
+				target: stageTarget,
+				group: `${groupB}/isolated`,
+				lifecycle: "running",
+				routeEligible: true,
+			},
+		]);
+		await owner.listSessions();
+		await stage.connect({ ...sessionInfo, name: "isolated-reviewer", group: `${groupB}/isolated` });
+		await stage.registerLiveWorkflowStageRoute(runB, ["reviewer"], "multigroup-capability");
+		const joined = await host.execute({ action: "join", group: groupB });
+		assert.equal(joined.isError, false, joined.content[0]?.text);
+		const status = await host.execute({ action: "status" });
+		assert.ok(status.content[0]?.text.includes(groupA));
+		assert.ok(status.content[0]?.text.includes(groupB));
+		const direct = await host.execute({ action: "send", to: owner.sessionId!, message: "direct works" });
+		assert.equal(direct.details.delivered, true, direct.content[0]?.text);
+
+		for (const target of [`${groupB}/**`, `${groupB}/review-*`, `${groupB}/future`]) {
+			const sent = await host.execute({ action: "send", to: target, message: `control ${target}` });
+			assert.equal(sent.details.queued, true, sent.content[0]?.text);
+		}
+		const listed = await host.execute({ action: "list", group: `${groupB}/isolated` });
+		assert.ok(listed.content[0]?.text.includes(stageTarget), listed.content[0]?.text);
+		const live = await host.execute({ action: "send", to: stageTarget, message: "live control" });
+		assert.equal(live.details.delivered, true, live.content[0]?.text);
+		await received.promise;
+		assert.equal((await host.execute({ action: "leave", group: groupA })).isError, false);
+		const afterLeave = await host.execute({ action: "send", to: `${groupB}/**`, message: "still control B" });
+		assert.equal(afterLeave.details.queued, true, afterLeave.content[0]?.text);
+		assert.deepEqual(
+			requests.map((request) => request.target),
+			[`${groupB}/**`, `${groupB}/review-*`, `${groupB}/future`, stageTarget, `${groupB}/**`],
+		);
+	} finally {
+		await stage.disconnect();
+		await owner.disconnect();
+		await host.shutdown();
+	}
+});
+
+test.each(["", "/worker"])(
+	"a workflow stage in invocation subgroup '%s' cannot gain control by joining and reconnecting",
+	async (suffix) => {
+		const runA = "82a2d5fd-56a5-4bc9-93ef-27c5e857c74d";
+		const homeGroup = `workflow:${runA}${suffix}`;
+		const runB = "6e55df27-a9d9-43a2-87d9-49f16b669c74";
+		const groupB = `workflow:${runB}`;
+		const stageTarget = `${groupB}/reviewer`;
+		const worker = extensionFixture("multigroup-worker-session", "multigroup-worker", {
+			intercomGroup: homeGroup,
+			kind: "workflow-stage",
+			workflowRunId: runA,
+			workflowStageId: "worker",
+			workflowStageName: "worker",
+		});
+		intercomHeavy(worker.pi as never);
+		const owner = new IntercomClient();
+		const stage = new IntercomClient();
+		const sessionInfo = { cwd: repoRoot, model: "test", pid: process.pid, startedAt: 1, lastActivity: 1 };
+		const requests: PendingStageMessageRequest[] = [];
+		owner.on("pending_stage_message", (request: PendingStageMessageRequest) => {
+			requests.push(request);
+			owner.respondPendingStageMessage(
+				request.requestId,
+				request.live ? { outcome: "forward", target: request.target } : { outcome: "queued", position: 1 },
+			);
+		});
+		const connectVictim = async () => {
+			await owner.connect({ ...sessionInfo, name: "victim-owner", group: groupB });
+			owner.registerPendingStageRoute(runB, groupB, "victim-capability", [
+				{
+					stageId: "reviewer",
+					stageName: "reviewer",
+					target: stageTarget,
+					group: `${groupB}/isolated`,
+					lifecycle: "running",
+					routeEligible: true,
+				},
+			]);
+			await owner.listSessions();
+			await stage.connect({ ...sessionInfo, name: "victim-stage", group: `${groupB}/isolated` });
+			await stage.registerLiveWorkflowStageRoute(runB, ["reviewer"], "victim-capability");
+		};
+		const assertIsolated = async () => {
+			const registration = (await owner.listSessions()).find((session) => session.name === "multigroup-worker");
+			assert.ok(registration);
+			assert.deepEqual(
+				registration.groups,
+				suffix ? [groupB, "default"] : [groupB],
+				"reconnect must not restore a deliberately left home group",
+			);
+			const direct = await worker.execute({
+				action: "send",
+				to: owner.sessionId!,
+				message: "joined member traffic",
+			});
+			assert.equal(direct.details.delivered, true, direct.content[0]?.text);
+			for (const target of [`${groupB}/**`, `${groupB}/review-*`, `${groupB}/future`, stageTarget]) {
+				const sent = await worker.execute({ action: "send", to: target, message: "must not gain control" });
+				assert.equal(sent.isError, true, `worker gained control of ${target}: ${sent.content[0]?.text}`);
+				assert.match(sent.content[0]?.text ?? "", /different intercom group/);
+			}
+			const listed = await worker.execute({ action: "list", group: `${groupB}/isolated` });
+			assert.ok(!listed.content[0]?.text.includes(stageTarget), listed.content[0]?.text);
+			assert.deepEqual(requests, [], "unauthorized operations must never reach the route owner");
+		};
+		try {
+			await worker.start();
+			assert.equal((await worker.execute({ action: "join", group: groupB })).isError, false);
+			// Cover both reclassification as another invocation owner and as an ordinary host.
+			if (suffix) assert.equal((await worker.execute({ action: "join", group: "default" })).isError, false);
+			assert.equal((await worker.execute({ action: "leave", group: homeGroup })).isError, false);
+			await connectVictim();
+			await assertIsolated();
+			await stage.disconnect();
+			await owner.disconnect();
+			const firstPid = await waitForBrokerPid();
+			killBroker(firstPid);
+			await waitForBrokerPid(firstPid);
+			await connectVictim();
+			await waitFor("the workflow worker to re-register", async () =>
+				(await owner.listSessions()).some((session) => session.name === "multigroup-worker") ? true : undefined,
+			);
+			await assertIsolated();
+		} finally {
+			await stage.disconnect();
+			await owner.disconnect();
+			await worker.shutdown();
+		}
+	},
+);
 
 test("a failed background reconnect still recovers the session with no intercom tool call", async () => {
 	const forced = failFirstConnectAttempt("background");


### PR DESCRIPTION
## Summary

Fix workflow broadcasts and pending-stage routing for ordinary controller sessions that join multiple Intercom groups and reconnect. Created in a separate worktree from merged main after CI PR #2879 passed and merged.

## Changes

- Keep immutable workflow authority separate from mutable memberships. Reconnect previously registered the last joined group as the session's origin, causing an ordinary host to be mistaken for a worker of that invocation.
- Send the cached home group in an optional registration-only `registrationGroup` field. The broker validates and snapshots it; legacy clients retain their existing fallback. Existing workflow authorization checks are unchanged.
- Preserve explicitly left groups and membership ordering. Simply replacing the legacy `group` field with the home group restored memberships users had deliberately removed, so the final fix keeps the fields separate.
- Cover the inverse error too: actual workflow workers cannot acquire another invocation's control authority by joining groups and reconnecting. Ordinary shared-membership traffic remains allowed.
- Update Intercom documentation and Unreleased notes.

## Validation

- Reproduced the original host failure with the real extension and restarted broker: both groups visible, direct send succeeds, workflow broadcast fails.
- Reproduced both worker escalation cases on original code and left-home membership resurrection on the initial candidate.
- Final reconnect integration suite: 8 passed.
- Routing, security, sticky delivery, broker membership and tool-group unit suites: 74 passed.
- `npm run check`, docs link validation, applicable Biome checks, diff checks and signed-commit hooks passed.
- Hosted CI is pending; no Windows runtime success claimed yet.

## Notes

The optional field is sent only at registration and does not make membership updates an authority-update mechanism. Updated extension and broker code are required for the fix; sessions carrying an incorrect prior registration need to reconnect after updating. No workflow isolation predicates were relaxed. This PR does not change CI configuration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791241666&installation_model_id=10562&pr_number=2880&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2880&signature=faba0f96f98076482f41bb453e8e8237189ccc4139c58cee9e667b8b7bbc864d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change separates immutable Intercom workflow authority from mutable group memberships during registration and reconnect. It preserves an ordinary host’s joined workflow routing after reconnect while retaining workflow-worker isolation across invocation boundaries. The targeted reconnect scenarios completed successfully.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the exercised reconnect and authority-boundary flows behaved as intended, with no actionable issue found.

No final findings were identified. The targeted host reconnect flow and both workflow-worker isolation variants completed successfully.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Uploaded the registration-group-validation.sh executable used for the validation workflow.
- Executed the targeted Vitest tests and confirmed both invocations exited with code 0.
- Validated the host-case workflow by simulating a real broker kill and re-registration, and verified pending-stage queueing, live delivery, stage listing, and retained access after leaving another group.
- Validated the worker-case workflow by testing a joined/reconnected workflow-stage worker, ensuring membership traffic is retained while target control/list visibility is denied and no pending-stage route-owner requests are produced.

<a href="https://app.greptile.com/trex/runs/22730234/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(intercom): preserve workflow authori..."](https://github.com/bastani-inc/atomic/commit/bafc6ebd17fa8d58e61f2ee925ee7e9b6b72f1e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60841061)</sub>

**Context used:**

- Knowledge Base — [Intercom messaging](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/intercom-messaging.md)
- Knowledge Base — [Intercom delivery and replies](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/intercom-delivery-and-replies.md)

<!-- /greptile_comment -->