### PR TITLE
fix(intercom): prevent stale subagent notices after completion

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Settled tasks now leave the compact footer immediately while remaining inspectable in `/tasks` and completion cards, so retained failures do not keep the live indicator red.
 - Opening `/tasks` in isolated mode no longer emits an approval prompt or incorrectly changes Herdr to blocked. Genuine approval reporting remains unchanged.
 - Filled theme backgrounds now survive nested and truncation resets, keeping long task-completion titles, previews, and expand hints shaded through the last column.
+- Owner-bound task notifications now order queued same-child Intercom messages before completion through the delivery outbox. Failed delivery keeps the terminal intent retryable without changing the execution outcome, replaying successful earlier messages, or relaunching the task.
 
 ## [0.9.19-alpha.1] - 2026-09-06
 

--- a/packages/coding-agent/docs/intercom.md
+++ b/packages/coding-agent/docs/intercom.md
@@ -119,6 +119,8 @@ See auth.ts:142-156.
 
 The reply hint (enabled by default) points to `intercom({ action: "reply", ... })`, so recipients never need raw sender or `replyTo` IDs. Idle recipients get a new turn immediately; busy interactive recipients receive the message once they go idle. Attachment content is included in the agent-visible body, and messages are rendered inline and stored in Atomic session history.
 
+A busy non-interactive recipient can refuse a message without interrupting its task. A successful `send` receipt acknowledges transport delivery, not acceptance by the recipient's model. The refusal carries the original reply thread: a waiting `ask` returns an error; otherwise the sender sees **Intercom delivery failed** feedback with a `Sent:` timestamp. That feedback bypasses the ordinary idle queue and does not trigger a standalone agent turn. During an active turn, protected delivery makes it visible and reconciles it at a protocol-safe boundary. Its wording describes the refused send, not the recipient's later activity.
+
 Atomic treats ordinary `intercom` as a mandatory runtime tool in main chat and every workflow model stage. Tool allowlists, exclusions, `noTools`, optional-extension restrictions, and reloads cannot unload or deactivate it. Restrictions on every other tool are unchanged, and `contact_supervisor` remains subagent-only. Tool registration is lightweight; broker connection and heavy initialization remain lazy until an Intercom surface is used.
 
 ## How Connection Works
@@ -417,7 +419,7 @@ If live peer coordination is needed, invoke `intercom({ action: "status" })` in 
 
 Blocking `contact_supervisor` decisions and interviews, plus `intercom.ask` calls whose resolved target is the launching parent, end at the source before Intercom send or waiter admission. The parent receives the verbatim question, ordered attachments, child identity, and fresh-start handoff. In parallel, the claim interrupts active siblings and prevents queued work from starting without retaining the sibling set. Progress updates, sends, and asks to other peers retain the probe/commit detach path.
 
-For delegated children, queued messages and terminal lifecycle notices remain ordered per child. Exact terminal-identity deduplication prevents double admission, failed dispatches remain retryable, and correlated ask replies bypass unrelated queued sends. See [Subagents](/subagents) for the full coordination contract.
+For delegated children, queued messages and terminal lifecycle notices remain ordered per child, including owner-bound background tasks. Before publishing completion, the notification outbox drains already-queued ordinary messages from that child's trusted run and Intercom target. Other children and pending asks stay separate. Each earlier message keeps its own admission identity; the completion ID belongs only to the terminal notice. A failed message or terminal delivery remains retryable without changing the task's outcome or rerunning it. Restored completions without a live source binding still deliver normally rather than guessing a child identity. See [Subagents](/subagents) for the full coordination contract.
 
 ## Configuration
 

--- a/packages/coding-agent/src/core/agent-session-tasks.ts
+++ b/packages/coding-agent/src/core/agent-session-tasks.ts
@@ -1,4 +1,5 @@
 import type { AgentSessionInternalSurface as AgentSession } from "./agent-session-methods.ts";
+import { getExtensionRuntimeEventBus } from "./extensions/loader-core.js";
 import { AgentTaskHost } from "./tasks/agent-adapter.js";
 import { COMMAND_DETAIL_TAIL_BYTES, taskOutputText } from "./tasks/command-output.js";
 import {
@@ -7,6 +8,7 @@ import {
 	TaskCompletionOutbox,
 	taskCompletionNotice,
 } from "./tasks/completion.js";
+import { flushTaskCompletionMessages } from "./tasks/completion-ordering.js";
 import { bindOwnerTaskStore, OwnerTaskStore } from "./tasks/owner-store.js";
 import { taskTranscriptSource } from "./tasks/supervisor.js";
 import { WorkflowStageAdmissionBoundary } from "./workflow-stage-admission.ts";
@@ -70,6 +72,14 @@ export function getAgentTaskHost(this: AgentSession): AgentTaskHost {
 					// Missing retained output must not suppress a terminal notification.
 					output = "Output unavailable";
 				}
+			}
+			const completionSource = source?.ok ? source.value.session.completionSource : undefined;
+			if (completionSource) {
+				await flushTaskCompletionMessages(
+					getExtensionRuntimeEventBus(this._resourceLoader.getExtensions().runtime),
+					completionSource,
+					envelope.completionId,
+				);
 			}
 			await admission.admit(
 				envelope.completionId,

--- a/packages/coding-agent/src/core/tasks/completion-ordering.ts
+++ b/packages/coding-agent/src/core/tasks/completion-ordering.ts
@@ -1,0 +1,31 @@
+import type { EventBus } from "../event-bus.js";
+
+/** Shared with the optional Intercom/subagent companions. */
+export const SUBAGENT_TERMINAL_ORDERING_BARRIER_EVENT = "subagent:terminal-ordering-barrier";
+
+/** Trusted runner metadata; never inferred from model-provided task IDs or labels. */
+export interface TaskCompletionSource {
+	readonly runId: string;
+	readonly intercomTarget: string;
+}
+
+/** Notification delivery owns this wait. It must never reject a runner's execution result. */
+export async function flushTaskCompletionMessages(
+	events: EventBus,
+	source: TaskCompletionSource,
+	completionId: string,
+): Promise<void> {
+	const request = {
+		runId: source.runId,
+		terminalId: completionId,
+		terminalAt: Date.now(),
+		source: "owner-task" as const,
+		sourceSessionTargets: [source.intercomTarget],
+		completion: undefined as Promise<void> | undefined,
+	};
+	Object.defineProperty(request, "terminalOwner", { value: events });
+	// The event bus invokes listeners synchronously but does not await them.
+	// A claiming listener publishes its completion promise before returning.
+	events.emit(SUBAGENT_TERMINAL_ORDERING_BARRIER_EVENT, request);
+	await request.completion;
+}

--- a/packages/coding-agent/src/core/tasks/supervisor.ts
+++ b/packages/coding-agent/src/core/tasks/supervisor.ts
@@ -3,9 +3,12 @@ import type * as native from "@bastani/atomic-natives";
 import { createModuleRequire } from "../../utils/module-require.ts";
 import type { SessionManager } from "../session-manager.ts";
 import { COMMAND_FOREGROUND_BUDGET_MS } from "./command-output.js";
+import type { TaskCompletionSource } from "./completion-ordering.js";
 import type * as C from "./contracts.js";
 
-export type TaskTranscriptSource = Pick<SessionManager, "getSessionId" | "getEntries">;
+export type TaskTranscriptSource = Pick<SessionManager, "getSessionId" | "getEntries"> & {
+	readonly completionSource?: TaskCompletionSource;
+};
 
 export const DEFAULT_AGENT_WAIT_BUDGET_MS = 30000;
 /** These objects are live authority, not DTOs, restart tokens or model arguments. */

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 - Excluded internal workflow route-owner/control connections, model-less `ctx.ui` prompts, and `ctx.tool` nodes from recipient discovery. Broker checks refuse known non-agent targets before delivery or queueing, including retained completed prompts. Genuine agents busy in tools or awaiting human input remain eligible, and connected aliases survive pending-capability changes and completion without same-name controls changing agent ambiguity diagnostics.
 - Reject malformed session/roster recipient purposes while preserving omitted-purpose legacy agents. Workflow roster updates now wait for broker processing before reporting completion, preventing stale discovery across connections ([#2895](https://github.com/bastani-inc/atomic/pull/2895)).
 - `send`, `ask`, and `reply` now retry recoverable disconnects inside one tool invocation, preserving delivery identity and reply correlation for up to three retries. Cancellation stops retries, unresolved outcomes warn against automatic resending, and client retry state is released on exit. Broker deduplication and durable acceptance safeguards remain unchanged.
+- Busy non-interactive recipients now return correlated delivery errors instead of a stale "still working" auto-reply. Unclaimed refusals bypass the parent's idle queue as timestamped delivery feedback without starting another turn; waiting asks retain exact error correlation.
+- Owner-bound subagent task completion now participates in same-child message ordering, preserving unrelated queued messages and retrying failed delivery without repeating task execution.
 
 ## [0.9.18] - 2026-09-05
 

--- a/packages/intercom/closed-workflow-stage-message.ts
+++ b/packages/intercom/closed-workflow-stage-message.ts
@@ -1,5 +1,6 @@
 import type { IntercomClient } from "./broker/client.js";
 import type { InboundMessageAdmission } from "./inbound-message-admission.js";
+import { isDeliveryFeedback } from "./incoming-message-delivery.js";
 import type { InboundMessageEntry } from "./intercom-utils.js";
 import { routeIncomingReply } from "./reply-routing.js";
 import type { ReplyTracker } from "./reply-tracker.js";
@@ -27,7 +28,7 @@ export function routeClosedWorkflowStageMessage(
   const sourceRunId = entry.message.source?.subagentRunId;
   if (sourceRunId !== undefined && ownsSubagentRun(sourceRunId)) return;
 
-  if (entry.message.expectsReply !== true) {
+  if (entry.message.expectsReply !== true && !isDeliveryFeedback(entry.message)) {
     void retryStableDelivery({ deliver, isCurrent }).catch(() => {});
     return;
   }
@@ -35,6 +36,13 @@ export function routeClosedWorkflowStageMessage(
   if (admitted.kind !== "reserved") return;
   if (routeIncomingReply(waiter, entry.from, entry.message)) {
     admission.commit(admitted.reservation);
+    return;
+  }
+  if (isDeliveryFeedback(entry.message)) {
+    void retryStableDelivery({ deliver, isCurrent }).then(
+      () => { admission.commit(admitted.reservation); },
+      (error) => { admission.release(admitted.reservation, error instanceof Error ? error : new Error(String(error))); },
+    );
     return;
   }
   const replyContext = tracker.recordIncomingMessage(entry.from, entry.message);

--- a/packages/intercom/inbound-idle-queue.ts
+++ b/packages/intercom/inbound-idle-queue.ts
@@ -2,6 +2,7 @@ import type { InboundMessageEntry } from "./intercom-utils.js";
 
 export interface InboundIdleClaim {
   entries: InboundMessageEntry[];
+  isCurrent(): boolean;
   rollbackFrom(index: number): void;
 }
 
@@ -12,6 +13,7 @@ export interface InboundIdleClaim {
  */
 export class InboundIdleQueue {
   private entries: InboundMessageEntry[] = [];
+  private generation = 0;
 
   get size(): number {
     return this.entries.length;
@@ -40,6 +42,7 @@ export class InboundIdleQueue {
 
   claimOrdinarySourceTargets(runId: string, sourceSessionTargets: readonly string[], terminalAt = Number.POSITIVE_INFINITY): InboundIdleClaim {
     const targets = new Set(sourceSessionTargets);
+    const generation = this.generation;
     const original = this.entries;
     const legacyIdsByName = new Map<string, Set<string>>();
     for (const entry of original) {
@@ -64,8 +67,9 @@ export class InboundIdleQueue {
     let settled = false;
     return {
       entries: selected,
+      isCurrent: () => generation === this.generation,
       rollbackFrom: (index) => {
-        if (settled) return;
+        if (settled || generation !== this.generation) return;
         settled = true;
         const undelivered = new Set(selected.slice(index));
         const laterEntries = this.entries.filter((entry) => !originalSet.has(entry));
@@ -77,6 +81,7 @@ export class InboundIdleQueue {
   }
 
   clear(): void {
+    this.generation++;
     this.entries = [];
   }
 }

--- a/packages/intercom/incoming-message-delivery.ts
+++ b/packages/intercom/incoming-message-delivery.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@bastani/atomic";
 import type { InboundMessageEntry } from "./intercom-utils.js";
 import type { IntercomContext } from "./reply-tracker.js";
+import type { Message } from "./types.js";
 
 export type IncomingMessageDelivery = "trigger" | "followUp" | "prelude";
 export type IncomingMessageSender = (
@@ -49,6 +50,19 @@ export function framePreStartPendingStageMessage(entry: InboundMessageEntry): In
 		...entry,
 		bodyText: `**Messages received before you started**\n\nSent: ${framePendingStageTimestamp(entry.message.timestamp)}\n\n${entry.bodyText}`,
 	};
+}
+
+export function isDeliveryFeedback(message: Message): boolean {
+  return Boolean(message.replyTo) && message.replyError !== undefined;
+}
+
+/** Delivery feedback describes a past send, not the recipient's current activity. */
+export function frameDeliveryFeedback(entry: InboundMessageEntry): InboundMessageEntry {
+  return {
+    ...entry,
+    replyCommand: undefined,
+    bodyText: `**Intercom delivery failed**\n\nSent: ${framePendingStageTimestamp(entry.message.timestamp)}\n\n${entry.bodyText}`,
+  };
 }
 
 export function buildIncomingCustomMessage(entry: InboundMessageEntry) {

--- a/packages/intercom/index-heavy.ts
+++ b/packages/intercom/index-heavy.ts
@@ -26,6 +26,8 @@ import { readSubagentMessageSource } from "./source-ownership.js";
 import {
   buildIncomingCustomMessage,
   createIncomingMessageSender,
+  frameDeliveryFeedback,
+  isDeliveryFeedback,
   framePreStartPendingStageMessage,
 } from "./incoming-message-delivery.js";
 import { InboundIdleQueue } from "./inbound-idle-queue.js";
@@ -342,7 +344,8 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
       ? `intercom({ action: "reply", message: "..." })`
       : undefined;
     const rawEntry = { from, message, replyCommand, bodyText, ...(channel ? { channel } : {}) };
-    const entry = receivedBeforeStageStart ? framePreStartPendingStageMessage(rawEntry) : rawEntry;
+    const framedEntry = isDeliveryFeedback(message) ? frameDeliveryFeedback(rawEntry) : rawEntry;
+    const entry = receivedBeforeStageStart ? framePreStartPendingStageMessage(framedEntry) : framedEntry;
     if (receivedBeforeStageStart) {
       return sendIncomingMessage(entry, "prelude", messageGeneration, false);
     }
@@ -353,7 +356,7 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
     if (stageClosed) {
       routeClosedWorkflowStageMessage(
         entry, inboundDeliveries, replyTracker, replyWaiters.pending(),
-        () => sendIncomingMessage(entry, "trigger", messageGeneration, false),
+        () => sendIncomingMessage(entry, isDeliveryFeedback(message) ? "prelude" : "trigger", messageGeneration, false),
         () => client,
         () => Boolean(getLiveContext(liveContext, messageGeneration)),
         (runId) => stageAdmission.boundary.ownsSubagentRun(runId),
@@ -366,6 +369,17 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
     if (routeIncomingReply(replyWaiters.pending(), from, message)) {
       inboundDeliveries.commit(reservation);
       return;
+    }
+    if (isDeliveryFeedback(message)) {
+      // Correlated asks were resolved above. A refusal of a fire-and-forget
+      // send is feedback, not a new conversation to queue until parent idle.
+      return retryStableDelivery({
+        deliver: () => sendIncomingMessage(entry, "prelude", messageGeneration, false),
+        isCurrent: () => Boolean(getLiveContext(liveContext, messageGeneration)),
+      }).then(
+        () => inboundDeliveries.commit(reservation),
+        (error) => inboundDeliveries.release(reservation, toError(error)),
+      );
     }
     const replyContext = replyTracker.recordIncomingMessage(from, message);
     const commit = (): void => { inboundDeliveries.commit(reservation); };
@@ -406,9 +420,11 @@ export default function piIntercomExtension(pi: ExtensionAPI, testOverrides: Int
             const activeClient = client;
             if (!message.replyTo && activeClient?.isConnected()) {
               try {
+                const refusal = "Message not accepted: recipient was busy in non-interactive mode. Its task was not interrupted.";
                 const result = await activeClient.send(from.id, {
-                  text: "This agent is running in non-interactive mode and cannot respond to intercom messages while it is working. It will continue its current task and exit when done.",
+                  text: refusal,
                   replyTo: message.id,
+                  replyError: refusal,
                 });
                 if (result.delivered && getLiveContext(liveContext, messageGeneration)) {
                   replyTracker.markReplied(message.id);

--- a/packages/intercom/terminal-ordering-barrier.ts
+++ b/packages/intercom/terminal-ordering-barrier.ts
@@ -20,7 +20,7 @@ export interface TerminalOrderingBarrier {
   runId: string;
   terminalId: string;
   terminalAt: number;
-  source: "detached-notify" | "result-relay";
+  source: "detached-notify" | "result-relay" | "owner-task";
   owner?: object;
   sourceSessionTargets: string[];
   dispatch?(prefix: OrderedTerminalPreludeMessage[]): unknown;
@@ -39,7 +39,7 @@ function parseBarrier(value: unknown): TerminalOrderingBarrier | null {
   const record = value as Record<string, unknown>;
   if (typeof record.runId !== "string" || !record.runId) return null;
   if (typeof record.terminalAt !== "number" || !Number.isFinite(record.terminalAt)) return null;
-  if (record.source !== "detached-notify" && record.source !== "result-relay") return null;
+  if (record.source !== "detached-notify" && record.source !== "result-relay" && record.source !== "owner-task") return null;
   if (!Array.isArray(record.sourceSessionTargets)) return null;
   const sourceSessionTargets = record.sourceSessionTargets
     .filter((target): target is string => typeof target === "string")
@@ -125,10 +125,18 @@ export function registerTerminalOrderingBarrier(
     const terminalKey = `${terminalOwnerId(barrier.owner)}:${barrier.runId}\0${barrier.terminalId}`;
     const currentOwner = inFlightByTerminal.get(terminalKey);
     if (currentOwner) { envelope.completion = currentOwner; return; }
-    const drainedTargets = drainedTargetsByTerminal.get(terminalKey) ?? new Set<string>();
+    // Owner-task calls drain only preludes; the outbox publishes the terminal
+    // afterward and may retry it. Rescan on retry for newly queued messages.
+    const drainedTargets = barrier.source === "owner-task" ? new Set<string>() : drainedTargetsByTerminal.get(terminalKey) ?? new Set<string>();
     const pendingTargets = barrier.sourceSessionTargets.filter((target) => !drainedTargets.has(target));
     if (pendingTargets.length === 0) return;
     const claim = options.queue.claimOrdinarySourceTargets(barrier.runId, pendingTargets, barrier.terminalAt);
+    const deliverPrelude = (entry: InboundMessageEntry): unknown => {
+      if (!claim.isCurrent() || options.isCurrent?.() === false) {
+        throw new Error("Intercom terminal delivery owner retired");
+      }
+      return options.deliver(entry, "prelude");
+    };
     const ownership = Promise.withResolvers<void>();
     void ownership.promise.catch(() => {});
     inFlightByTerminal.set(terminalKey, ownership.promise);
@@ -137,7 +145,7 @@ export function registerTerminalOrderingBarrier(
       ownership.reject(error);
     };
     const finish = (): void => {
-      if ((barrier.dispatch && options.toMessage) || claim.entries.length > 0) {
+      if (barrier.source !== "owner-task" && ((barrier.dispatch && options.toMessage) || claim.entries.length > 0)) {
         for (const target of pendingTargets) drainedTargets.add(target);
         drainedTargetsByTerminal.set(terminalKey, drainedTargets);
       }
@@ -184,7 +192,7 @@ export function registerTerminalOrderingBarrier(
       let delivered: unknown;
       let deliveredAsync: boolean;
       try {
-        delivered = options.deliver(claim.entries[index]!, "prelude");
+        delivered = deliverPrelude(claim.entries[index]!);
         deliveredAsync = isPromiseLike(delivered);
       } catch (error) {
         // Owned producers follow the event path with the global fallback. Keep the failed
@@ -200,7 +208,7 @@ export function registerTerminalOrderingBarrier(
         try {
           await delivered;
           for (current = index + 1; current < claim.entries.length; current++) {
-            await options.deliver(claim.entries[current]!, "prelude");
+            await deliverPrelude(claim.entries[current]!);
           }
           finish();
         } catch (error) {

--- a/packages/intercom/types.ts
+++ b/packages/intercom/types.ts
@@ -79,7 +79,7 @@ export interface Message {
   timestamp: number;
   replyTo?: string;
   expectsReply?: boolean;
-  /** Actionable remote failure for a correlated ask reply. */
+  /** Correlated delivery refusal: settles a waiting ask, otherwise surfaces as send feedback. */
   replyError?: string;
   source?: {
     subagentRunId: string;

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Already-admitted in-process task callers now yield each active foreground sibling's observation on an exact Intercom group commit without ending or replacing the original executions ([#2884](https://github.com/bastani-inc/atomic/pull/2884)).
 - Status and interrupt now accept owner-bound task IDs returned by launches, and wait results use readable observation summaries. Corrected foreground-only claims in orchestrator guidance, the bundled delegation and terminal skills, and the README. Agents can choose foreground-first or background observation; automatic yielding preserves the original execution.
+- Bound task transcript sources now retain the trusted run and actual Intercom target so queued child messages are delivered before owner-bound completion notices, without guessing from task or SDK session IDs.
 
 ### Changed
 

--- a/packages/subagents/src/runs/foreground/task-execution.ts
+++ b/packages/subagents/src/runs/foreground/task-execution.ts
@@ -53,7 +53,19 @@ export async function runAgentTask(input: {
 						taskExecution: {
 							signal: context.signal,
 							reportActivity: context.reportActivity,
-							bindTranscript: context.bindTranscript,
+							bindTranscript: (session) =>
+								context.bindTranscript({
+									getSessionId: () => session.getSessionId(),
+									getEntries: () => session.getEntries(),
+									...(input.options.intercomSessionName
+										? {
+												completionSource: {
+													runId: input.options.runId,
+													intercomTarget: input.options.intercomSessionName,
+												},
+											}
+										: {}),
+								}),
 							onExecution: (execution) => {
 								executionBound = true;
 								void execution.cleanup.then(cleaned.resolve, (error) =>

--- a/test/integration/task-completion-delivery.test.ts
+++ b/test/integration/task-completion-delivery.test.ts
@@ -363,3 +363,46 @@ test.runIf(process.platform !== "win32")(
 		}
 	},
 );
+
+test("a persisted Intercom prelude cannot suppress a missing terminal notification on restore", async () => {
+	const manager = SessionManager.inMemory();
+	const completionId = "terminal-after-persisted-prelude";
+	manager.appendCustomEntry("task-completion-intent", {
+		completionId,
+		ownerId: "historical-owner",
+		taskId: "historical-task",
+		terminalSequence: 7,
+		result: { kind: "cancelled", cause: "user" },
+		display: false,
+	});
+	manager.appendCustomMessageEntry(
+		"intercom_message",
+		"Earlier child finding",
+		true,
+		{},
+		undefined,
+		undefined,
+		"intercom:earlier-finding",
+	);
+	const deliveries: string[] = [];
+	const session = {
+		sessionManager: manager,
+		async sendCustomMessage(_message: object, options: { stageAdmissionKey: string }) {
+			deliveries.push(options.stageAdmissionKey);
+		},
+	} as unknown as ThisParameterType<typeof getAgentTaskHost>;
+	const host = getAgentTaskHost.call(session);
+	try {
+		await vi.waitFor(() => assert.deepEqual(deliveries, [completionId]));
+		await session._taskCompletionOutbox!.flush();
+		assert.equal(session._taskCompletionOutbox!.pending.length, 0);
+		assert.equal(
+			manager
+				.getEntries()
+				.filter((entry) => entry.type === "custom_message" && entry.customType === "intercom_message").length,
+			1,
+		);
+	} finally {
+		await host.close("session-close");
+	}
+});

--- a/test/integration/task-intercom-completion-order.test.ts
+++ b/test/integration/task-intercom-completion-order.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import { getAgentTaskHost } from "../../packages/coding-agent/src/core/agent-session-tasks.js";
+import {
+	createExtensionRuntime,
+	getExtensionRuntimeEventBus,
+} from "../../packages/coding-agent/src/core/extensions/loader.js";
+import type { SendMessageOptions } from "../../packages/coding-agent/src/core/extensions/types.js";
+import { SessionManager } from "../../packages/coding-agent/src/core/session-manager.js";
+import { AgentTaskHost } from "../../packages/coding-agent/src/core/tasks/agent-adapter.js";
+import type { OperationId, TaskResult } from "../../packages/coding-agent/src/core/tasks/contracts.js";
+import { taskTranscriptSource } from "../../packages/coding-agent/src/core/tasks/supervisor.js";
+import { InboundIdleQueue } from "../../packages/intercom/inbound-idle-queue.js";
+import { createIncomingMessageSender } from "../../packages/intercom/incoming-message-delivery.js";
+import type { InboundMessageEntry } from "../../packages/intercom/intercom-utils.js";
+import { registerTerminalOrderingBarrier } from "../../packages/intercom/terminal-ordering-barrier.js";
+import { runAgentTask } from "../../packages/subagents/src/runs/foreground/task-execution.js";
+
+function message(id: string, target = "child-target", runId = "child-run"): InboundMessageEntry {
+	const from = {
+		id: `${target}-broker-id`,
+		name: target,
+		cwd: "/repo",
+		model: "test",
+		pid: 1,
+		startedAt: 1,
+		lastActivity: 1,
+	};
+	return {
+		from,
+		message: { id, timestamp: 1, source: { subagentRunId: runId }, content: { text: id } },
+		bodyText: id,
+	};
+}
+
+for (const failAt of [undefined, "second", "task-completion"] as const) {
+	test(`owner-bound completion orders child messages in the delivery outbox, failAt=${failAt}`, async () => {
+		const manager = SessionManager.inMemory();
+		const child = SessionManager.inMemory();
+		const runtime = createExtensionRuntime();
+		const events = getExtensionRuntimeEventBus(runtime);
+		const queue = new InboundIdleQueue();
+		queue.enqueue(message("first"));
+		queue.enqueue(message("unrelated", "other-target", "other-run"));
+		queue.enqueue(message("second"));
+		queue.enqueue(message("same-alias-other-run", "child-target", "other-run"));
+		const delivered: string[] = [];
+		let fail = failAt !== undefined;
+		const session = {
+			sessionManager: manager,
+			_resourceLoader: { getExtensions: () => ({ runtime }) },
+			async sendCustomMessage(
+				value: { customType: string; content: string; details?: InboundMessageEntry },
+				options?: SendMessageOptions,
+			) {
+				const id = value.customType === "intercom_message" ? value.details!.message.id : value.customType;
+				if (fail && id === failAt) throw new Error("injected delivery failure");
+				if (value.customType === "intercom_message") {
+					assert.equal(options?.stageAdmissionKey, `intercom:${id}`);
+					assert.equal(options?.triggerTurn, undefined, "prelude must not trigger another turn");
+				} else assert.ok(!options?.stageAdmissionKey?.startsWith("intercom:"));
+				delivered.push(id);
+			},
+		} as unknown as ThisParameterType<typeof getAgentTaskHost>;
+		const send = createIncomingMessageSender({
+			pi: { sendMessage: (value, options) => session.sendCustomMessage(value, options) },
+			currentGeneration: () => 1,
+			canDeliver: () => true,
+			queueTurnContext() {},
+		});
+		const unregister = registerTerminalOrderingBarrier({ events } as never, {
+			queue,
+			deliver: (entry) => send(entry, "prelude", 1, false),
+		});
+		const host = getAgentTaskHost.call(session);
+		const result = Promise.withResolvers<TaskResult>();
+		let launches = 0;
+		try {
+			const started = await host.startAgentTask(
+				{ kind: "agent", agent: "fake", task: "Inspect" },
+				"ordered-completion" as OperationId,
+				(context) => {
+					launches++;
+					context.bindTranscript({
+						getSessionId: () => child.getSessionId(),
+						getEntries: () => child.getEntries(),
+						completionSource: { runId: "child-run", intercomTarget: "child-target" },
+					});
+					return { result: result.promise, cleanup: Promise.resolve({ kind: "reaped" }) };
+				},
+			);
+			assert.ok(started.ok);
+			await host.observeAgentLaunch(started.value.taskId, { kind: "background" });
+			const before = host.watchOwnerTasks();
+			assert.ok(before.ok);
+			const outcome: TaskResult = { kind: "completed", output: before.value.snapshot.tasks[0]!.output };
+			before.value.dispose();
+			result.resolve(outcome);
+			await host.waitForTask(started.value.taskId);
+			await vi.waitFor(() =>
+				assert.ok(
+					manager
+						.getEntries()
+						.some((entry) => entry.type === "custom" && entry.customType === "task-completion-intent"),
+				),
+			);
+			await session._taskCompletionOutbox!.flush();
+			if (failAt) {
+				assert.deepEqual(delivered, failAt === "second" ? ["first"] : ["first", "second"]);
+				assert.equal(session._taskCompletionOutbox!.pending.length, 1);
+				if (failAt === "task-completion") queue.enqueue(message("late-before-retry"));
+				fail = false;
+				await session._taskCompletionOutbox!.flush();
+			}
+			assert.deepEqual(delivered, [
+				"first",
+				"second",
+				...(failAt === "task-completion" ? ["late-before-retry"] : []),
+				"task-completion",
+			]);
+			assert.equal(session._taskCompletionOutbox!.pending.length, 0);
+			assert.deepEqual(
+				queue.drain().map((entry) => entry.message.id),
+				["unrelated", "same-alias-other-run"],
+			);
+			assert.equal(launches, 1);
+			const watched = host.watchOwnerTasks();
+			assert.ok(watched.ok);
+			assert.deepEqual(watched.value.snapshot.tasks[0]!.execution, { kind: "settled", result: outcome });
+			watched.value.dispose();
+		} finally {
+			unregister();
+			await host.close("session-close");
+		}
+	});
+}
+
+test("subagent task bridge binds its actual run and Intercom target, not its SDK session ID", async () => {
+	const host = new AgentTaskHost({ scope: { kind: "session", sessionId: "source-owner" }, authorizeLaunch() {} });
+	const child = SessionManager.inMemory();
+	const finish = Promise.withResolvers<void>();
+	try {
+		const response = await runAgentTask({
+			host,
+			cwd: process.cwd(),
+			agents: [],
+			agent: "fake",
+			task: "Inspect",
+			options: { runId: "actual-run", intercomSessionName: "actual-intercom-target" },
+			wait: { kind: "background" },
+			runtime: {
+				async runSync(_cwd, _agents, _agent, _task, options) {
+					options.taskExecution!.bindTranscript!(child);
+					await finish.promise;
+					return {
+						agent: "fake",
+						task: "Inspect",
+						status: "ok",
+						envelope: "Done",
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 },
+					};
+				},
+			},
+		});
+		assert.equal(response.kind, "admitted");
+		if (response.kind !== "admitted") return;
+		const task = host.resolveTask(response.observation.taskId);
+		assert.ok(task.ok);
+		const source = taskTranscriptSource(task.value);
+		assert.ok(source.ok);
+		assert.equal(source.value.session.getSessionId(), child.getSessionId());
+		assert.deepEqual(source.value.session.completionSource, {
+			runId: "actual-run",
+			intercomTarget: "actual-intercom-target",
+		});
+	} finally {
+		finish.resolve();
+		await host.close("session-close");
+	}
+});

--- a/test/unit/intercom-closed-workflow-stage-message.test.ts
+++ b/test/unit/intercom-closed-workflow-stage-message.test.ts
@@ -594,3 +594,40 @@ test("the ask tool receives the production-composed correlated revival failure w
 	assert.equal(result.content[0]?.text, `Failed: ${exact}`);
 	assert.equal(callerWaiter.has(), false);
 });
+
+test("a closed stage routes correlated delivery errors only to their exact waiting ask", async () => {
+	const admission = new InboundMessageAdmission();
+	const tracker = new ReplyTracker();
+	const waiters = new ReplyWaiterRegistry();
+	const expected = waiters.begin(sender.id, "original-send");
+	const unrelated = waiters.begin("other-peer", "other-send");
+	assert.ok(expected.ok && unrelated.ok);
+	let deliveries = 0;
+	const refusal: Message = {
+		id: "refusal",
+		timestamp: 1,
+		replyTo: "original-send",
+		replyError: "recipient busy",
+		content: { text: "recipient busy" },
+	};
+	try {
+		routeClosedWorkflowStageMessage(
+			{ from: sender, message: refusal, bodyText: refusal.content.text },
+			admission,
+			tracker,
+			waiters.pending(),
+			async () => {
+				deliveries++;
+			},
+			() => null,
+			() => true,
+			() => false,
+		);
+		assert.equal(waiters.size(), 1);
+		assert.equal((await expected.wait.promise).replyError, "recipient busy");
+		assert.equal(deliveries, 0, "a matched ask error is not a separate notification");
+		assert.deepEqual(tracker.listPending(), []);
+	} finally {
+		waiters.rejectAll(new Error("test cleanup"));
+	}
+});

--- a/test/unit/intercom-delivery-feedback.test.ts
+++ b/test/unit/intercom-delivery-feedback.test.ts
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import { afterEach, test, vi } from "vitest";
+import { createEventBus } from "../../packages/coding-agent/src/core/event-bus.js";
+import type { ExtensionContext, SendMessageOptions } from "../../packages/coding-agent/src/core/extensions/types.js";
+import { flushTaskCompletionMessages } from "../../packages/coding-agent/src/core/tasks/completion-ordering.js";
+import intercomHeavy from "../../packages/intercom/index-heavy.js";
+import type { IntercomExtensionTestOverrides } from "../../packages/intercom/intercom-test-seams.js";
+import type { Message, SessionInfo } from "../../packages/intercom/types.js";
+
+const sender: SessionInfo = {
+	id: "child-session",
+	name: "subagent-debugger-refusal-1",
+	cwd: "/repo",
+	model: "test",
+	pid: 1,
+	startedAt: 1,
+	lastActivity: 1,
+};
+const refusal: Message = {
+	id: "busy-refusal",
+	timestamp: 1000,
+	replyTo: "parent-amendment",
+	replyError: "Message not accepted: recipient was busy in non-interactive mode. Its task was not interrupted.",
+	content: { text: "Message not accepted: recipient was busy in non-interactive mode. Its task was not interrupted." },
+};
+
+afterEach(() => vi.useRealTimers());
+
+async function fixture(closedStage = false) {
+	let idle = false;
+	let rejectDelivery = false;
+	let sessionId = "parent-feedback-test";
+	let deliveryGate: Promise<void> | undefined;
+	const handlers = new Map<string, Array<(event: object, ctx: ExtensionContext) => void | Promise<void>>>();
+	let inbound!: Parameters<NonNullable<IntercomExtensionTestOverrides["captureInboundHandler"]>>[0];
+	const sent: Array<{ content: string; options?: SendMessageOptions }> = [];
+	const send = (message: { content: string }, options?: SendMessageOptions) => {
+		if (rejectDelivery) throw new Error("display admission failed");
+		sent.push({ content: message.content, options });
+		return deliveryGate;
+	};
+	const pi = {
+		on(name: string, handler: (event: object, ctx: ExtensionContext) => void | Promise<void>) {
+			handlers.set(name, [...(handlers.get(name) ?? []), handler]);
+		},
+		registerTool() {},
+		registerCommand() {},
+		registerShortcut() {},
+		registerMessageRenderer() {},
+		appendEntry() {},
+		getSessionName: () => undefined,
+		sendMessage: send,
+		sendMessages: (messages: Array<{ content: string }>, options?: SendMessageOptions) => {
+			for (const message of messages) send(message, options);
+		},
+		events: createEventBus(),
+	};
+	intercomHeavy(pi as never, {
+		captureInboundHandler: (handler) => {
+			inbound = handler;
+		},
+	});
+	const ctx = {
+		hasUI: true,
+		cwd: "/repo",
+		isIdle: () => idle,
+		ui: { notify() {} },
+		sessionManager: { getSessionId: () => sessionId, getBranch: () => [] },
+		...(closedStage
+			? {
+					orchestrationContext: {
+						kind: "workflow-stage",
+						messageAdmission: {
+							isOpen: () => false,
+							boundary: { ownsSubagentRun: (runId: string) => runId === "owned-run" },
+						},
+					},
+				}
+			: {}),
+	} as unknown as ExtensionContext;
+	const fire = async (name: string) => {
+		for (const handler of handlers.get(name) ?? []) await handler({ type: name }, ctx);
+	};
+	await fire("session_start");
+	return {
+		sent,
+		fire,
+		events: pi.events,
+		setSessionId(value: string) {
+			sessionId = value;
+		},
+		setDeliveryGate(value: Promise<void> | undefined) {
+			deliveryGate = value;
+		},
+		setIdle(value: boolean) {
+			idle = value;
+		},
+		setReject(value: boolean) {
+			rejectDelivery = value;
+		},
+		deliver: (message: Message) => inbound(ctx, sender, message),
+		close: () => fire("session_shutdown"),
+	};
+}
+
+test("a busy parent's correlated delivery refusal appears immediately, never as a later triggered turn", async () => {
+	vi.useFakeTimers();
+	const current = await fixture();
+	try {
+		const delivered = current.deliver(refusal);
+		await vi.advanceTimersByTimeAsync(60);
+		await delivered;
+		assert.equal(current.sent.length, 1, "refusal must not wait in the busy parent's idle queue");
+		assert.match(current.sent[0]!.content, /Intercom delivery failed/);
+		assert.match(current.sent[0]!.content, /1970-01-01T00:00:01.000Z/);
+		assert.notEqual(current.sent[0]!.options?.triggerTurn, true);
+		assert.equal(current.sent[0]!.options?.persistWhenStreaming, true);
+		await current.deliver(refusal);
+		current.setIdle(true);
+		await current.fire("agent_end");
+		await vi.advanceTimersByTimeAsync(2000);
+		assert.equal(current.sent.length, 1, "idle flush and duplicate receipt must not replay stale feedback");
+	} finally {
+		await current.close();
+	}
+});
+
+test("ordinary child messages retain their FIFO idle delivery rather than being discarded as status", async () => {
+	vi.useFakeTimers();
+	const current = await fixture();
+	try {
+		for (const id of ["first", "second"]) {
+			const pending = current.deliver({ id, timestamp: 1000, content: { text: id } });
+			await vi.advanceTimersByTimeAsync(60);
+			await pending;
+		}
+		assert.equal(current.sent.length, 0);
+		current.setIdle(true);
+		await current.fire("agent_end");
+		await vi.advanceTimersByTimeAsync(2000);
+		assert.equal(current.sent.length, 2);
+		assert.match(current.sent[0]!.content, /first/);
+		assert.match(current.sent[1]!.content, /second/);
+	} finally {
+		await current.close();
+	}
+});
+
+test("feedback retries transient display admission with one stable identity", async () => {
+	vi.useFakeTimers();
+	const current = await fixture();
+	try {
+		current.setReject(true);
+		const pending = current.deliver(refusal);
+		await vi.advanceTimersByTimeAsync(250);
+		assert.equal(current.sent.length, 0);
+		current.setReject(false);
+		await vi.advanceTimersByTimeAsync(100);
+		await pending;
+		assert.equal(current.sent.length, 1);
+		assert.equal(current.sent[0]!.options?.stageAdmissionKey, `intercom:${refusal.id}`);
+		await current.deliver(refusal);
+		assert.equal(current.sent.length, 1);
+	} finally {
+		await current.close();
+	}
+});
+
+test("idle delivery feedback does not start a new agent turn", async () => {
+	const current = await fixture();
+	try {
+		current.setIdle(true);
+		await current.deliver(refusal);
+		assert.equal(current.sent.length, 1);
+		assert.notEqual(current.sent[0]!.options?.triggerTurn, true);
+	} finally {
+		await current.close();
+	}
+});
+
+test("completion prelude cannot continue or roll back into a replacement parent session", async () => {
+	vi.useFakeTimers();
+	const current = await fixture();
+	const gate = Promise.withResolvers<void>();
+	try {
+		for (const id of ["old-first", "old-second"]) {
+			const pending = current.deliver({ id, timestamp: 1, content: { text: id } });
+			await vi.advanceTimersByTimeAsync(60);
+			await pending;
+		}
+		current.setDeliveryGate(gate.promise);
+		const ordering = flushTaskCompletionMessages(
+			current.events,
+			{ runId: "child-run", intercomTarget: sender.name! },
+			"old-completion",
+		);
+		const rejected = assert.rejects(ordering, /retired/);
+		assert.equal(current.sent.length, 1);
+		current.setSessionId("replacement-parent");
+		await current.fire("session_start");
+		current.setDeliveryGate(undefined);
+		const fresh = current.deliver({ id: "fresh", timestamp: 2, content: { text: "new-owner-message" } });
+		await vi.advanceTimersByTimeAsync(60);
+		await fresh;
+		gate.resolve();
+		await rejected;
+		current.setIdle(true);
+		await current.fire("agent_end");
+		await vi.advanceTimersByTimeAsync(1000);
+		assert.equal(current.sent.length, 2);
+		assert.match(current.sent[0]!.content, /old-first/);
+		assert.match(current.sent[1]!.content, /new-owner-message/);
+	} finally {
+		gate.resolve();
+		await current.close();
+	}
+});
+
+test("closed stages keep non-owned refusals as feedback and suppress their own retired child traffic", async () => {
+	const current = await fixture(true);
+	try {
+		await current.deliver({ ...refusal, id: "owned-refusal", source: { subagentRunId: "owned-run" } });
+		assert.equal(current.sent.length, 0);
+		await current.deliver({ ...refusal, source: { subagentRunId: "external-run" } });
+		assert.equal(current.sent.length, 1);
+		assert.match(current.sent[0]!.content, /Intercom delivery failed/);
+		assert.match(current.sent[0]!.content, /1970-01-01T00:00:01.000Z/);
+		assert.notEqual(current.sent[0]!.options?.triggerTurn, true);
+		await current.deliver({ ...refusal, source: { subagentRunId: "external-run" } });
+		assert.equal(current.sent.length, 1);
+	} finally {
+		await current.close();
+	}
+});


### PR DESCRIPTION
## Summary

Fix the delayed subagent notice observed while working on #2916, which is already merged. Automatic busy-recipient refusals no longer wait for the parent to become idle and appear as stale "still working" messages after the child has completed.

## Changes

- Mark busy headless refusals as correlated delivery errors. A waiting ask receives its exact error; otherwise the sender receives timestamped delivery feedback without a standalone triggered turn.
- Include owner-bound task completions in same-child Intercom ordering. The completion outbox drains queued child messages before publishing the terminal notification, using trusted run and actual Intercom-target metadata rather than task or SDK session IDs.
- Keep earlier-message admission keys separate from the terminal completion ID. Failed message/terminal delivery remains retryable without changing a successful task result, replaying successful earlier messages, or relaunching execution.
- Rescan for newly queued child messages when terminal publication retries.
- Bind queued-message claims to their parent generation. Replacement sessions cannot receive the remainder of an old claim or have old messages restored by rollback.
- Preserve closed-stage child suppression and exact ask correlation while keeping non-owned delivery errors as non-triggering feedback.
- Update user-facing Intercom docs and relevant Unreleased changelogs. No native or persisted task schema changes.

## Validation

Tested head: `119d3c1381baf1cf8052c0d83b18a71b0d79a465`.

- `npm run check` passed, including Biome, root/package typechecks, type tests, and shrinkwrap verification.
- `npm run build` passed, including copied builtin extension bundling.
- 162 focused tests passed: 124 root unit, 20 integration, and 18 coding-agent tests covering protected message delivery.
- New regressions reproduce the original busy-parent delay, parent replacement during asynchronous delivery, closed-stage error routing, failed terminal publication with newly queued messages, restoration after a persisted earlier message, and exact trusted-source binding.
- Read-only reviews identified owner-lifetime, copied-package, and closed-stage issues; these were fixed and regression-tested. Final focused review approved the refinements.
- Supplemental `qlty smells` reported no findings in the new completion-ordering and incoming-message-delivery helpers.
- Mandatory commit hooks run normally. GitHub CI is separate from these local results; this PR is not merged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791429539&installation_model_id=10562&pr_number=2917&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2917&signature=137b4af0aba2625567bf33866f974b64a60a40c98fb2422d6c26e13a2b7040d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR revises Intercom refusal handling and owner-bound task completion ordering so busy-recipient errors surface promptly and queued same-child messages precede terminal notifications.

- Adds correlated, non-triggering delivery feedback for busy non-interactive recipients.
- Connects owner-bound task completion to Intercom’s terminal-ordering barrier using trusted run and target metadata.
- Adds generation-bound queue claims and retry-safe completion publication.
- Expands regression coverage and user-facing documentation.
- One closed-stage ordering issue remains: owned-source suppression can discard an exact correlated refusal before it settles the pending ask.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until closed-stage owned-child refusals settle their exact pending asks before ordinary owned-run traffic is suppressed.

The new suppression order can drop a correlated busy refusal from a directly owned child after stage closure, leaving the matching ask pending until timeout; the remaining completion-ordering and lifecycle changes are supported by consistent identities and focused regression coverage.

**Files Needing Attention:** packages/intercom/closed-workflow-stage-message.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/intercom/closed-workflow-stage-message.ts | Extends closed-stage delivery-feedback handling, but owned-run suppression precedes and can bypass exact waiter correlation. |
| packages/intercom/index-heavy.ts | Converts busy non-interactive auto-responses into correlated, non-triggering delivery feedback. |
| packages/intercom/terminal-ordering-barrier.ts | Adds owner-task ordering, retry rescans, and generation-safe prelude claims. |
| packages/intercom/inbound-idle-queue.ts | Binds queue claims and rollback behavior to the lifecycle generation. |
| packages/coding-agent/src/core/agent-session-tasks.ts | Flushes trusted same-child Intercom messages before owner-bound completion admission. |
| packages/subagents/src/runs/foreground/task-execution.ts | Attaches trusted subagent run and actual Intercom target metadata to task transcript sources. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant P as Parent workflow stage
  participant C as Owned child
  participant I as Intercom router
  P->>C: ask(messageId)
  Note over P: Stage closes while waiter remains pending
  C-->>I: "busy refusal(replyTo=messageId, source=ownedRun)"
  I->>I: Owned-run suppression
  Note over I: Returns before exact reply routing
  Note over P: Ask remains pending until timeout
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/intercom/closed-workflow-stage-message.ts:28-29
**Owned refusals are discarded**

When a workflow stage closes while an ask to one of its directly owned children is still pending, the child’s busy-recipient refusal carries its owned run ID. This check discards that refusal before exact reply routing can settle the matching ask, so the ask waits until timeout instead of immediately receiving the correlated delivery error.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(intercom): prevent stale subagent no..."](https://github.com/bastani-inc/atomic/commit/119d3c1381baf1cf8052c0d83b18a71b0d79a465) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61445553)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Intercom messaging](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/intercom-messaging.md)
- Knowledge Base — [Intercom delivery and replies](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/intercom-delivery-and-replies.md)
- Knowledge Base — [Subagent discovery and execution](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/subagent-discovery-and-execution.md)
</details>


<!-- /greptile_comment -->