### PR TITLE
fix(settings): preserve primary provenance on scoped writes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Prevented accepted S1 activity IDs such as `runner-outcome` from blocking runner settlement, independent cleanup and owner closure. Internal terminal IDs are allocated atomically without reserving caller IDs or changing report conflict/replay and cancellation rules ([#2884](https://github.com/bastani-inc/atomic/pull/2884)).
 - Prevented accepted NaN S1 wait budgets, including owner-configured agent budgets, from panicking native scheduling. Observations remain releasable by yield, settlement, disposal and owner closure without changing other budgets or per-call precedence ([#2884](https://github.com/bastani-inc/atomic/pull/2884)).
 - Restored task completion outboxes now retry unacknowledged terminal intents on initialization instead of waiting for another task to settle, retaining completion identity and current admission checks ([#2906](https://github.com/bastani-inc/atomic/pull/2906)).
+- Fixed unrelated settings changes copying inherited `.pi` fields into primary `.atomic` settings and changing their resource provenance. Scoped writes preserve newer primary-file edits, explicit Atomic overrides (including empty arrays), and inherited builtin-resource precedence ([#2299](https://github.com/bastani-inc/atomic/issues/2299)).
 
 ## [0.9.19-alpha.1] - 2026-09-06
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -9,6 +9,8 @@ Atomic uses JSON settings files with project settings overriding global settings
 
 Edit directly or use `/settings` for common options. Choosing a model or thinking level with `/model`, `/thinking`, or their cycling shortcuts automatically saves it as the startup default. Thinking choices also update the active model's saved thinking level. `/scoped-models` saves cycle-list changes automatically. SDK calls, session restoration, and automatic fallbacks do not overwrite these defaults unless persistence is explicitly requested. Atomic also reads legacy `~/.pi/agent/settings.json` and `.pi/settings.json` as compatibility fallbacks, with `.atomic` paths taking precedence.
 
+Saving an Atomic setting applies only the changed fields to the corresponding `.atomic` file; it does not copy untouched fallback fields out of `.pi`. To intentionally override an inherited array such as `packages`, set it in `.atomic`, including an explicit empty array (`"packages": []`) when the inherited list should be disabled.
+
 ## Project Trust
 
 On interactive startup, Atomic asks before trusting a project folder that contains trust-gated project inputs and has no saved decision for the folder or a parent folder in `~/.atomic/agent/trust.json`. Trusting a project allows Atomic to load project-local `.atomic/settings.json` and `.atomic` resources, legacy `.pi/settings.json` and `.pi` resources, project-local context files, install missing project packages, and execute project extensions.

--- a/packages/coding-agent/src/core/settings-manager-core.ts
+++ b/packages/coding-agent/src/core/settings-manager-core.ts
@@ -393,9 +393,9 @@ export class SettingsManager {
 		modifiedFields: Set<keyof Settings>,
 		modifiedNestedFields: Map<keyof Settings, Set<string>>,
 	): void {
-		this.storage.withLock(scope, (current) => {
-			const currentFileSettings = current
-				? SettingsManager.migrateSettings(parseJsonFileContent(current) as Record<string, unknown>)
+		const persist = (currentPrimary: string | undefined): string => {
+			const currentFileSettings = currentPrimary
+				? SettingsManager.migrateSettings(parseJsonFileContent(currentPrimary) as Record<string, unknown>)
 				: {};
 			const mergedSettings: Settings = { ...currentFileSettings };
 			for (const field of modifiedFields) {
@@ -415,7 +415,13 @@ export class SettingsManager {
 			}
 
 			return JSON.stringify(mergedSettings, null, 2);
-		});
+		};
+
+		if (this.storage.withPrimaryWriteLock) {
+			this.storage.withPrimaryWriteLock(scope, persist);
+		} else {
+			this.storage.withLock(scope, persist);
+		}
 	}
 
 	private save(): void {

--- a/packages/coding-agent/src/core/settings-storage.ts
+++ b/packages/coding-agent/src/core/settings-storage.ts
@@ -117,6 +117,25 @@ export class FileSettingsStorage implements SettingsStorage {
 			}
 		}
 	}
+
+	withPrimaryWriteLock(scope: SettingsScope, fn: (currentPrimary: string | undefined) => string | undefined): void {
+		const path = scope === "global" ? this.globalSettingsPath : this.projectSettingsPath;
+		const dir = dirname(path);
+		if (!existsSync(dir)) {
+			mkdirSync(dir, { recursive: true });
+		}
+
+		const release = this.acquireLockSyncWithRetry(path);
+		try {
+			const currentPrimary = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
+			const next = fn(currentPrimary);
+			if (next !== undefined) {
+				writeFileSync(path, next, "utf-8");
+			}
+		} finally {
+			release();
+		}
+	}
 }
 
 export class InMemorySettingsStorage implements SettingsStorage {

--- a/packages/coding-agent/src/core/settings-types.ts
+++ b/packages/coding-agent/src/core/settings-types.ts
@@ -169,6 +169,14 @@ export type SettingsFieldOrigin = "primary" | "legacy";
 
 export interface SettingsStorage {
 	withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void;
+	/**
+	 * Optional write-specific lock whose callback receives the current primary
+	 * document rather than a layered effective view. Storage implementations
+	 * without a distinct primary document can omit this method; layered storage
+	 * implementations must provide it to keep fallback fields out of the primary
+	 * document.
+	 */
+	withPrimaryWriteLock?(scope: SettingsScope, fn: (currentPrimary: string | undefined) => string | undefined): void;
 	getFieldOrigin?(scope: SettingsScope, field: keyof Settings): SettingsFieldOrigin | undefined;
 }
 

--- a/packages/coding-agent/test/1955-extension-overlap.test.ts
+++ b/packages/coding-agent/test/1955-extension-overlap.test.ts
@@ -14,6 +14,7 @@ import {
 import { resolveExtensionShortcuts } from "../src/core/extensions/runner-shortcuts.ts";
 import { DefaultResourceLoader } from "../src/core/resource-loader.ts";
 import type { ResourceLoader } from "../src/core/resource-loader-types.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
 import { builtInExtensions } from "../src/extensions/index.ts";
 import type { ExtensionActions, ExtensionRuntime, RpcSessionState } from "../src/index.ts";
 
@@ -159,6 +160,27 @@ function createLoader(): DefaultResourceLoader {
 describe("inherited Pi resource overlap compatibility", () => {
 	beforeEach(setupFixture);
 	afterEach(restoreFixture);
+
+	it("keeps inherited collision precedence after an unrelated Atomic settings write (#2299)", async () => {
+		const settingsManager = SettingsManager.create(cwd, getAgentDir());
+		settingsManager.setTheme("dark");
+		await settingsManager.flush();
+
+		expect(JSON.parse(readFileSync(join(getAgentDir(), "settings.json"), "utf8"))).toEqual({ theme: "dark" });
+
+		const loader = createLoader();
+		await loader.reload();
+		const result = loader.getExtensions();
+		expect(result.errors).toEqual([]);
+		expect(
+			collectRegisteredTools(result.extensions).find((tool) => tool.definition.name === "shared-tool")?.definition
+				.description,
+		).toBe("bundled tool");
+		expect(result.extensions.some((extension) => extension.sourceInfo.configurationOrigin === "inherited-pi")).toBe(
+			true,
+		);
+		expect(readFileSync(legacySettingsPath, "utf8")).toBe(legacySettingsBytes);
+	});
 
 	it("keeps bundled exact-name registrations and all unrelated inherited resources without mutating Pi settings", async () => {
 		const loader = createLoader();

--- a/packages/coding-agent/test/1955-extension-overlap.test.ts
+++ b/packages/coding-agent/test/1955-extension-overlap.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -14,7 +15,7 @@ import {
 import { resolveExtensionShortcuts } from "../src/core/extensions/runner-shortcuts.ts";
 import { DefaultResourceLoader } from "../src/core/resource-loader.ts";
 import type { ResourceLoader } from "../src/core/resource-loader-types.ts";
-import { SettingsManager } from "../src/core/settings-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.js";
 import { builtInExtensions } from "../src/extensions/index.ts";
 import type { ExtensionActions, ExtensionRuntime, RpcSessionState } from "../src/index.ts";
 
@@ -166,20 +167,22 @@ describe("inherited Pi resource overlap compatibility", () => {
 		settingsManager.setTheme("dark");
 		await settingsManager.flush();
 
-		expect(JSON.parse(readFileSync(join(getAgentDir(), "settings.json"), "utf8"))).toEqual({ theme: "dark" });
+		assert.deepEqual(JSON.parse(readFileSync(join(getAgentDir(), "settings.json"), "utf8")), { theme: "dark" });
 
 		const loader = createLoader();
 		await loader.reload();
 		const result = loader.getExtensions();
-		expect(result.errors).toEqual([]);
-		expect(
+		assert.deepEqual(result.errors, []);
+		assert.equal(
 			collectRegisteredTools(result.extensions).find((tool) => tool.definition.name === "shared-tool")?.definition
 				.description,
-		).toBe("bundled tool");
-		expect(result.extensions.some((extension) => extension.sourceInfo.configurationOrigin === "inherited-pi")).toBe(
+			"bundled tool",
+		);
+		assert.equal(
+			result.extensions.some((extension) => extension.sourceInfo.configurationOrigin === "inherited-pi"),
 			true,
 		);
-		expect(readFileSync(legacySettingsPath, "utf8")).toBe(legacySettingsBytes);
+		assert.equal(readFileSync(legacySettingsPath, "utf8"), legacySettingsBytes);
 	});
 
 	it("keeps bundled exact-name registrations and all unrelated inherited resources without mutating Pi settings", async () => {

--- a/packages/coding-agent/test/settings-manager-provenance.test.ts
+++ b/packages/coding-agent/test/settings-manager-provenance.test.ts
@@ -1,0 +1,219 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SettingsScope, SettingsStorage } from "../src/core/settings-manager.ts";
+import { FileSettingsStorage, SettingsManager } from "../src/core/settings-manager.ts";
+
+// Regression coverage for #2299: writes must preserve layered field provenance.
+describe("SettingsManager layered settings provenance", () => {
+	let root: string;
+	let agentDir: string;
+	let projectDir: string;
+	let primaryGlobalPath: string;
+	let legacyGlobalPath: string;
+	let primaryProjectPath: string;
+	let legacyProjectPath: string;
+
+	function writeJson(path: string, value: object): string {
+		mkdirSync(dirname(path), { recursive: true });
+		const bytes = `${JSON.stringify(value, null, 2)}\n`;
+		writeFileSync(path, bytes);
+		return bytes;
+	}
+
+	function readJson(path: string): Record<string, unknown> {
+		return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+	}
+
+	function createManager(): SettingsManager {
+		const storage = new FileSettingsStorage(projectDir, agentDir, {
+			globalReadPaths: [primaryGlobalPath, legacyGlobalPath],
+			projectReadPaths: [primaryProjectPath, legacyProjectPath],
+		});
+		return SettingsManager.fromStorage(storage);
+	}
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "atomic-2299-settings-"));
+		agentDir = join(root, ".atomic", "agent");
+		projectDir = join(root, "project");
+		primaryGlobalPath = join(agentDir, "settings.json");
+		legacyGlobalPath = join(root, ".pi", "agent", "settings.json");
+		primaryProjectPath = join(projectDir, ".atomic", "settings.json");
+		legacyProjectPath = join(projectDir, ".pi", "settings.json");
+		mkdirSync(projectDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("does not materialize legacy-only global fields into an absent primary file (#2299)", async () => {
+		const legacyBytes = writeJson(legacyGlobalPath, {
+			packages: ["npm:legacy-package"],
+			extensions: ["./legacy-extension.ts"],
+		});
+		const manager = createManager();
+
+		expect(manager.getPackages()).toEqual(["npm:legacy-package"]);
+		expect(manager.isFieldInherited("global", "packages")).toBe(true);
+
+		manager.setTheme("dark");
+		await manager.flush();
+
+		expect(readJson(primaryGlobalPath)).toEqual({ theme: "dark" });
+		expect(readFileSync(legacyGlobalPath, "utf8")).toBe(legacyBytes);
+
+		await manager.reload();
+		expect(manager.getPackages()).toEqual(["npm:legacy-package"]);
+		expect(manager.isFieldInherited("global", "packages")).toBe(true);
+	});
+
+	it("writes only a modified nested field over an empty primary file (#2299)", async () => {
+		const legacyBytes = writeJson(legacyGlobalPath, {
+			packages: ["npm:legacy-package"],
+			compaction: { enabled: true, reserveTokens: 8192 },
+		});
+		writeJson(primaryGlobalPath, {});
+		const manager = createManager();
+
+		manager.setCompactionEnabled(false);
+		await manager.flush();
+
+		expect(readJson(primaryGlobalPath)).toEqual({ compaction: { enabled: false } });
+		expect(readFileSync(legacyGlobalPath, "utf8")).toBe(legacyBytes);
+
+		await manager.reload();
+		expect(manager.getCompactionSettings()).toMatchObject({ enabled: false, reserveTokens: 8192 });
+		expect(manager.isFieldInherited("global", "packages")).toBe(true);
+	});
+
+	describe.each(["global", "project"] as const)("%s primary overrides", (scope) => {
+		it.each([
+			{ label: "a non-empty list", packages: ["npm:primary-package"] as string[] },
+			{ label: "an explicit empty list", packages: [] as string[] },
+		])("preserves primary packages when they are $label (#2299)", async ({ packages }) => {
+			const primaryPath = scope === "global" ? primaryGlobalPath : primaryProjectPath;
+			const legacyPath = scope === "global" ? legacyGlobalPath : legacyProjectPath;
+			const legacyBytes = writeJson(legacyPath, { packages: ["npm:legacy-package"] });
+			writeJson(primaryPath, { packages });
+			const manager = createManager();
+
+			if (scope === "global") manager.setExtensionPaths(["./atomic-extension.ts"]);
+			else manager.setProjectExtensionPaths(["./atomic-extension.ts"]);
+			await manager.flush();
+
+			expect(manager.drainErrors()).toEqual([]);
+			expect(readJson(primaryPath)).toEqual({ packages, extensions: ["./atomic-extension.ts"] });
+			expect(readFileSync(legacyPath, "utf8")).toBe(legacyBytes);
+			await manager.reload();
+			expect(manager.isFieldInherited(scope, "packages")).toBe(false);
+			expect(scope === "global" ? manager.getPackages() : manager.getProjectSettings().packages).toEqual(packages);
+		});
+	});
+
+	it.each([
+		{ label: "absent", createPrimary: false },
+		{ label: "empty", createPrimary: true },
+	])(
+		"does not materialize legacy-only project fields into an $label primary file (#2299)",
+		async ({ createPrimary }) => {
+			const legacyBytes = writeJson(legacyProjectPath, {
+				packages: ["npm:legacy-project-package"],
+				prompts: ["./legacy-prompt.md"],
+			});
+			if (createPrimary) writeJson(primaryProjectPath, {});
+			const manager = createManager();
+
+			manager.setProjectExtensionPaths(["./atomic-extension.ts"]);
+			await manager.flush();
+
+			expect(readJson(primaryProjectPath)).toEqual({ extensions: ["./atomic-extension.ts"] });
+			expect(readFileSync(legacyProjectPath, "utf8")).toBe(legacyBytes);
+
+			await manager.reload();
+			expect(manager.getProjectSettings().packages).toEqual(["npm:legacy-project-package"]);
+			expect(manager.isFieldInherited("project", "packages")).toBe(true);
+		},
+	);
+
+	it("preserves external edits and concurrent scoped writes without copying legacy fields (#2299)", async () => {
+		writeJson(legacyGlobalPath, { packages: ["npm:legacy-package"] });
+		writeJson(primaryGlobalPath, { theme: "dark" });
+		const firstManager = createManager();
+		const secondManager = createManager();
+
+		writeJson(primaryGlobalPath, {
+			theme: "external",
+			enabledModels: ["anthropic/claude-sonnet"],
+		});
+		firstManager.setDefaultThinkingLevel("high");
+		secondManager.setTheme("light");
+		await Promise.all([firstManager.flush(), secondManager.flush()]);
+
+		expect(readJson(primaryGlobalPath)).toEqual({
+			theme: "light",
+			enabledModels: ["anthropic/claude-sonnet"],
+			defaultThinkingLevel: "high",
+		});
+	});
+
+	it("preserves project edits made after the manager loaded (#2299)", async () => {
+		const legacyBytes = writeJson(legacyProjectPath, { packages: ["npm:legacy-project-package"] });
+		const manager = createManager();
+		writeJson(primaryProjectPath, { prompts: ["./external-prompt.md"] });
+
+		manager.setProjectExtensionPaths(["./atomic-extension.ts"]);
+		await manager.flush();
+
+		expect(manager.drainErrors()).toEqual([]);
+		expect(readJson(primaryProjectPath)).toEqual({
+			prompts: ["./external-prompt.md"],
+			extensions: ["./atomic-extension.ts"],
+		});
+		expect(readFileSync(legacyProjectPath, "utf8")).toBe(legacyBytes);
+		await manager.reload();
+		expect(manager.isFieldInherited("project", "packages")).toBe(true);
+	});
+
+	it("preserves newer primary nested fields without promoting fallback siblings (#2299)", async () => {
+		writeJson(legacyGlobalPath, { compaction: { enabled: true, reserveTokens: 8192, preserve_recent: 4 } });
+		const manager = createManager();
+		writeJson(primaryGlobalPath, { compaction: { reserveTokens: 16384 } });
+
+		manager.setCompactionEnabled(false);
+		await manager.flush();
+
+		expect(manager.drainErrors()).toEqual([]);
+		expect(readJson(primaryGlobalPath)).toEqual({ compaction: { enabled: false, reserveTokens: 16384 } });
+		await manager.reload();
+		expect(manager.getCompactionSettings()).toMatchObject({
+			enabled: false,
+			reserveTokens: 16384,
+			preserve_recent: 4,
+		});
+	});
+
+	it("keeps alternate SettingsStorage implementations source-compatible (#2299)", async () => {
+		const values: Record<SettingsScope, string | undefined> = {
+			global: JSON.stringify({ packages: ["npm:custom-storage"] }),
+			project: undefined,
+		};
+		const storage: SettingsStorage = {
+			withLock(scope, fn) {
+				const next = fn(values[scope]);
+				if (next !== undefined) values[scope] = next;
+			},
+		};
+		const manager = SettingsManager.fromStorage(storage);
+
+		manager.setTheme("dark");
+		await manager.flush();
+
+		expect(JSON.parse(values.global ?? "{}")).toEqual({
+			packages: ["npm:custom-storage"],
+			theme: "dark",
+		});
+	});
+});

--- a/packages/coding-agent/test/settings-manager-provenance.test.ts
+++ b/packages/coding-agent/test/settings-manager-provenance.test.ts
@@ -1,9 +1,10 @@
+import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { SettingsScope, SettingsStorage } from "../src/core/settings-manager.ts";
-import { FileSettingsStorage, SettingsManager } from "../src/core/settings-manager.ts";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import type { SettingsScope, SettingsStorage } from "../src/core/settings-manager.js";
+import { FileSettingsStorage, SettingsManager } from "../src/core/settings-manager.js";
 
 // Regression coverage for #2299: writes must preserve layered field provenance.
 describe("SettingsManager layered settings provenance", () => {
@@ -56,18 +57,18 @@ describe("SettingsManager layered settings provenance", () => {
 		});
 		const manager = createManager();
 
-		expect(manager.getPackages()).toEqual(["npm:legacy-package"]);
-		expect(manager.isFieldInherited("global", "packages")).toBe(true);
+		assert.deepEqual(manager.getPackages(), ["npm:legacy-package"]);
+		assert.equal(manager.isFieldInherited("global", "packages"), true);
 
 		manager.setTheme("dark");
 		await manager.flush();
 
-		expect(readJson(primaryGlobalPath)).toEqual({ theme: "dark" });
-		expect(readFileSync(legacyGlobalPath, "utf8")).toBe(legacyBytes);
+		assert.deepEqual(readJson(primaryGlobalPath), { theme: "dark" });
+		assert.equal(readFileSync(legacyGlobalPath, "utf8"), legacyBytes);
 
 		await manager.reload();
-		expect(manager.getPackages()).toEqual(["npm:legacy-package"]);
-		expect(manager.isFieldInherited("global", "packages")).toBe(true);
+		assert.deepEqual(manager.getPackages(), ["npm:legacy-package"]);
+		assert.equal(manager.isFieldInherited("global", "packages"), true);
 	});
 
 	it("writes only a modified nested field over an empty primary file (#2299)", async () => {
@@ -81,12 +82,13 @@ describe("SettingsManager layered settings provenance", () => {
 		manager.setCompactionEnabled(false);
 		await manager.flush();
 
-		expect(readJson(primaryGlobalPath)).toEqual({ compaction: { enabled: false } });
-		expect(readFileSync(legacyGlobalPath, "utf8")).toBe(legacyBytes);
+		assert.deepEqual(readJson(primaryGlobalPath), { compaction: { enabled: false } });
+		assert.equal(readFileSync(legacyGlobalPath, "utf8"), legacyBytes);
 
 		await manager.reload();
-		expect(manager.getCompactionSettings()).toMatchObject({ enabled: false, reserveTokens: 8192 });
-		expect(manager.isFieldInherited("global", "packages")).toBe(true);
+		assert.equal(manager.getCompactionSettings().enabled, false);
+		assert.equal(manager.getCompactionSettings().reserveTokens, 8192);
+		assert.equal(manager.isFieldInherited("global", "packages"), true);
 	});
 
 	describe.each(["global", "project"] as const)("%s primary overrides", (scope) => {
@@ -104,12 +106,12 @@ describe("SettingsManager layered settings provenance", () => {
 			else manager.setProjectExtensionPaths(["./atomic-extension.ts"]);
 			await manager.flush();
 
-			expect(manager.drainErrors()).toEqual([]);
-			expect(readJson(primaryPath)).toEqual({ packages, extensions: ["./atomic-extension.ts"] });
-			expect(readFileSync(legacyPath, "utf8")).toBe(legacyBytes);
+			assert.deepEqual(manager.drainErrors(), []);
+			assert.deepEqual(readJson(primaryPath), { packages, extensions: ["./atomic-extension.ts"] });
+			assert.equal(readFileSync(legacyPath, "utf8"), legacyBytes);
 			await manager.reload();
-			expect(manager.isFieldInherited(scope, "packages")).toBe(false);
-			expect(scope === "global" ? manager.getPackages() : manager.getProjectSettings().packages).toEqual(packages);
+			assert.equal(manager.isFieldInherited(scope, "packages"), false);
+			assert.deepEqual(scope === "global" ? manager.getPackages() : manager.getProjectSettings().packages, packages);
 		});
 	});
 
@@ -129,12 +131,12 @@ describe("SettingsManager layered settings provenance", () => {
 			manager.setProjectExtensionPaths(["./atomic-extension.ts"]);
 			await manager.flush();
 
-			expect(readJson(primaryProjectPath)).toEqual({ extensions: ["./atomic-extension.ts"] });
-			expect(readFileSync(legacyProjectPath, "utf8")).toBe(legacyBytes);
+			assert.deepEqual(readJson(primaryProjectPath), { extensions: ["./atomic-extension.ts"] });
+			assert.equal(readFileSync(legacyProjectPath, "utf8"), legacyBytes);
 
 			await manager.reload();
-			expect(manager.getProjectSettings().packages).toEqual(["npm:legacy-project-package"]);
-			expect(manager.isFieldInherited("project", "packages")).toBe(true);
+			assert.deepEqual(manager.getProjectSettings().packages, ["npm:legacy-project-package"]);
+			assert.equal(manager.isFieldInherited("project", "packages"), true);
 		},
 	);
 
@@ -152,7 +154,7 @@ describe("SettingsManager layered settings provenance", () => {
 		secondManager.setTheme("light");
 		await Promise.all([firstManager.flush(), secondManager.flush()]);
 
-		expect(readJson(primaryGlobalPath)).toEqual({
+		assert.deepEqual(readJson(primaryGlobalPath), {
 			theme: "light",
 			enabledModels: ["anthropic/claude-sonnet"],
 			defaultThinkingLevel: "high",
@@ -167,14 +169,14 @@ describe("SettingsManager layered settings provenance", () => {
 		manager.setProjectExtensionPaths(["./atomic-extension.ts"]);
 		await manager.flush();
 
-		expect(manager.drainErrors()).toEqual([]);
-		expect(readJson(primaryProjectPath)).toEqual({
+		assert.deepEqual(manager.drainErrors(), []);
+		assert.deepEqual(readJson(primaryProjectPath), {
 			prompts: ["./external-prompt.md"],
 			extensions: ["./atomic-extension.ts"],
 		});
-		expect(readFileSync(legacyProjectPath, "utf8")).toBe(legacyBytes);
+		assert.equal(readFileSync(legacyProjectPath, "utf8"), legacyBytes);
 		await manager.reload();
-		expect(manager.isFieldInherited("project", "packages")).toBe(true);
+		assert.equal(manager.isFieldInherited("project", "packages"), true);
 	});
 
 	it("preserves newer primary nested fields without promoting fallback siblings (#2299)", async () => {
@@ -185,14 +187,13 @@ describe("SettingsManager layered settings provenance", () => {
 		manager.setCompactionEnabled(false);
 		await manager.flush();
 
-		expect(manager.drainErrors()).toEqual([]);
-		expect(readJson(primaryGlobalPath)).toEqual({ compaction: { enabled: false, reserveTokens: 16384 } });
+		assert.deepEqual(manager.drainErrors(), []);
+		assert.deepEqual(readJson(primaryGlobalPath), { compaction: { enabled: false, reserveTokens: 16384 } });
 		await manager.reload();
-		expect(manager.getCompactionSettings()).toMatchObject({
-			enabled: false,
-			reserveTokens: 16384,
-			preserve_recent: 4,
-		});
+		const compaction = manager.getCompactionSettings();
+		assert.equal(compaction.enabled, false);
+		assert.equal(compaction.reserveTokens, 16384);
+		assert.equal(compaction.preserve_recent, 4);
 	});
 
 	it("keeps alternate SettingsStorage implementations source-compatible (#2299)", async () => {
@@ -211,7 +212,7 @@ describe("SettingsManager layered settings provenance", () => {
 		manager.setTheme("dark");
 		await manager.flush();
 
-		expect(JSON.parse(values.global ?? "{}")).toEqual({
+		assert.deepEqual(JSON.parse(values.global ?? "{}"), {
 			packages: ["npm:custom-storage"],
 			theme: "dark",
 		});


### PR DESCRIPTION
## Summary

Changing an unrelated setting, such as the theme, currently copies legacy-only `.pi` fields into `.atomic/settings.json`. This promotes inherited packages to explicit Atomic configuration and can bring back builtin extension conflicts. Persist scoped changes against a fresh primary-file snapshot under the write lock while keeping merged Atomic/Pi reads.

Closes #2299.

## Changes

- Add an optional `SettingsStorage.withPrimaryWriteLock` capability for layered storage. Existing single-document implementations keep their `withLock` behavior.
- Acquire the primary-file lock before reading the persistence base, including when the primary file does not yet exist, and apply only modified top-level or nested fields.
- Cover global/project scopes, missing and empty primary files, explicit package arrays including `[]`, unchanged legacy files, reload provenance, newer external edits, queued writes, and inherited builtin-resource precedence. Update settings documentation and the unreleased changelog.

## Validation

- The 12 new provenance cases produce 7 failures and 5 passes against unmodified production code at `187de04`; all 12 pass with this fix.
- Final focused run: 70/70 passed across 7 files (55 settings regressions and 15 inherited-resource overlap cases).
- Root TypeScript, coding-agent TypeScript/tsgo, full-repository Biome, and shrinkwrap checks passed.
- Windows native module release build passed with Rust 1.98.0; the resulting binding loads under Node 24.15.0.
- All applicable pre-commit hooks passed, including the complete `npm run check` with the Windows alias adapter described below.
- Full `npm run test:unit`: **NOT_COMPLETED**. Stopped after a 20-minute diagnostic limit with 12 failing files / 39 failed tests observed; there is no complete-suite pass count.
- Re-ran three representative failing root files with the three production changes reversed to baseline `187de04`: 75 passed / 21 failed. The same 21 cases fail on both versions: 5 embedded-Postgres symlink `EPERM` failures, 1 routing-guidance failure resolving `@bastani/atomic/workflows`, and 15 remote-input failures (`tui.setLayoutRoot is not a function`). The other 9 failing files / 18 observed failures have not been baseline-compared.

## Notes

The unmodified `npm run check` stops at `scripts/alias-pi-ai.mjs` because this Windows host cannot create directory symlinks (`EPERM`). Local hook validation uses an external adapter scoped solely to that script's `@earendil-works/pi-ai` alias, creating a Windows junction to the same `packages/ai` directory. No repository script or hook is changed, and no applicable check is skipped.

AI-assisted implementation and validation with OpenAI Codex.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791344668&installation_model_id=10562&pr_number=2899&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2899&signature=9c1f8322b5857a6cdb0abf3f5216fa5bababfbe263012a3099840977535e839e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents scoped settings writes from copying inherited legacy `.pi` values into primary `.atomic` settings. It adds a write-specific storage capability that reads the primary document while holding its file lock, applies modified fields to that fresh primary snapshot, preserves concurrent external edits, and adds regression coverage for layered settings provenance.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

The prior test import-convention finding was resolved by greptile-apps[bot] without explanation and is fixed in the current code. No outstanding findings remain.

<sub>Reviews (3): Last reviewed commit: ["test(settings): follow assertion and imp..."](https://github.com/bastani-inc/atomic/commit/fce073bf449864f5b4a9993225d3416d81247c8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61092964)</sub>

<!-- /greptile_comment -->