### PR TITLE
docs: prepare 0.9.18 release notes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,44 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
+## [0.9.18] - 2026-09-05
+
+Cumulative release of the `0.9.18-alpha.5` through `0.9.18-alpha.7` prereleases. Per-change details remain in the unchanged prerelease sections below.
+
+### Breaking Changes
+
+- `createGatewayBindingFetch` requires `binding.fetch()` and forwards requests verbatim. The `gateway(id).run(...)` fallback is removed, `baseUrl` and `gateway` options are ignored, and bindings without `fetch()` fail at construction. Set model base URLs to `https://workers-binding.ai/ai-gateway/gateways/{gateway}/{provider}` ([#8287](https://github.com/earendil-works/pi/pull/8287)).
+- Fast inference is explicit `Model.fastRoute` metadata, not a name suffix. Responses adapters accept the canonical model, send its route's upstream ID, enforce its declared tier even against caller options, and price priority using its base model. A route without a tier sends none. Payload hooks that replace the body with a non-object or change the route's model or tier now fail. Models without routes retain caller-controlled tiers and hooks.
+- GitHub Copilot exposes route-bearing fast models only when OAuth `fastModelIds` advertises the exact ID. Provider-owned names ending in `-fast` remain ordinary models governed by `availableModelIds`.
+
+### Added
+
+- Added Claude Fable 5.1 with provider-specific pricing, a 1M-token context window, 128K output, always-on adaptive thinking, and exactly `low`, `medium`, `high`, `xhigh`, and `max` efforts. Added its server-side fallback targets, Claude Opus 4.8 and Opus 5, and compatibility controls for thinking binding, forced tool choice, and temperature.
+- Added Gemini 3.8 Flash across supported provider catalogs, including GitHub Copilot. Google and Vertex use a 1,048,576-token context window and 65,536 output tokens with low, medium, and high thinking; other providers retain their own metadata. Added Copilot Claude Fable 5/5.1 and Baseten `zai-org/GLM-5.3-Fast`.
+- Added GPT-6-Astra on OpenAI, OpenAI Codex, Bedrock, OpenRouter, and Vercel AI Gateway, retaining provider-owned IDs, reasoning levels, pricing, and request-wide long-context tiers. Added a provisional Copilot entry with zero costs for unverified pricing; account availability still depends on Copilot's authenticated catalog.
+- Added OpenRouter `microsoft/mai-image-2.6` and `microsoft/mai-image-2.6-flash` image models.
+- Added public `DocumentContent` PDF input for Anthropic Messages and Bedrock Converse. Unsupported models receive a visible placeholder; non-PDF MIME types are rejected, and token estimates measure the encoded document payload.
+- Added public `FallbackContent`, per-turn Anthropic effort persistence, historical effort markers, signed-thinking recovery, and diagnostics for thinking blocks dropped at request start or after server-side fallback.
+- Added `ModelFastRoute`, `resolveRequestedServiceTier`, and `assertPayloadPreservesFastRoute`, plus `AssistantMessageFrameEncoder` and `reduceAssistantMessageFrames` for compact, replayable stream progress.
+- Added `compat.vllmPriority` for servers using priority scheduling, `supportsMaxOutputTokens` for Responses gateways that reject the output cap, and compatibility flags for unsupported temperature and forced-tool-choice fields.
+
+### Changed
+
+- Exported `./utils/*` subpaths for Pi 0.85 runtime packages.
+- Qwen3.8 Max and Flash thinking choices follow models.dev on Qwen Token Plan providers, offering low, medium, and xhigh without off.
+- Responses models supporting `prompt_cache_options`, including Astra, use `ttl: "30m"` for long retention. Earlier models keep the 24-hour legacy field; short and explicit no-cache modes retain capability checks.
+- Assistant-frame reduction reconstructs owned block values rather than deleting fields on externally supplied content, preserving output and field order.
+
+### Fixed
+
+- Fixed Claude Fable temperature rejection across Anthropic, Bedrock, OpenRouter, and Copilot, including sampling defaults that reintroduced `temperature`, `top_p`, or `top_k`. Forced tool choices on Fable 5.1 now fail explicitly across supported APIs, including all OpenAI forcing shapes and Bedrock requests without tools; auto and none remain unchanged.
+- Fixed first-party Anthropic model switches and Fable 5.1 prefix changes by preserving eligible signed reasoning and letting the API drop incompatible blocks. Disabled thinking no longer sends the interleaved-thinking beta, and recovery diagnostics survive empty later reports or failed streams.
+- Fixed mid-stream Anthropic fallback attribution, replay, and billing. Handoff markers survive, serving-model prices apply, earlier output-producing attempts are charged once, and pre-handoff reasoning and unexecuted calls/results are dropped together. Faux-provider replay keeps content indices aligned around fallback markers.
+- Fixed Fable 5.1 OAuth requests rejected as `claude_code_version_too_old` by advertising the verified minimum Claude Code version, `2.1.251`.
+- Fixed Copilot Claude Fable routing through Anthropic Messages and all Fireworks GLM models through OpenAI-compatible completions. Removed retired xAI `grok-build-0.1` and restored Qwen3.8 Flash on Qwen Token Plan Individual.
+- Fixed Codex SSE terminal events without a trailing blank line and assistant-frame start snapshots losing `providerThinkingLevel`.
+- Fixed `NO_PROXY` matching for root domains, subdomains, IPv6, port-scoped entries, and wildcard entries.
+
 ## [0.9.18-alpha.7] - 2026-09-05
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 ## [Unreleased]
 
+## [0.9.18] - 2026-09-05
+
+Cumulative release of the `0.9.18-alpha.1` through `0.9.18-alpha.7` prereleases. Per-change details remain in the unchanged prerelease sections below.
+
+### Breaking Changes
+
+- Replaced `/fast` with selectable canonical `-fast` model IDs. Removed its selector, `codexFastMode.chat`/`codexFastMode.workflow` settings, `ATOMIC_CODEX_FAST_MODE`, scope inheritance, toggle-state exports, settings-manager methods, and the environment-sourced settings-override layer without a compatibility shim. Select a fast model explicitly; effective settings now merge global then project settings.
+- Fast-routing APIs now live in `core/fast-model-routing.ts` and `core/fast-model-routing-transport.ts`, with package-root exports retained for the replacement APIs. `usesChatGptCodexTransport` and `usesFirstPartyCodexRouting` remain; `withCodexFastRouteHeaders` derives identity from route metadata rather than an enabled flag.
+- Cloudflare AI Gateway binding transport requires `binding.fetch()` and no longer falls back to `gateway(id).run(...)`.
+- `WorkflowPendingStageDelivery` now requires `fail(reason: Error): void` so delivery owners can settle exhausted recovery instead of leaving stages parked forever.
+- Removed the experimental remote-session lease API, transcript projection helpers, and harness factory. `@bastani/atomic/client` now re-exports the service-addressed `@earendil-works/pi-client` API.
+
+### Added
+
+- Added explicit fast model variants to `/model`, `--list-models`, workflow catalogs, scoped lists, session restore, fallback candidates, usage, and attempt records. Thinking suffixes remain supported. OpenAI and Codex variants send the base upstream ID with priority tier; Copilot exposes only account-advertised fast IDs and sends them without an OpenAI tier.
+- Added fast-specific `modelOverrides`, derivation APIs, `ModelRuntime.getFastModelVariantDiagnostics()`, and `getWarning()`. Existing provider, custom, or extension-owned IDs win collisions and produce actionable startup/catalog warnings. Route metadata, not a name suffix, grants fast behavior.
+- Added GPT-6-Astra across OpenAI, Codex, Bedrock, OpenRouter, and Vercel, including derived first-party fast variants, provider-specific pricing, long-context tiers, and provisional account-gated Copilot support. Added Gemini 3.8 Flash, Claude Fable 5.1, Copilot Claude Fable 5/5.1, and Baseten GLM-5.3-Fast with provider-owned metadata and availability.
+- Embedded PostgreSQL now supports offline durable storage on Linux musl x64/ARM64 and Windows ARM64. Windows ARM64 uses PostgreSQL x64 through Windows 11 emulation; installs and standalone archives carry only the matching runtime.
+- Added `supportsMidConvoEffort` and `compat.vllmPriority` custom-model settings, and transcript notices for dropped Anthropic thinking when cache-miss notices are enabled.
+- Added a clickable fullscreen `Jump to latest message` overlay with the configured shortcut. Holding Alt makes fullscreen mouse-wheel scrolling move five times as far ([upstream #9166](https://github.com/earendil-works/pi/pull/9166)).
+- Documented Zed terminal keybindings for Kitty-protocol modified keys ([#8828](https://github.com/earendil-works/pi/pull/8828)).
+
+### Changed
+
+- Updated Pi runtime dependencies to 0.85.1, preserving Atomic startup, client API, and footer watchers. Fullscreen search uses the cached index and visible-match highlighting introduced in Pi 0.85.0.
+- Startup paints the themed identity and focused editor before isolated-engine readiness. First submissions wait for optional resources, Escape cancels a waiting submission, and `/reload` retries extension failures without publishing failed candidates' host-managed state.
+- Compiled/bundled builds reuse native-imported builtin extension factories across reloads while editable extensions and workflows retain content-hash invalidation. Standalone builds use syntax-minified shared sidecars and bytecode launchers, including Windows.
+- Interactive model, thinking, cycling, and scoped-list selections save as startup defaults immediately. Selectors keep active choices marked while browsing; scoped lists use consistent toggles and strike through unavailable models. Removed Ctrl+S save-default UI.
+- The working indicator reads `Working`, preserving Atomic's animated status row. The centered jump overlay no longer consumes a transcript row, and workflow stage chat uses matching copy and shortcuts.
+- `ModelRuntime` enforces first-party Codex routing for standalone stream/complete calls too. Fast derivation excludes unsupported adapters and extension-owned transports, Copilot restore requires account entitlement and a base catalog model, and all provider catalog accessors agree on derived variants. Labels show the canonical model ID without a redundant fast badge.
+- Claude on Anthropic and Bedrock accepts PDF input through the bundled AI library, with visible placeholders elsewhere. Interactive sessions do not yet produce document blocks; Bedrock requires citations for full visual understanding.
+- Updated hashline edit guidance with worked examples, rejected-shape warnings, and a specification of native block resolution. Model-selection references record the August 26 DeepSWE snapshot, corrected prices and Pareto choices, and Fable 5.1's unmeasured status. Compaction docs explain why `preserve_recent` preserves text and tool exchanges but resets signed reasoning.
+- Capable Responses models use `prompt_cache_options.ttl: "30m"` for long retention; older models retain the 24-hour legacy control.
+
+### Fixed
+
+- Fixed Windows x64 and ARM64 archives crashing before startup in `0.9.18-alpha.1` ([#2781](https://github.com/bastani-inc/atomic/pull/2781)).
+- Restored startup resource listings, source-path expansion, slash-prefixed prompt labels, isolated-child extension inventory, deterministic collision labels, overlap warnings, and consistent hidden-resource handling across platforms.
+- Fixed in-memory forks during running tools, lost compaction boundaries after forks, session import filename collisions, RPC aborts not cancelling manual compaction, and concurrent `/share` exports overwriting temporary files.
+- Builtin tools resolve relative paths against an extension's `ctx.cwd`, including matching search hashline tags. Write confirmations no longer mislabel UTF-16 counts as bytes or discard user prose merely because it begins with `Successfully wrote to`.
+- Fixed Claude Fable thinking-level routing on Copilot, Fireworks GLM endpoint routing, Fable 5.1 prefix/model-switch recovery, exact reasoning-byte restoration, unsupported sampling fields and forced tool choices, fallback replay and serving-model billing, and persisted thinking-drop notices on resume. Custom Responses gateways can disable `max_output_tokens`.
+- Fixed managed fd/rg downloads behind GitHub API quotas, selected static musl archives on Linux x64/ARM64, and pinned darwin/x64 fd to 10.3.0. Fixed proxied plain-HTTP requests hanging after tool calls and signal-killed subprocesses appearing successful.
+- Fixed JPEG EXIF orientation detection, skills disappearing when bash exists without read, and model-refresh errors missing their status spacing. Jump-overlay clicks preserve other mouse reports in the same input chunk.
+- Raised branch-summary output to 4096 tokens, clamped to model limits, to avoid reasoning exhausting the previous cap ([#8845](https://github.com/earendil-works/pi/issues/8845)).
+- Resumed workflows cannot report completion or start replacement work while skipping their exact unfinished durable tool. Completed work remains cached and cancellation retains precedence.
+
+### Removed
+
+- Removed `/atomic`. Use `/workflow list`, `/changelog`, and `/hotkeys` instead.
+- Removed Ctrl+X copy-message/selection to avoid workflow-navigation conflicts. `/copy` and automatic mouse-selection copying remain.
+
 ## [0.9.18-alpha.7] - 2026-09-05
 
 ### Added

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.18] - 2026-09-05
+
+Cumulative release of the `0.9.18-alpha.3` through `0.9.18-alpha.7` prereleases. Per-change details remain in the unchanged prerelease sections below.
+
+### Breaking Changes
+
+- Workflow-stage targets require root-anchored `workflow:<rootRunId>/<segment>[/<segment>...]` paths. Legacy `<runId>:<stageKey>` targets fail with a migration hint.
+
+### Added
+
+- Added literal, run-ID, and glob stage-path routing, sticky delivery to future matches, and `workflow:<rootRunId>/**` broadcasts to live and future descendants until root termination.
+- `intercom list` shows persisted possible future targets and queued counts. Valid unknown paths queue with `notInKnownSet` warnings and produce terminal undeliverable notices only if never delivered. Tool guidance, skills, and docs teach path discovery and live-only asks.
+
+### Fixed
+
+- Fixed invocation control across isolated workflow subgroups, pending-stage roster discovery and delivery, correlated live replies, registration-based authorization, and sibling/cross-run isolation. Queued sends render as successful, not failed ([#2784](https://github.com/bastani-inc/atomic/issues/2784)).
+- Background reconnects retry with bounded backoff after releasing ownership, restore stage visibility/routing, and close failed accepted connections instead of accumulating stale registrations. Host sessions retain their startup home group across joins and reconnects, preserving multi-workflow control without granting workers cross-invocation authority.
+- Recoverable disconnects during lazy initialization, stage warm-up, advisory subagent authorization, or event relays no longer produce misleading stage/UI failures. Registered transport resets enter typed recovery; unrelated protocol, auth, configuration, and terminal errors remain actionable.
+- Stage warm-up owns bounded retries. Exhaustion settles queued delivery with a stage-scoped terminal failure instead of hanging or printing into the host transcript. No model retry/fallback is spent, queued messages remain available, late drains are safe, and stages without queued messages still start.
+- Brokers retire ended sockets before routing more traffic. Delivery waits for socket-write acknowledgement, so failed writes cannot claim success, open reply authority, poison retry identity, or inflate sticky-broadcast receipts.
+- Recoverable disconnects on send/ask/reply return opaque `retryToken` values for explicit exact-operation retries. Tokenless identical calls remain distinct. Tokens allow three claimed attempts within the original 11-minute deadline, retain identity after inconclusive nondelivery, preserve implicit reply correlation, and reject invalid or mismatched claims before side effects. Capacity is reserved before new operations begin.
+- Retry signatures survive reconnects while preserving caller-visible target and argument distinctions. Local subagent result relays reserve deduplication identity before delivery and fail closed on conflicts, capacity, and uncertain acceptance.
+- Broker acceptance records use keyed SHA-256 HMACs rather than plaintext signatures, keeping message and attachment text out of SQLite/WAL/SHM. POSIX directories/files use owner-only modes; key/database mismatch and corruption fail closed. The 12-minute durability and 10,000-record/64 MiB limits remain enforced.
+- Closed stages suppress late messages from their own cancelled subagents without dropping other stages' traffic; already-submitted sends preserve receipts and retry identities ([#2840](https://github.com/bastani-inc/atomic/issues/2840)).
+
 ## [0.9.18-alpha.7] - 2026-09-05
 
 ### Fixed

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+## [0.9.18] - 2026-09-05
+
+Cumulative release of the `0.9.18-alpha.6` prerelease. Per-change details remain in the unchanged prerelease section below.
+
+### Breaking Changes
+
+- Removed `fastMode` from result, progress, runtime, artifact, and run-history metadata. Select fast inference with a canonical `-fast` model ID in model or fallback fields, such as `openai-codex/gpt-5.6-sol-fast:medium`.
+
+### Changed
+
+- Labels show the complete selected model ID without a separate fast badge.
+- Bundled agents use GPT-6 Astra at low, with debugger at xhigh. Added Astra and Claude Fable 5.1 fallbacks ahead of older models, and aligned locator fallback chains with ordinary agents, including Sol, GPT-5.5, and Opus 4.8 at medium.
+- The qlty skill follows repository/user priorities, preserves authoritative checks and read-only boundaries, supports offline/manual setup, and distinguishes prepared configuration from executed checks.
+- Default guidance honors task-scoped inline/no-workflow requests while retaining testing, review, safety, and reconciliation of active workflow effects. Model selection for unpinned agents consults task-specific measured evals alongside role guidance.
+
+### Fixed
+
+- Completing workflow stages cancel their still-running single, parallel, and detached subagents. Children retain interrupted/abort outcomes and cleanup, late findings no longer reach parent chat, and exact ownership preserves other stages' traffic. Already-submitted Intercom sends keep receipts/retry identities; detached children still notify while their owning stage is live ([#2840](https://github.com/bastani-inc/atomic/issues/2840)).
+
 ## [0.9.18-alpha.6] - 2026-09-04
 
 ### Breaking Changes

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.18] - 2026-09-05
+
+Cumulative release of the `0.9.18-alpha.3` through `0.9.18-alpha.7` prereleases. Per-change details remain in the unchanged prerelease sections below.
+
+### Breaking Changes
+
+- Workflow-stage Intercom targets require root-anchored `workflow:<rootRunId>/<segment>[/<segment>...]` paths. Legacy `<runId>:<stageKey>` targets fail with a migration hint.
+- Removed `fastMode` from task results, stage snapshots, fallback metadata, and durable records. Pin canonical `-fast` model IDs explicitly; normal and fast IDs remain separate ordered fallback candidates.
+
+### Added
+
+- Added checksum-pinned embedded PostgreSQL on Linux musl x64/ARM64 and Windows ARM64, retaining explicit database URL precedence, Docker fallback, privilege dropping, and process-owned shutdown. Windows ARM64 uses PostgreSQL x64 through Windows 11 emulation.
+- Launch persists possible literal, patterned, and nested-child stage paths. Sticky sends reach future matches, root broadcasts reach live and future descendants until termination, and `intercom list` shows possible targets and queued counts. Valid unknown paths queue with warnings and settle as undeliverable only if never matched.
+- Status, list/detail views, and the `BACKGROUND` panel identify materialized pending stages, expose exact targets only when delivery is available, and distinguish unavailable delivery explicitly.
+
+### Changed
+
+- Heartbeat and stage guidance use one authoritative path broadcast for shared scope changes, teach discovery/globs/live-only asks, and distinguish orchestration from cross-cutting extension policy with explicit companion dependencies.
+- Goal/Ralph orchestration, Ralph prompt engineering/research, and Open Claude Design use Astra at high. Goal reviewers and Ralph reviewer B use Astra at xhigh; reviewer A uses Fable 5.1 at high. Added both model families to role-specific fallback chains and updated Ralph research/reviewer ordering.
+- Guidance honors task-scoped inline requests, reconciles active runs without duplicate execution, chooses verification by browser/terminal/desktop environment, supports offline qlty setup, and requires verified hosted links for authorized GitHub media uploads. Model-pinning advice consults measured task-specific evals alongside role guidance.
+- Expanded the prompt-engineering skill with sourced Astra prompting/API migration guidance and separate GPT-5.6, GPT-5.5, Fable 5.1, Fable 5, Opus 5, Opus 4.8, and Sonnet 5 guides. Shared instructions cover selective references, proportionate verification, permission boundaries, and completion criteria.
+- Stage chat uses the same jump-to-latest copy and shortcut as fullscreen chat.
+
+### Fixed
+
+- Fixed invocation-owned stage groups, collision-free identities, durable-resume identity preservation, and isolated Goal/Ralph reviewers. Pending target/ID displays wrap without truncating usable addresses; ended runs no longer advertise delivery, and narrow widgets preserve tool/elapsed metadata with accurate overflow counts ([#2784](https://github.com/bastani-inc/atomic/issues/2784)).
+- Tool-only workflows no longer produce `ZERO_STAGES` warnings or advertise tool nodes as chat-stage targets.
+- Structured-output exhaustion now advances the model fallback chain. Each candidate gets the prompt plus three corrective follow-ups; failed attempts remain recorded and successful model metadata persists immediately ([#2812](https://github.com/bastani-inc/atomic/issues/2812)).
+- Exhausted queued Intercom delivery fails its stage deterministically without model retries or fallback. The first failure settles readiness once, preserves queued steering, disposes the refused session, and handles pre-latched failures and late drains safely.
+- Durability degradation uses display-only warnings in interactive/RPC sessions and actionable console diagnostics in headless mode. Pending-message sweeps skip unrelated runs, deduplicate interactive warnings, and preserve messages for recovery.
+- In-flight resume, catalog preparation, and completed-run opening retain the backend selected during initialization rather than failing after concurrent mutable-state changes.
+- Targeted durable-tool aborts retain exact unfinished-tool identity and an inspection-only cancellation frontier. Resume, DBOS hydration, and session restoration replay completed work and retry that tool without fabricating model stages. Invalid or ambiguous checkpoint state fails before callbacks; older state requires typed checkpoint proof, not transcript inference.
+- Graph parent replacement rejects self-edges and cycles before mutation. Tool-frontier continuations reject completion that skips the unfinished tool and reject replacement model/task or child-workflow work before side effects, including worktree setup. Recovery evidence and completed callbacks remain intact.
+
 ## [0.9.18-alpha.7] - 2026-09-05
 
 ### Fixed


### PR DESCRIPTION
## Summary

Prepare the cumulative release notes for the stable `0.9.18` release across AI, coding-agent, Intercom, subagents, and workflows.

## Changes

- Add dated `0.9.18` sections covering the applicable alpha prereleases, including breaking changes and migration guidance.
- Summarize explicit fast-model routing, model catalog additions, Anthropic thinking/fallback fixes, startup and fullscreen improvements, workflow durability, and Intercom routing and recovery.
- Preserve every historical release section and the empty Unreleased sections.
- Keep the diff limited to the five prepared changelogs. All eight workspace package manifests, workspace lock entries, first-party version pins, Cargo workspace versions, generated native checks, and version badges remain at `0.0.0`.

## Validation

- `bun run test:unit test/unit/changelog.test.ts test/unit/build-release-notes.test.ts`: 19 tests passed.
- `bun run check`: passed, with one existing informational Biome diagnostic in `test/ci/ci-workflow-contracts.test.ts`. No unrelated repair or tracked generated-file changes.
- `bun run scripts/build-release-notes.ts 0.9.18`: combined release notes generated successfully.
- Read-only Bun assertions verified the exact five-file diff, unique dated release headings, unchanged historical notes, all eight versionless manifests, lock entries, first-party pins, inherited Cargo versions, all 27 native version comparisons and mismatch messages, and version badges. Repeated successfully after commit.
- `git diff --check` and all applicable commit hooks passed. Worktree clean after commit.

## Notes

This PR only prepares release notes. This stage does not merge, tag, stamp versions, or publish. After the changelog PR merges, only `scripts/cut-release.ts` may stamp `0.9.18` on the detached Release commit. Pushing the version tag starts `publish.yml` directly; no duplicate normal publication dispatch is needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791245742&installation_model_id=10562&pr_number=2883&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2883&signature=aa4eb20d0d401d9a1f1a0bd6f32513e498abf903352b5bda4db6c0481f6eb232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary

- Adds cumulative `0.9.18` release notes across the AI, coding-agent, Intercom, subagents, and workflows package changelogs.
- The new notes are placed in dated release sections while each `Unreleased` section remains empty. The repository requirement for changelog placement must be satisfied before merging.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until the repository’s changelog-placement requirement is satisfied.

The review contains one explicit repository-requirement violation and no higher-impact findings.

**Files Needing Attention:** packages/ai/CHANGELOG.md, packages/coding-agent/CHANGELOG.md, packages/intercom/CHANGELOG.md, packages/subagents/CHANGELOG.md, and packages/workflows/CHANGELOG.md need their new entries moved under their respective Unreleased sections.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/ai/CHANGELOG.md:7
**Keep Notes Under Unreleased**

This adds the release notes as a dated `0.9.18` section while `## [Unreleased]` remains empty. The repository directive requires new changelog entries to be added under `## [Unreleased]`; the same placement is used in all five changed package changelogs. This repository requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: prepare 0.9.18 release notes"](https://github.com/bastani-inc/atomic/commit/6a789013f7226bb9bf2c8986ba02ea6b0880d849) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60853417)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->