### PR TITLE
ci: calibrate job timeouts with 50% measured headroom

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,14 +45,14 @@ jobs:
         include:
           - os: blacksmith-4vcpu-ubuntu-2404
             binary_platform: linux-x64
-            timeout_minutes: 28
+            timeout_minutes: 10
           - os: blacksmith-4vcpu-windows-2025
             binary_platform: windows-x64
-            timeout_minutes: 28
+            timeout_minutes: 14
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Retain the combined suites job's 28-minute cap conservatively. This is an
-    # inherited hang detector with retry headroom, not a measured split-job budget.
+    # ceil(1.5 x slower job duration / 60) from runs 33997174167 and 33997819241.
+    # Measurements and retry/cold-cache limitations are recorded in docs/ci.md.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       # Sticky disks are Blacksmith-Linux-only; Windows takes a standard clone.
@@ -135,13 +135,13 @@ jobs:
         include:
           - os: blacksmith-4vcpu-ubuntu-2404
             binary_platform: linux-x64
-            timeout_minutes: 28
+            timeout_minutes: 3
           - os: blacksmith-4vcpu-windows-2025
             binary_platform: windows-x64
-            timeout_minutes: 28
+            timeout_minutes: 5
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Inherited hang detector, not a measured split-job budget. Keep retry headroom.
+    # Two-run maximum plus 50% headroom, rounded up to minutes; see docs/ci.md.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       - uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1.1
@@ -208,20 +208,13 @@ jobs:
         include:
           - os: blacksmith-4vcpu-ubuntu-2404
             binary_platform: linux-x64
-            timeout_minutes: 8
+            timeout_minutes: 6
           - os: blacksmith-4vcpu-windows-2025
             binary_platform: windows-x64
-            timeout_minutes: 12
+            timeout_minutes: 9
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Measured on sha 772a373: 154s / 250s in the green run 31047542976, and a
-    # worst observation of 221s Linux / 270s Windows across both events on that
-    # SHA; the first split run measured 138s / 349s. Linux moves 6 -> 8 min
-    # (480s, 2.17x of the 221s worst observation) because 6 min had decayed to
-    # 1.6x, the same drift that cancelled `suites`. Windows stays at 12 min
-    # (720s), 2.06x that historical 349s observation. Current PR samples put
-    # the critical path on `suites`, usually its Windows unit step. Keep these
-    # retry-inclusive caps; sharding is prohibited by the testing contract.
+    # Two-run maximum plus 50% headroom, rounded up to minutes; see docs/ci.md.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       - uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1.1
@@ -290,16 +283,13 @@ jobs:
         include:
           - os: blacksmith-4vcpu-ubuntu-2404
             binary_platform: linux-x64
-            timeout_minutes: 5
+            timeout_minutes: 2
           - os: blacksmith-4vcpu-windows-2025
             binary_platform: windows-x64
-            timeout_minutes: 9
+            timeout_minutes: 4
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # The warm sample measured 162s, but cold acquisition consumed 152s for
-    # rust-toolchain and 71s for checkout, on top of ~110s native build and
-    # ~40s archive smoke: an observed tail near 6m50s versus a healthy 4m04s.
-    # Keep 9m of headroom for that cold toolchain tail.
+    # Two-run maximum plus 50% headroom, rounded up to minutes; see docs/ci.md.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       - uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1.1
@@ -455,7 +445,7 @@ jobs:
     # Platform-independent checks run once on Linux. The CI project's native
     # global setup still builds a missing binding, so a cold job needs Rust.
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 6
+    timeout-minutes: 3
     steps:
       - uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1.1
         with:
@@ -535,7 +525,7 @@ jobs:
             binary_platform: windows-x64
       fail-fast: false
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 5
+    timeout-minutes: 1
     steps:
       - name: Require every work job to have succeeded
         shell: bash

--- a/.npmrc
+++ b/.npmrc
@@ -25,9 +25,9 @@ min-release-age=0
 #
 # Give each request 25 seconds and two quick retries. Conservatively charging
 # all three attempts the full fetch timeout and both backoffs the 5-second
-# maximum bounds one stalled request to 85 seconds. That is below one third of
-# the smallest job budget in test.yml (the CI contract derives that relationship
-# from the workflow), while a healthy warm-cache install pays no timeout or
+# maximum bounds one stalled request to 85 seconds, below the smallest npm job
+# cap in test.yml. Setup and other requests share that cap, so the job deadline
+# can still interrupt retries. A healthy warm-cache install pays no timeout or
 # backoff at all. What this gives up: one unusually slow response no longer gets
 # five uninterrupted minutes; it is abandoned after 25 seconds and retried.
 fetch-timeout=25000

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -200,42 +200,56 @@ If maintainers later prefer real per-job required contexts, that is a separate d
 
 ### Per-job time limits
 
-The blanket 10/15-minute pair is gone. Each job declares its own cap as a hang
-detector with room for the bounded flake retries it owns: `unit-tests` and
-`integration-tests` each retain 28/28, `agent-suite` 8/12, `release-archive` 5/9,
-`static-checks` 6, gate 5. Root-suite caps conservatively retain the former combined job's headroom; they are not newly measured split-job budgets. The topology contract pins every value.
+Job caps use the latest two completed CI runs available at calibration time:
+[33997174167](https://github.com/bastani-inc/atomic/actions/runs/33997174167)
+(main, `c77de93380`) and
+[33997819241](https://github.com/bastani-inc/atomic/actions/runs/33997819241)
+(PR, `bafc6ebd17`). Both succeeded. Run `33998194502` was still in progress
+and was excluded rather than treating unfinished durations as measurements.
 
-A cap has to cover the retries its job owns. `scripts/run-flaky-test-suite.ts`
-replays only the step it wraps, so the budget is `setup + 2 × (retryable steps)`
-rather than 2× the whole job. The former `suites` job wrapped **two** steps;
-each new root-suite job now owns one independently retryable step.
+For each job/platform, the cap in minutes is
+`ceil(max(run_1_seconds, run_2_seconds) × 1.5 / 60)`. Durations come from
+GitHub's job `completedAt - startedAt`, including setup and teardown but not
+time queued for a runner. Whole-minute rounding provides at least 50% headroom.
 
-Recent Windows observations show why the old value no longer covered that
-contract. Run `33858796656` used 140 s before its suites, 475 s for unit, and
-75 s for integration. On run `33864468533`, setup took 103 s, unit took 511 s
-and its passing retry took another 494 s, then the 20-minute job cap cancelled
-integration after more than 92 s with 41 of 42 files complete. The outstanding
-file was the structural packed-package install and typecheck, so 92 s is a lower
-bound rather than a completed integration sample.
+| Job | Platform | Run 33997174167 | Run 33997819241 | Timeout |
+| --- | --- | ---: | ---: | ---: |
+| Unit tests | Linux | 371 s | 367 s | 10 min |
+| Unit tests | Windows | 526 s | 511 s | 14 min |
+| Integration tests | Linux | 112 s | 118 s | 3 min |
+| Integration tests | Windows | 195 s | 195 s | 5 min |
+| Agent suite | Linux | 226 s | 216 s | 6 min |
+| Agent suite | Windows | 331 s | 327 s | 9 min |
+| Release archive | Linux | 76 s | 80 s | 2 min |
+| Release archive | Windows | 138 s | 135 s | 4 min |
+| Static checks | Linux | 78 s | 88 s | 3 min |
+| Final test gate | Linux matrix label | 4 s | 3 s | 1 min |
+| Final test gate | Windows matrix label | 4 s | 5 s | 1 min |
 
-Using the pessimistic observed values, the retry-inclusive floor is
-`140 + 2 × (511 + 92) = 1346 s` (22.4 min). Both former `suites` legs therefore received
-one 28-minute cap: 1.25× that floor, effectively the same headroom as the old
-cap's 1.24× Windows ratio when it was introduced. A per-platform split would
-again encode precision these shared 4-vCPU runners do not support and invite one
-leg to decay independently.
+Both final gate legs execute on Linux. The topology contract pins the caps and
+the sampled matrix-job maxima used to calculate them.
 
-`agent-suite` keeps its 8/12 pair because it still clears its retry-inclusive
-observations, and `release-archive` keeps 5/9 because it runs no retryable step
-at all; its Windows cap is 9 because cold setup observed a 152 s Rust toolchain
-acquisition and 71 s checkout before the roughly 110 s native build and 40 s
-archive smoke. A cap that cancels a passing retried run is worse than a late hang
-detection.
+These are two-run wall-clock limits, not a guarantee that a full suite retry or
+a cold-cache toolchain download will fit. Bounded retries remain enabled but
+share the job's remaining time. This replaces the older retry-inclusive and
+cold-setup allowances; recalibrate with fresh evidence if those paths exceed
+the new limits. No test coverage, retry count, or per-test timeout changes.
 
-These caps are wall-clock ceilings, not performance budgets. Shortening the
-~8.5 min unit step is what buys headroom back; raising a cap again should come
-with fresh measurements, and the contract test bounds every cap at 28 minutes
-so that stays a deliberate decision.
+The unchanged npm policy allows 85 seconds for one stalled request and its two
+retries: `3 × 25 s + 2 × 5 s` maximum backoff. The contract checks that this is
+less than the smallest **npm-installing** job cap (120 seconds, Linux release
+archive); the 60-second result gate never runs npm. The former one-third-of-a-job
+guarantee no longer applies: 255 seconds cannot fit into
+120 seconds. Even one 85-second allowance may not fit after setup and other
+work, and an install may make multiple requests. The job deadline wins; this
+contract does not guarantee that npm retries or the install will finish.
+
+Existing individual step limits remain unchanged: Rust installation and its
+retry each allow 4 minutes, and PR-only Mintlify validation allows 5 minutes.
+The enclosing job deadline always wins, even when a step's own limit is longer.
+The main-branch sample skipped Mintlify; the PR sample ran it in 10 seconds.
+Skipped steps are not zero-duration performance samples. Publish and CodeQL
+workflow limits are outside this calibration.
 
 Every job that runs a suite through `scripts/run-flaky-test-suite.ts` uploads `.ci-diagnostics/` under a job-unique artifact name (`test-diagnostics-<job>-<binary_platform>`). `actions/upload-artifact@v4+` fails the entire run when two jobs upload the same name. All three upload steps explicitly set `include-hidden-files: true`, producing six platform-specific artifacts: files inside a dot-prefixed directory are hidden on Linux and Windows, and the default previously excluded every diagnostic. Keep `path: .ci-diagnostics/` narrow rather than enabling hidden uploads across the workspace. The `always()` condition, 14-day retention and `if-no-files-found: ignore` remain, so a job failing before test execution need not produce an artifact. Restoring uploads may add a small upload cost; it is an observability fix, not a speedup.
 

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -83,11 +83,13 @@ test("every test suite entry point resolves to one shared per-test timeout", asy
  * so the install policy could not recover before the job that owned it died.
  *
  * Bound one request conservatively as every attempt consuming fetch-timeout
- * plus every retry consuming the maximum backoff. Keeping that below one third
- * of the smallest job cap leaves the rest of the job two thirds of its budget
- * and makes a future cap reduction move together with the repository policy.
+ * plus every retry consuming the maximum backoff. The measured job caps no
+ * longer reserve three times that allowance. Keep it below the smallest cap
+ * among jobs that install with npm; the npm-free result gate is irrelevant.
+ * This is not a completion guarantee: setup and other work share the cap, and
+ * the enclosing job deadline can interrupt a request or its retries.
  */
-test("npm registry retries finish well inside the smallest CI job budget", async () => {
+test("npm registry request retries are bounded below npm-installing CI job caps", async () => {
 	const npmConfig = new Map(
 		(await readText(join(root, ".npmrc")))
 			.split("\n")
@@ -111,6 +113,7 @@ test("npm registry retries finish well inside the smallest CI job budget", async
 
 	const workflow = parseYaml(await readText(testPath)) as Workflow;
 	const jobBudgetsMinutes = Object.values(workflow.jobs ?? {}).flatMap((job) => {
+		if (!job.steps?.some((step) => /\bnpm ci\b/u.test(step.run ?? ""))) return [];
 		const directBudget = job["timeout-minutes"];
 		const direct = typeof directBudget === "number" ? [directBudget] : [];
 		const matrix = (job.strategy?.matrix?.include ?? []).flatMap((entry) => {
@@ -119,12 +122,12 @@ test("npm registry retries finish well inside the smallest CI job budget", async
 		});
 		return [...direct, ...matrix];
 	});
-	assert.ok(jobBudgetsMinutes.length > 0, "test.yml must declare job timeout budgets");
+	assert.ok(jobBudgetsMinutes.length > 0, "test.yml must declare npm-installing job timeout budgets");
 	const smallestJobBudgetMs = Math.min(...jobBudgetsMinutes) * 60_000;
 	const stalledRequestBudgetMs = fetchTimeoutMs * (fetchRetries + 1) + retryMaxTimeoutMs * fetchRetries;
 	assert.ok(
-		stalledRequestBudgetMs * 3 <= smallestJobBudgetMs,
-		`one stalled npm request can consume ${stalledRequestBudgetMs}ms, more than one third of the smallest CI job budget (${smallestJobBudgetMs}ms)`,
+		stalledRequestBudgetMs < smallestJobBudgetMs,
+		`one stalled npm request can consume ${stalledRequestBudgetMs}ms, not below the smallest npm-installing CI job cap (${smallestJobBudgetMs}ms)`,
 	);
 });
 
@@ -935,6 +938,7 @@ interface WorkflowJob {
 	"runs-on"?: string | string[];
 	"timeout-minutes"?: number | string;
 	strategy?: { matrix?: WorkflowMatrix };
+	steps?: { run?: string }[];
 }
 
 interface Workflow {

--- a/test/ci/test-workflow-topology.test.ts
+++ b/test/ci/test-workflow-topology.test.ts
@@ -112,15 +112,15 @@ test("every work job the gate names exists and is otherwise independent", async 
 	}
 });
 
-/** Root-suite caps retain the combined job's headroom, not measured split-job budgets. */
-test("each split job retains its timeout hang detector", async () => {
+/** Ceil the slower job duration from runs 33997174167 / 33997819241 plus 50% headroom. */
+test("each split job retains its measured timeout hang detector", async () => {
 	const workflow = await readText(testPath);
 	const blocks = await jobs();
 	const caps: Record<string, [number, number]> = {
-		"unit-tests": [28, 28],
-		"integration-tests": [28, 28],
-		"agent-suite": [8, 12],
-		"release-archive": [5, 9],
+		"unit-tests": [Math.ceil((371 * 1.5) / 60), Math.ceil((526 * 1.5) / 60)],
+		"integration-tests": [Math.ceil((118 * 1.5) / 60), Math.ceil((195 * 1.5) / 60)],
+		"agent-suite": [Math.ceil((226 * 1.5) / 60), Math.ceil((331 * 1.5) / 60)],
+		"release-archive": [Math.ceil((80 * 1.5) / 60), Math.ceil((138 * 1.5) / 60)],
 	};
 	for (const [job, [linux, windows]] of Object.entries(caps)) {
 		const block = blocks.get(job) as string;
@@ -140,13 +140,13 @@ test("each split job retains its timeout hang detector", async () => {
 		assert.match(block, /timeout-minutes: \$\{\{ matrix\.timeout_minutes \}\}/u, job);
 		assert.match(block, /fail-fast: false/u, job);
 	}
-	assert.match(blocks.get("static-checks") as string, /^[ \t]+timeout-minutes: 6$/mu);
-	assert.match(blocks.get("test") as string, /^[ \t]+timeout-minutes: 5$/mu);
+	assert.match(blocks.get("static-checks") as string, /^[ \t]+timeout-minutes: 3$/mu);
+	assert.match(blocks.get("test") as string, /^[ \t]+timeout-minutes: 1$/mu);
 	// A cap is still a hang detector: it must bound a stuck job to minutes rather
 	// than GitHub's six-hour default. The bound is the largest cap the current
 	// measurements justify, so raising one further has to come with new numbers.
 	for (const [, value] of workflow.matchAll(/^\s+timeout_minutes: (\d+)$/gmu)) {
-		assert.ok(Number(value) <= 28, `cap ${value} is too loose to detect a hang`);
+		assert.ok(Number(value) <= 14, `cap ${value} is too loose to detect a hang`);
 	}
 });
 


### PR DESCRIPTION
## Summary
Recalibrate test CI job deadlines from completed runs [33997174167](https://github.com/bastani-inc/atomic/actions/runs/33997174167) and [33997819241](https://github.com/bastani-inc/atomic/actions/runs/33997819241), using the slower duration plus 50% headroom, rounded up to whole minutes.

## Changes
- Set Linux/Windows caps to unit 10/14, integration 3/5, agent suite 6/9, and release archive 2/4 minutes; static checks 3 minutes and both result gates 1 minute.
- Document both timing samples, calculation, and cold-cache/full-retry limitations in docs/ci.md.
- Update topology assertions and scope the npm request-budget contract to npm-installing jobs. Keep npm settings and individual step limits unchanged; correct the stale npm policy comment.

## Validation
- Focused CI contract suites: 41 tests passed.
- npm run check passed, including again in commit hooks.
- All applicable commit hooks passed.

## Notes
These sample-based caps do not guarantee a full retry or cold-cache setup fits. Admin merge requested by the maintainer; this PR does not claim a completed new CI run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791242659&installation_model_id=10562&pr_number=2881&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2881&signature=e32489dc06360ead832f7003f182f7178b108cf53b382b1542eb13d3dc85127f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change shortens Windows test deadlines, but two documented healthy execution paths no longer fit: a full unit-test retry and the release-archive build on warm or cold setup paths. These failures can reject valid changes, so the timeout values need adjustment before merging.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the Windows unit-test retry and release-archive timeouts accommodate their documented healthy execution paths.

Two independently reproduced failures show that valid Windows checks can be cancelled before completion.

**Files Needing Attention:** .github/workflows/test.yml needs revised Windows timeout values; docs/ci.md provides the timing evidence those values must cover.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Two P1 finding proofs were posted and linked to review comments for validation.
- A P1 finding proof was posted with a Python-based script, and the corresponding output log artifact is available for review.
- A focused workflow and documentation validation was run against the CI workflow and docs, locating the Windows timeout at line 289 and reporting a 240-second timeout, a 244-second documented healthy p100, and an approximately 410-second documented cold tail.
- A CI-timeout budget check was executed; the execution record shows prior cap of 1,680 seconds, current cap of 840 seconds, a documented normal duration of 526 seconds, a retry duration of 493 seconds, a retry path of 1,019 seconds, and a current deficit of 179 seconds, with the result reproduced; the companion prior-cap check showed the same 1,019-second path fit under the former cap with 661 seconds remaining.

<a href="https://app.greptile.com/trex/runs/22731423/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Windows archive cap expires**

   - **Bug**
     - Executed evidence confirmed the configured deadline is 240 seconds, 4 seconds below the documented healthy 244-second p100 and about 170 seconds below the documented 410-second cold tail.
   - **Cause**
     - The PR changes the Windows release-archive timeout from 9 minutes to 4 minutes while replacing the prior cold-cache allowance with a two-run warm calibration.
   - **Fix**
     - Set the Windows release-archive timeout to at least a value that covers the documented cold setup/build/smoke tail with appropriate headroom, rather than the current four-minute cap.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/test.yml:51
**Retry Exceeds Unit Cap**

The Windows unit-test timeout is 14 minutes, but the flaky-suite wrapper can retry the full `npm run test:unit` command. The documented 526-second initial run plus 493-second retry takes 1,019 seconds (about 17 minutes), so a late flake will cancel an otherwise successful retry and reject a valid change. This must be fixed before merging.

### Issue 2
.github/workflows/test.yml:289
**Archive Cap Is Too Short**

The Windows release-archive timeout is four minutes. The documented healthy warm p100 is 4 minutes 4 seconds, and the documented cold setup, build, and smoke path is about 6 minutes 50 seconds, so healthy archive checks can be cancelled before they finish. This must be fixed before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: calibrate job timeouts with 50% meas..."](https://github.com/bastani-inc/atomic/commit/744c0034f59d474c4b4097b5f39617a4eac87ccb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60846039)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->