### PR TITLE
docs: prepare 0.9.19-alpha.1 prerelease notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.1] - 2026-09-06
+
 ### Fixed
 
 - Restored offline embedded PostgreSQL discovery in compiled archives and bundled target-selected runtimes for all eight supported archive/npm platforms, preserving scriptless installs and existing v18 clusters. Windows ARM64 continues to require Windows 11 x64 emulation.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.19-alpha.1] - 2026-09-06
+
 ### Fixed
 
 - Interrupting a workflow tool call during initialization now cancels its startup owner instead of leaving an empty, uncontrollable running root. Resume preparation respects cancellation, and already-aborted requests cannot begin actions. Accepted request timeouts and acknowledged background execution retain their existing behavior.


### PR DESCRIPTION
## Summary

Prepare the `0.9.19-alpha.1` prerelease notes in the coding-agent and workflows changelogs.

## Changes

- Move the prepared Unreleased fixes into dated `0.9.19-alpha.1` sections without changing their content or historical release notes.
- Cover offline embedded PostgreSQL discovery and runtime packaging, workflow initialization cancellation, live pause/resume ownership, nested child controls, and terminal failure handling.
- Limit the diff to `packages/coding-agent/CHANGELOG.md` and `packages/workflows/CHANGELOG.md`. All eight workspace manifests remain at `0.0.0`, as do workspace lock entries, first-party pins, Cargo workspace versions, generated native version checks, shrinkwrap versions, and version badges.

## Validation

- `bun run test:unit test/unit/changelog.test.ts test/unit/build-release-notes.test.ts`: 19 tests passed.
- `bun run check`: passed. One existing informational Biome diagnostic in `test/ci/ci-workflow-contracts.test.ts` was left unchanged.
- `bun run scripts/build-release-notes.ts 0.9.19-alpha.1`: combined notes generated successfully.
- Read-only Bun assertions confirmed the exact two-file, heading-only diff and versionless state. An initial validation regex missed the WASI message prefix; correcting that check confirmed all 27 native comparisons and messages expect `0.0.0`. No source repair was needed.
- `git diff --check` and all applicable commit hooks passed. Post-commit checks confirmed a clean worktree and changelog-only commit.

## Notes

This stage does not merge, stamp versions, tag, or publish. After this PR merges, only `scripts/cut-release.ts` may stamp `0.9.19-alpha.1` on the detached Release commit. Pushing the version tag directly starts `publish.yml`; do not dispatch a duplicate normal publication run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791307109&installation_model_id=10562&pr_number=2889&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2889&signature=9e8ffd1363dcdecfe8f342167045a03c9ba52c469f5783e1838c08871056987d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the `0.9.19-alpha.1` prerelease notes by adding matching release headings to the coding-agent and workflows changelogs. Generated release notes contain one Fixed section with the expected six unique entries.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

The release-note generator completed successfully and the focused checks confirmed the new headings produce the expected, non-duplicated notes.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the release notes validation script trex-artifacts/release-notes-0919-validation.sh to verify the changelog.
- The script initially exited with code 1 and a no-changelog error, and the subsequent run completed with code 0, producing a single non-duplicated Fixed section with all expected notes.
- There were no validation blockers reported for this proof.
- Artifacts were captured to support reviewer review, including the validation script source and three log artifacts.

<a href="https://app.greptile.com/trex/runs/22800182/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: prepare 0.9.19-alpha.1 prerelease ..."](https://github.com/bastani-inc/atomic/commit/1f5e3215608b01365126e59cd4a7ef842155025c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60989873)</sub>

<!-- /greptile_comment -->