### PR TITLE
docs: prepare 0.9.18-alpha.7 prerelease notes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
+## [0.9.18-alpha.7] - 2026-09-05
+
 ### Added
 
 - Added OpenRouter's `microsoft/mai-image-2.6` and `microsoft/mai-image-2.6-flash` image models from the Pi 0.85.1 catalog.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.18-alpha.7] - 2026-09-05
+
 ### Added
 
 - Fullscreen mouse-wheel scrolling moves five times as far while Alt is held, through the Pi TUI 0.85.1 update ([upstream #9166](https://github.com/earendil-works/pi/pull/9166)).

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.18-alpha.7] - 2026-09-05
+
 ### Fixed
 
 - Host sessions that join multiple workflow groups retain workflow broadcast and pending-stage routing after reconnecting. Registration now preserves the startup home group instead of treating the most recently joined group as the session's origin; workflow workers still cannot gain another invocation's control authority through joins or reconnects.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.18-alpha.7] - 2026-09-05
+
 ### Fixed
 
 - Pending-stage Intercom settlement now skips unrelated runs with no messages to settle. Genuine sweep failures produce one display-only warning per distinct message in interactive sessions instead of repeated console stack traces; headless sessions retain console diagnostics, and pending messages remain available for recovery.


### PR DESCRIPTION
## Summary

Prepare the package release notes for the `0.9.18-alpha.7` prerelease.

## Changes

- Add the dated prerelease heading to the AI, coding-agent, Intercom, and workflows changelogs.
- Preserve the existing pending notes and all historical release sections.
- Keep the diff changelog-only. All eight package manifests, workspace lock entries, first-party version pins, Cargo workspace versions, generated native checks, and version badges remain at `0.0.0`.

## Validation

- `bun run test:unit test/unit/changelog.test.ts test/unit/build-release-notes.test.ts`: 19 tests passed.
- `bun run check`: passed, with one existing informational Biome diagnostic.
- `bun run scripts/build-release-notes.ts 0.9.18-alpha.7`: generated the combined notes successfully.
- Read-only Bun assertions verified the four-file diff, unique dated release headings, preserved notes, versionless manifests and lock entries, inherited Cargo version, and all 27 generated native version comparisons and mismatch messages.
- `git diff --check` and commit hooks passed. Worktree clean after commit.

The first ad hoc Cargo assertion incorrectly expected a literal version instead of resolving `version.workspace = true`. Corrected validation passed; no repository repair was needed.

## Notes

This stage does not merge, tag, stamp versions, or publish. After this PR merges, only `scripts/cut-release.ts` may stamp the real version on the detached Release commit. Pushing the version tag starts `publish.yml` directly; no duplicate publication dispatch is needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change prepares the 0.9.18-alpha.7 prerelease notes across the AI, coding-agent, Intercom, and workflows package changelogs. The generated release notes include the intended entries and omit the empty Unreleased sections.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

No actionable issues were found. Release-note generation was exercised against the parent and updated changelogs, confirming that the new version headings produce the intended notes.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Authored an executable validator for release notes heading validation.
- Executed the validator and captured its output in the release notes heading validation output log.
- Compared the before-capture and after-capture command logs to confirm the validation behaved as expected.
- Reviewed the validation results to confirm that the release notes heading validation produced the anticipated result.

<a href="https://app.greptile.com/trex/runs/22732821/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: prepare 0.9.18-alpha.7 prerelease ..."](https://github.com/bastani-inc/atomic/commit/ea71a786a2d9a74d1cab83eeb45c6fbbdb4176fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60848724)</sub>

<!-- /greptile_comment -->