### PR TITLE
feat(tasks): add inline picker, model labels, and live transcripts

### DIFF
--- a/crates/atomic-natives/src/task_supervisor/process.rs
+++ b/crates/atomic-natives/src/task_supervisor/process.rs
@@ -278,6 +278,8 @@ impl Actor {
 					intent.command.first_nonblank_line().unwrap_or_else(|| intent.command.clone())
 				}),
 			agent_name: None,
+			model: None,
+			thinking: None,
 			execution: Execution::Queued {},
 			observation: HostObservation::Background { reason: "not-observed".into() },
 			was_background: None,

--- a/crates/atomic-natives/src/task_supervisor/report_identity.rs
+++ b/crates/atomic-natives/src/task_supervisor/report_identity.rs
@@ -24,6 +24,7 @@ pub(super) fn activity_hash(report: &ActivityReport) -> [u8; 32] {
 	std::mem::discriminant(&report.change).hash(&mut hash);
 	match &report.change {
 		ActivityChange::Action { tool, text } => (tool, text).hash(&mut hash),
+		ActivityChange::Model { model, thinking } => (model, thinking).hash(&mut hash),
 		ActivityChange::Metrics { elapsed_ms, tool_count, token_count } => {
 			(
 				elapsed_ms.map(f64::to_bits),

--- a/crates/atomic-natives/src/task_supervisor/task.rs
+++ b/crates/atomic-natives/src/task_supervisor/task.rs
@@ -246,6 +246,10 @@ pub struct TaskRecord {
 	pub title: JsString,
 	#[napi(ts_type = "string")]
 	pub agent_name: Option<JsString>,
+	#[napi(ts_type = "string")]
+	pub model: Option<JsString>,
+	#[napi(ts_type = "string")]
+	pub thinking: Option<JsString>,
 	pub execution: Execution,
 	pub observation: HostObservation,
 	/// True after a designated observation yields; retained after settlement and snapshot resets.
@@ -264,6 +268,12 @@ pub enum ActivityChange {
 		tool: JsString,
 		#[napi(ts_type = "string")]
 		text: JsString,
+	},
+	Model {
+		#[napi(ts_type = "string")]
+		model: Option<JsString>,
+		#[napi(ts_type = "string")]
+		thinking: Option<JsString>,
 	},
 	Metrics {
 		elapsed_ms: Option<f64>,
@@ -290,6 +300,10 @@ impl PartialEq for ActivityChange {
 			(Self::Action { tool, text }, Self::Action { tool: other_tool, text: other_text }) => {
 				tool == other_tool && text == other_text
 			},
+			(
+				Self::Model { model, thinking },
+				Self::Model { model: other_model, thinking: other_thinking },
+			) => model == other_model && thinking == other_thinking,
 			(
 				Self::Metrics { elapsed_ms, tool_count, token_count },
 				Self::Metrics {
@@ -447,6 +461,8 @@ impl Actor {
 			kind: "agent".into(),
 			title,
 			agent_name: Some(intent.agent.clone()),
+			model: None,
+			thinking: None,
 			execution: Execution::Queued {},
 			observation: HostObservation::Background { reason: "not-observed".into() },
 			was_background: None,
@@ -532,6 +548,10 @@ impl Actor {
 				if matches!(t.record.attention, Attention::NoRecentActivity { .. }) {
 					t.record.attention = Attention::None {};
 				}
+			},
+			ActivityChange::Model { model, thinking } => {
+				t.record.model = model.clone();
+				t.record.thinking = thinking.clone();
 			},
 			ActivityChange::Metrics { elapsed_ms, tool_count, token_count } => {
 				let m = t.record.metrics.get_or_insert_default();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,12 +20,15 @@
 
 ### Changed
 
+- `/tasks` now opens as a compact inline picker like `/workflow connect`, with fullscreen detail, transcript, input, and confirmation pages. Returning from detail preserves selection.
+- Foreground and background subagent rows, task lists, and completion cards now display resolved model and reasoning settings, retaining them after completion.
 - `/tasks` in an attached stage chat is now a local inspection command, never a model message, including while an Escape interruption settles. Hosts without a task inspector report that it is unavailable.
 - Task lists and subagent detail views now use grouped counts, semantic status styling, pinned status/metrics/actions, recent tool activity, bounded response and shell-output previews, and narrow-terminal layouts. Finished tasks remain discoverable through `/tasks`; background bash receipts distinguish observation time from execution completion.
 - Default guidance now routes all user questions, including confirmations and approvals, through `ask_user_question` or an equivalent available question tool rather than prose-only prompts. Sessions without a usable question tool continue autonomously using best judgment.
 
 ### Fixed
 
+- Open subagent transcripts now refresh from live session events, including streaming text and partial/final tool results. Shell transcript reads coalesce pending state updates instead of requiring the view to be reopened.
 - Discarded stale command detail results and read errors after task selection, focus, or inspector lifetime changes, preventing another task's output from appearing in the current view ([#2908](https://github.com/bastani-inc/atomic/pull/2908)).
 - Connected isolated interactive sessions to the engine's compact background-task indicator below the prompt box and command-opened `/tasks` inspector instead of opening an empty host-local task owner. Added `/tasks` autocomplete and live subagent activity, tool/token counts, and response previews inside task details.
 - Connected top-level POSIX model bash executions to their task owner so long-running shells appear in task inspection after their observation yields. Preserved cleared session environment variables in the supervised shell path; native Windows and child-agent bash retain their existing execution path.

--- a/packages/coding-agent/docs/background-tasks.md
+++ b/packages/coding-agent/docs/background-tasks.md
@@ -15,7 +15,7 @@ Tasks  2 local agents running · 1 queued · /tasks
 
 It summarizes only active background agents and shells, including queued work, stopping tasks, and tasks needing attention. Completed, failed, and stopped tasks leave the footer immediately; when no background work is active, the indicator disappears. Results and failure details remain in completion cards and `/tasks`, so an old failure cannot keep the live indicator red. Running tasks do not expire merely because they are quiet.
 
-Run `/tasks` to open the background-only list. The command also appears in workflow-stage slash suggestions, including when skill commands are disabled. Foreground-only commands do not appear. Work that ran in the background stays available after completion or a later foreground wait. Updates never open the list automatically. Closing the inspector does not stop the tasks.
+Run `/tasks` to open a compact inline picker in the editor slot, like `/workflow connect`, with the conversation still visible above it. Detail, transcript, input, and cancellation-confirmation pages use the full screen. Escape returns to the picker with the selected task preserved, then to chat. The command also appears in workflow-stage slash suggestions, including when skill commands are disabled. Foreground-only commands do not appear. Work that ran in the background stays available after completion or a later foreground wait. Updates never open the list automatically. Closing the inspector does not stop the tasks.
 
 Opening `/tasks` is navigation, not an approval request. It does not mark the agent blocked in Herdr. The inspector stays open until you close it, even when its tasks finish; task history is not deleted when the compact indicator disappears.
 
@@ -121,7 +121,11 @@ Configured task bindings take precedence over the default Left, page, and `x` sh
 
 The list groups **Agents** and **Shells**, with counts and status symbols. Detail views pin identity, state, available metrics, and the selected action while their body scrolls. Missing metrics are omitted rather than displayed as zero. Recorded zero values remain visible.
 
+Agent rows and completion cards show the resolved model and reasoning setting, for example `openai-codex/gpt-6-astra · thinking medium`. These settings update on fallback and remain after completion. Foreground results retain the same metadata. Missing settings are not inferred from token counts; early launch receipts may not yet have a resolved model.
+
 Agent details include recent retained tool activity, the prompt, a latest-response preview, and error or attention information. Transcript inspection uses a dedicated scrolling view with a pinned title, line position, and controls, rather than nesting full chat components inside a detail box. It renders retained messages and tool results without hidden reasoning or inline images. Earlier pages do not jump back to the latest page when background activity arrives.
+
+An open live transcript updates directly from the child's session events, including streaming assistant text and partial/final tool results. Shell output refreshes on task state updates, including updates received during an earlier output read. You do not need to leave and reopen the transcript. Reading earlier retained pages keeps your position while the live tail continues updating.
 
 Shell details show the command, available exit information, and a bounded output tail. The preview shows up to ten wrapped lines from the retained 8 KiB tail. Output gaps and omitted earlier content are labelled. An empty output stream says **No output available**. Shell transcript inspection exposes the retained tail, not an invented agent conversation or an unlimited log viewer.
 

--- a/packages/coding-agent/docs/subagents.md
+++ b/packages/coding-agent/docs/subagents.md
@@ -23,9 +23,13 @@ Hosts with an owner task store expose `/tasks` and `/tasks <id>` for background 
 
 `/tasks` appears in slash-command autocomplete. The inspector groups agents and shells with counts, status symbols, and a highlighted selection. Task descriptions lead; the selected row shows secondary activity and tool counts. The header and footer remain visible in ordinary terminal sizes, with a compact fallback for short terminals.
 
+The list opens as a compact inline widget, like the `/workflow connect` picker. Detail, transcript, input, and stop-confirmation pages are fullscreen; returning to the list preserves selection. Every agent row includes its resolved model and reasoning level when available, including completed background tasks.
+
 In the default isolated CLI, background subagents continue running after their launch observation returns. The engine publishes a compact task-status indicator below the prompt box, without task rows or activity previews. Run `/tasks` to open the list and inspect individual tasks; task updates never open it automatically. A compact finished-task summary remains after completion. Inspecting does not restart work or create a second task owner. Top-level model bash commands use this owner on POSIX systems; native Windows and commands inside subagent sessions retain their existing execution path.
 
 Transcript inspection uses a dedicated scrolling view with pinned identity, position, and controls. Retained child messages use the normal message renderers, excluding hidden reasoning and inline images. Missing capture is reported as `Transcript unavailable`; metrics never substitute for missing messages. Arrows scroll, PageUp/PageDown moves one viewport, and PageUp at the top loads earlier retained history. Home/End jumps within loaded history.
+
+Open live transcripts subscribe to child-session events, so streaming text and partial/final tool results refresh without reopening the page or waiting for a task-activity counter. Earlier pages remain anchored while updates arrive. Leaving the transcript releases its subscription without affecting execution.
 
 Detail views pin task identity, state, available metrics, and the selected action while PageUp/PageDown scrolls the body. Recent activity shows up to five retained tool actions; errors and input requests appear explicitly. Left returns to the previous view. `x` requests cancellation without bypassing confirmation or configured task bindings. Shell inspection shows a bounded output tail with omission markers.
 
@@ -167,6 +171,8 @@ Inside workflow stages, completion delivery observes the stage generation bounda
 Cancellation does not retract an Intercom send already submitted to the broker. That operation keeps its transport receipt or retry identity, while the closed stage suppresses late incoming messages from its own children. A transport acknowledgement does not mean a late finding was shown in the parent chat.
 
 Live progress and completed results show each step's resolved model ID and effective reasoning level, including after a model fallback; parallel steps keep their metadata separate. Fast inference is part of the model ID, so an agent pinned to a fast variant renders it directly — `codebase-analyzer (openai-codex/gpt-5.6-sol-fast · thinking medium)` — with no separate `fast` badge. Select fast inference in an agent definition's `model` and fallback model fields, for example `openai-codex/gpt-5.6-sol-fast:medium`; normal and fast IDs stay distinct fallback candidates and distinct records. See [Providers](/providers#fast-models) for which providers publish fast variants and what each one sends upstream.
+
+Owner-task rows, status cards, foreground result receipts, and background completion cards retain these settings too. A launch receipt is a snapshot and can precede model resolution; inspect `/tasks` for current settings. Missing model or reasoning data is shown as unavailable rather than guessed. Completion metadata is persisted with the notification so it remains visible when replaying chat history.
 
 ## Owner-bound task projection
 

--- a/packages/coding-agent/src/core/tasks/completion.ts
+++ b/packages/coding-agent/src/core/tasks/completion.ts
@@ -17,11 +17,13 @@ export type TaskCompletionNotice = {
 	preview: string;
 	status: "completed" | "failed" | "cancelled";
 	taskId: string;
+	model?: string;
+	thinking?: string;
 };
 
 export function taskCompletionNotice(
 	envelope: TaskCompletionEnvelope,
-	task?: Pick<TaskRecord, "kind" | "title" | "agentName">,
+	task?: Pick<TaskRecord, "kind" | "title" | "agentName" | "model" | "thinking">,
 	output?: string,
 ): TaskCompletionNotice {
 	const exitCode =
@@ -35,6 +37,8 @@ export function taskCompletionNotice(
 			.slice(0, 8000),
 		status: taskOutcomeStatus(envelope.result, task?.kind),
 		taskId: envelope.taskId,
+		...(task?.kind === "agent" && task.model !== undefined ? { model: task.model } : {}),
+		...(task?.kind === "agent" && task.thinking !== undefined ? { thinking: task.thinking } : {}),
 	};
 }
 

--- a/packages/coding-agent/src/core/tasks/contracts.ts
+++ b/packages/coding-agent/src/core/tasks/contracts.ts
@@ -126,6 +126,9 @@ export type TaskRecord = {
 	kind: "agent" | "command";
 	title: string;
 	agentName?: string;
+	/** Resolved execution settings, retained after completion. */
+	model?: string;
+	thinking?: string;
 	execution: Execution;
 	observation: HostObservation;
 	/** Retained native background membership, independent of the current wait. */
@@ -145,6 +148,7 @@ export type ActivityReport = {
 	reportId: string;
 	change:
 		| { kind: "action"; tool: string; text: string }
+		| { kind: "model"; model?: string; thinking?: string }
 		| { kind: "metrics"; elapsedMs?: number; toolCount?: number; tokenCount?: number }
 		| { kind: "output"; offset: string; bytesBase64: string }
 		| { kind: "attention-set"; attention: Exclude<Attention, { kind: "none" }> }

--- a/packages/coding-agent/src/core/tasks/supervisor.ts
+++ b/packages/coding-agent/src/core/tasks/supervisor.ts
@@ -1,6 +1,8 @@
 import { AsyncResource } from "node:async_hooks";
 import type * as native from "@bastani/atomic-natives";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { createModuleRequire } from "../../utils/module-require.ts";
+import type { AgentSessionEvent } from "../agent-session.js";
 import type { SessionManager } from "../session-manager.ts";
 import { COMMAND_FOREGROUND_BUDGET_MS } from "./command-output.js";
 import type { TaskCompletionSource } from "./completion-ordering.js";
@@ -8,6 +10,9 @@ import type * as C from "./contracts.js";
 
 export type TaskTranscriptSource = Pick<SessionManager, "getSessionId" | "getEntries"> & {
 	readonly completionSource?: TaskCompletionSource;
+	/** Viewer-only subscription; updates never publish task lifecycle events. */
+	subscribe?(listener: (event: AgentSessionEvent) => void): () => void;
+	getStreamingMessage?(): AgentMessage | undefined;
 };
 
 export const DEFAULT_AGENT_WAIT_BUDGET_MS = 30000;
@@ -212,6 +217,8 @@ function record(value: native.TaskRecord): C.TaskRecord {
 		kind: value.kind,
 		title: value.title,
 		...(value.agentName === undefined ? {} : { agentName: value.agentName }),
+		...(value.model === undefined ? {} : { model: value.model }),
+		...(value.thinking === undefined ? {} : { thinking: value.thinking }),
 		execution: execution(value.execution),
 		observation: observation(value.observation),
 		...(value.wasBackground === undefined ? {} : { wasBackground: value.wasBackground }),
@@ -367,6 +374,10 @@ function applyEvent(current: C.OwnerSnapshot, value: C.NativeEvent): C.OwnerSnap
 				case "action":
 					task.currentAction = { tool: activity.tool, text: activity.text };
 					if (task.attention.kind === "no-recent-activity") task.attention = { kind: "none" };
+					break;
+				case "model":
+					task.model = activity.model;
+					task.thinking = activity.thinking;
 					break;
 				case "metrics":
 					task.metrics = {

--- a/packages/coding-agent/src/core/tasks/transcript.ts
+++ b/packages/coding-agent/src/core/tasks/transcript.ts
@@ -21,6 +21,14 @@ export async function readTaskTranscript(
 	task: TaskLease,
 	cursor?: string,
 ): Promise<Result<TaskTranscriptPage, Failure<TranscriptError>>> {
+	return readTaskTranscriptSnapshot(task, cursor);
+}
+
+/** Synchronous history read lets an in-process viewer subscribe without an await gap. */
+export function readTaskTranscriptSnapshot(
+	task: TaskLease,
+	cursor?: string,
+): Result<TaskTranscriptPage, Failure<TranscriptError>> {
 	const bound = taskTranscriptSource(task);
 	if (!bound.ok) return bound;
 	const { session, taskId } = bound.value;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -5,6 +5,10 @@ export { type AdmittedAgentTask, collectAgentTasks } from "./core/tasks/executio
 export { bindOwnerTaskStore, getOwnerTaskStore, OwnerTaskStore } from "./core/tasks/owner-store.js";
 export { renderTaskFooter, TaskList, taskListSections } from "./modes/interactive/components/task-list.js";
 export { TaskRow } from "./modes/interactive/components/task-row.js";
+export {
+	applyAssistantMessageDelta,
+	beginStreamingAssistantMessage,
+} from "./modes/interactive/streaming-assistant-message.ts";
 // Core session management
 
 export { type Args, parseArgs } from "./cli/args.ts";

--- a/packages/coding-agent/src/modes/interactive/components/chat-session-host.ts
+++ b/packages/coding-agent/src/modes/interactive/components/chat-session-host.ts
@@ -232,7 +232,13 @@ export class ChatSessionHost<TExtraEntry extends ChatTranscriptEntryLike = never
 	}
 
 	renderBody(width: number, budget: number): string[] {
-		if (this.taskInspector) return this.taskInspector.renderViewport(width, budget);
+		if (this.taskInspector) {
+			if (this.taskInspector.fullscreen) return this.taskInspector.renderViewport(width, budget);
+			const picker = this.taskInspector.renderPicker(width, budget);
+			const remaining = Math.max(0, budget - picker.length);
+			const body = remaining ? renderChatSessionBody(this.state, width, remaining) : [];
+			return [...body, ...Array.from({ length: Math.max(0, remaining - body.length) }, () => ""), ...picker];
+		}
 		return renderChatSessionBody(this.state, width, budget);
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/task-completion-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/task-completion-message.ts
@@ -3,6 +3,7 @@ import { Box, type Component, truncateToWidth, wrapTextWithAnsi } from "@earendi
 import type { TaskCompletionNotice } from "../../../core/tasks/completion.js";
 import { theme } from "../theme/theme.js";
 import { keyHintIfBound } from "./keybinding-hints.js";
+import { taskModelText } from "./task-row.js";
 
 export function completionNoticeFromDetails(details: unknown): TaskCompletionNotice | undefined {
 	if (!details || typeof details !== "object" || !("notification" in details)) return undefined;
@@ -19,7 +20,14 @@ export function completionNoticeFromDetails(details: unknown): TaskCompletionNot
 	)
 		return undefined;
 	if (notice.status !== "completed" && notice.status !== "failed" && notice.status !== "cancelled") return undefined;
-	return { title: notice.title, preview: notice.preview, taskId: notice.taskId, status: notice.status };
+	return {
+		title: notice.title,
+		preview: notice.preview,
+		taskId: notice.taskId,
+		status: notice.status,
+		...("model" in notice && typeof notice.model === "string" ? { model: notice.model } : {}),
+		...("thinking" in notice && typeof notice.thinking === "string" ? { thinking: notice.thinking } : {}),
+	};
 }
 
 /** Same persisted completion message in main and workflow chats; no model reply required. */
@@ -50,6 +58,15 @@ export class TaskCompletionMessage implements Component {
 		const expand = !this.expanded && preview.length > limit ? keyHintIfBound("app.tools.expand", "Expand") : "";
 		return [
 			theme.fg(color, theme.bold(`${icon} ${clean(this.notice.title).replace(/\n/g, " ")}`)),
+			...(this.notice.model !== undefined || this.notice.thinking !== undefined
+				? wrapTextWithAnsi(
+						theme.fg(
+							"dim",
+							taskModelText({ kind: "agent", model: this.notice.model, thinking: this.notice.thinking }),
+						),
+						Math.max(1, width),
+					)
+				: []),
 			...(this.notice.preview ? preview.slice(0, limit).map((line) => theme.fg("muted", `  ${line}`)) : []),
 			theme.fg(
 				"dim",

--- a/packages/coding-agent/src/modes/interactive/components/task-detail.ts
+++ b/packages/coding-agent/src/modes/interactive/components/task-detail.ts
@@ -4,7 +4,7 @@ import type { Attention, Execution, TaskRecord } from "../../../core/tasks/contr
 import type { TaskActivity } from "../../../core/tasks/owner-store.js";
 import { theme } from "../theme/theme.js";
 import { keyHintIfBound } from "./keybinding-hints.js";
-import { taskDisplayText, taskMetricsText, taskStatusAppearance } from "./task-row.js";
+import { taskDisplayText, taskMetricsText, taskModelText, taskStatusAppearance } from "./task-row.js";
 
 export type TaskDetailAction = "transcript" | "foreground" | "cancel" | "input" | "question";
 
@@ -93,6 +93,8 @@ export class TaskDetail implements Component {
 	renderContent(width: number): string[] {
 		const task = this.task;
 		const lines: string[] = [];
+		if (task.kind === "agent")
+			lines.push(...wrapTextWithAnsi(theme.fg("dim", taskModelText(task)), Math.max(1, width)));
 		const section = (label: string, text: string, limit: number, tail = false) => {
 			const wrapped = wrapTextWithAnsi(displayMultiline(text), Math.max(1, width));
 			lines.push(

--- a/packages/coding-agent/src/modes/interactive/components/task-inspector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/task-inspector.ts
@@ -15,7 +15,7 @@ import { taskOutputText } from "../../../core/tasks/command-output.js";
 import type { OperationId, PromptRoute, TaskId } from "../../../core/tasks/contracts.js";
 import type { OwnerTaskStore } from "../../../core/tasks/owner-store.js";
 import { taskTranscriptSource } from "../../../core/tasks/supervisor.js";
-import { readTaskTranscript } from "../../../core/tasks/transcript.js";
+import { readTaskTranscriptSnapshot } from "../../../core/tasks/transcript.js";
 import { theme } from "../theme/theme.js";
 import { chatEntriesFromAgentMessages, renderChatMessageEntry } from "./chat-message-renderer.ts";
 import { mouseWheelDeltaRows } from "./chat-transcript.js";
@@ -28,8 +28,9 @@ import {
 	taskDetailSummary,
 } from "./task-detail.js";
 import { taskListSections } from "./task-list.js";
+import { TaskLiveTranscript } from "./task-live-transcript.js";
 import { TaskNavigation } from "./task-navigation.js";
-import { taskDisplayText, taskLabel, taskMetricsText, taskStatusAppearance } from "./task-row.js";
+import { taskDisplayText, taskLabel, taskMetricsText, taskModelText, taskStatusAppearance } from "./task-row.js";
 
 /** Focused view only. The store and original session remain the authorities. */
 export class TaskInspector implements Component {
@@ -37,6 +38,8 @@ export class TaskInspector implements Component {
 	private actionIndex = 0;
 	private confirmation?: (answer: boolean) => void;
 	private transcript?: Component[];
+	private liveTranscript?: TaskLiveTranscript;
+	private transcriptRefreshPending = false;
 	private transcriptRequested = false;
 	private transcriptLoading = false;
 	private transcriptHistorical = false;
@@ -61,6 +64,7 @@ export class TaskInspector implements Component {
 		this.close = privateClose;
 		this.navigation = new TaskNavigation(getKeybindings() as KeybindingsManager, {
 			inspect: () => {
+				this.releaseLiveTranscript();
 				this.actionIndex = 0;
 				this.scroll = 0;
 				this.transcript = undefined;
@@ -108,7 +112,7 @@ export class TaskInspector implements Component {
 		this.unsubscribe = this.store.subscribe(() => {
 			this.navigation.update(this.store.backgroundTasks);
 			if (this.transcriptRequested) {
-				if (!this.transcriptLoading && !this.transcriptHistorical && this.scroll === 0) void this.loadTranscript();
+				this.refreshTranscript();
 			} else if (this.navigation.focus.kind === "detail") void this.loadDetail();
 			this.requestRender();
 		});
@@ -126,6 +130,7 @@ export class TaskInspector implements Component {
 	}
 	dispose(): void {
 		this.disposed = true;
+		this.releaseLiveTranscript();
 		this.confirmation?.(false);
 		this.unsubscribe();
 	}
@@ -158,6 +163,22 @@ export class TaskInspector implements Component {
 		this.status = result.ok ? `Sent ${result.value.acceptedBytes} bytes` : result.error.message;
 		this.input.setValue("");
 		this.requestRender();
+	}
+	private releaseLiveTranscript(): void {
+		this.liveTranscript?.dispose();
+		this.liveTranscript = undefined;
+		this.transcriptRefreshPending = false;
+	}
+	private refreshTranscript(): void {
+		if (this.disposed || !this.transcriptRequested) return;
+		const task = this.selected();
+		const lease = task && this.store.resolveTask(task.ref.taskId);
+		const bound = lease?.ok ? taskTranscriptSource(lease.value) : undefined;
+		if (bound?.ok && this.liveTranscript?.source === bound.value.session) return;
+		// Legacy history-only sources have no live tail; keep their retained page anchored.
+		if (bound?.ok && !bound.value.session.subscribe && this.transcriptHistorical) return;
+		if (this.transcriptLoading) this.transcriptRefreshPending = true;
+		else void this.loadTranscript();
 	}
 	private async loadTranscript(earlier = false): Promise<void> {
 		const task = this.selected();
@@ -197,7 +218,7 @@ export class TaskInspector implements Component {
 				this.requestRender();
 				return;
 			}
-			const page = await readTaskTranscript(lease.value, earlier ? this.cursor : undefined);
+			const page = readTaskTranscriptSnapshot(lease.value, earlier ? this.cursor : undefined);
 			if (
 				this.disposed ||
 				generation !== this.detailGeneration ||
@@ -206,12 +227,12 @@ export class TaskInspector implements Component {
 			)
 				return;
 			const bound = taskTranscriptSource(lease.value);
-			if (!page.ok || !bound.ok) {
+			if (!bound.ok || (!page.ok && !bound.value.session.subscribe)) {
 				this.status = "Transcript unavailable";
 				this.requestRender();
 				return;
 			}
-			const ids = new Set(page.value.items.map((item) => item.source.entryId));
+			const ids = new Set(page.ok ? page.value.items.map((item) => item.source.entryId) : []);
 			const messages = bound.value.session.getEntries().flatMap<AgentMessage>((entry) => {
 				if (entry.type !== "message" || !ids.has(entry.id)) return [];
 				const message = entry.message;
@@ -222,6 +243,7 @@ export class TaskInspector implements Component {
 							content: message.content.filter(
 								(block, index) =>
 									block.type !== "thinking" &&
+									page.ok &&
 									page.value.items.some(
 										(item) => item.source.entryId === entry.id && item.source.contentIndex === index,
 									),
@@ -239,8 +261,12 @@ export class TaskInspector implements Component {
 					showImages: false,
 				}),
 			);
-			this.transcript = earlier ? [...components, ...(this.transcript ?? [])] : components;
-			this.cursor = page.value.nextCursor;
+			if (!earlier && bound.value.session.subscribe) {
+				this.releaseLiveTranscript();
+				this.liveTranscript = new TaskLiveTranscript(bound.value.session, messages, this.requestRender);
+				this.transcript = [this.liveTranscript];
+			} else this.transcript = earlier ? [...components, ...(this.transcript ?? [])] : components;
+			this.cursor = page.ok ? page.value.nextCursor : undefined;
 			this.status = this.cursor ? "PageUp: earlier retained messages" : "";
 			this.requestRender();
 		} catch {
@@ -250,7 +276,13 @@ export class TaskInspector implements Component {
 				this.requestRender();
 			}
 		} finally {
-			if (generation === this.detailGeneration) this.transcriptLoading = false;
+			if (generation === this.detailGeneration) {
+				this.transcriptLoading = false;
+				if (this.transcriptRefreshPending) {
+					this.transcriptRefreshPending = false;
+					this.refreshTranscript();
+				}
+			}
 		}
 	}
 	private async loadDetail(): Promise<void> {
@@ -343,6 +375,7 @@ export class TaskInspector implements Component {
 			(matchesKey(data, "left") && this.navigation.focus.kind !== "stdin" && !this.configuredTaskKey(data))
 		) {
 			if (this.transcriptRequested) {
+				this.releaseLiveTranscript();
 				this.detailGeneration++;
 				this.transcript = undefined;
 				this.transcriptRequested = false;
@@ -408,6 +441,17 @@ export class TaskInspector implements Component {
 			(key) => getKeybindings().matches(data, key),
 		);
 	}
+	/** Only the task picker stays inline; drill-down and confirmation own the screen. */
+	get fullscreen(): boolean {
+		return (
+			this.confirmation !== undefined ||
+			this.navigation.focus.kind === "detail" ||
+			this.navigation.focus.kind === "stdin"
+		);
+	}
+	renderPicker(width: number, availableRows: number): string[] {
+		return this.renderViewport(width, Math.max(1, Math.min(12, availableRows)));
+	}
 	render(width: number): string[] {
 		return this.renderViewport(width, Math.max(3, (process.stdout.rows || 24) - 5));
 	}
@@ -464,7 +508,8 @@ export class TaskInspector implements Component {
 		const height = Math.max(0, budget - (framed ? 4 : 1) - actionRow.length - compactSummary.length);
 		const selected = detail ? -1 : rows.findIndex((row) => stripVTControlCharacters(row).startsWith("›"));
 		this.scroll = Math.min(this.scroll, Math.max(0, rows.length - height));
-		const offset = detail ? this.scroll : Math.max(0, selected - height + 1);
+		const selectionRows = Math.min(height, current?.kind === "agent" ? 3 : 2);
+		const offset = detail ? this.scroll : Math.max(0, selected + selectionRows - height);
 		const view = rows.slice(offset, offset + height);
 		const inspect = keyHintIfBound("app.tasks.inspect", detail ? "select" : "view");
 		const hints = this.confirmation
@@ -560,6 +605,7 @@ export class TaskInspector implements Component {
 					.join(" · ");
 				return [
 					truncateToWidth(row, width),
+					...(item.kind === "agent" ? [theme.fg("dim", truncateToWidth(`  ${taskModelText(item)}`, width))] : []),
 					...(selected ? [theme.fg("dim", truncateToWidth(`  ${taskDisplayText(metadata)}`, width))] : []),
 				];
 			}),

--- a/packages/coding-agent/src/modes/interactive/components/task-live-transcript.ts
+++ b/packages/coding-agent/src/modes/interactive/components/task-live-transcript.ts
@@ -1,0 +1,48 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { Component } from "@earendil-works/pi-tui";
+import type { TaskTranscriptSource } from "../../../core/tasks/supervisor.js";
+import {
+	type ChatMessageEntry,
+	chatEntriesFromAgentMessages,
+	LiveChatEntriesController,
+	renderChatMessageEntry,
+} from "./chat-message-renderer.ts";
+
+/** A viewer subscription, not a second task runner or a task-activity publisher. */
+export class TaskLiveTranscript implements Component {
+	private readonly entries: ChatMessageEntry[];
+	private readonly live: LiveChatEntriesController;
+	private readonly unsubscribe?: () => void;
+	private components?: Component[];
+	readonly source: TaskTranscriptSource;
+	private readonly requestRender: () => void;
+	constructor(source: TaskTranscriptSource, messages: AgentMessage[], requestRender: () => void) {
+		this.source = source;
+		this.requestRender = requestRender;
+		this.entries = chatEntriesFromAgentMessages(messages);
+		this.live = new LiveChatEntriesController(this.entries);
+		this.live.hydrateStreamingAssistantMessage(source.getStreamingMessage?.());
+		this.unsubscribe = source.subscribe?.((event) => {
+			if (this.live.applyEvent(event)) this.components = undefined;
+			this.requestRender();
+		});
+	}
+	invalidate(): void {
+		this.components = undefined;
+	}
+	render(width: number): string[] {
+		this.components ??= this.entries.map((entry) =>
+			renderChatMessageEntry(entry, {
+				ui: { requestRender: this.requestRender },
+				cwd: process.cwd(),
+				hideThinkingBlock: true,
+				toolOutputExpanded: true,
+				showImages: false,
+			}),
+		);
+		return this.components.flatMap((component) => component.render(width));
+	}
+	dispose(): void {
+		this.unsubscribe?.();
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/task-row.ts
+++ b/packages/coding-agent/src/modes/interactive/components/task-row.ts
@@ -22,6 +22,14 @@ export function taskLabel(task: TaskRecord): string {
 export function taskTitle(task: TaskRecord): string {
 	return task.title || taskLabel(task);
 }
+export function taskModelText(task: Pick<TaskRecord, "kind" | "model" | "thinking">): string {
+	if (task.kind !== "agent") return "";
+	return taskDisplayText(
+		[task.model ?? "model unavailable", task.thinking ? `thinking ${task.thinking}` : "thinking unavailable"].join(
+			" · ",
+		),
+	);
+}
 export function taskShortId(task: TaskRecord): string {
 	return createHash("sha256").update(task.ref.taskId).digest("hex").slice(0, 6);
 }
@@ -109,6 +117,7 @@ export class TaskRow implements Component {
 			theme.bold(taskDisplayText(taskLabel(task))) +
 			theme.fg("muted", `: ${taskDisplayText(taskTitle(task))}`);
 		const lines = [truncateToWidth(title, Math.max(1, rowWidth - suffix.length)) + theme.fg("dim", suffix)];
+		if (task.kind === "agent") lines.push(theme.fg("dim", truncateToWidth(`  ${taskModelText(task)}`, rowWidth)));
 		const action =
 			live && task.currentAction
 				? ` · ${taskDisplayText(task.currentAction.tool)} ${taskDisplayText(task.currentAction.text)}`

--- a/packages/coding-agent/src/modes/rpc/task-ui-bridge.ts
+++ b/packages/coding-agent/src/modes/rpc/task-ui-bridge.ts
@@ -87,46 +87,71 @@ export async function showTaskInspector(
 	store: OwnerTaskStore,
 	taskId?: string,
 ): Promise<void> {
-	let inspector: TaskInspector | undefined;
+	let requestRender = () => {};
+	let finishView = () => {};
+	let closed = false;
+	let fullscreen = false;
+	const inspector = new TaskInspector(
+		store,
+		() => {
+			if (inspector.fullscreen !== fullscreen) finishView();
+			else requestRender();
+		},
+		() => {
+			closed = true;
+			finishView();
+		},
+	);
+	inspector.open(taskId as TaskId | undefined);
 	try {
-		await ui.custom<void>(
-			(tui, _theme, _keys, done) => {
-				inspector = new TaskInspector(
-					store,
-					() => tui.requestRender(),
-					() => done(),
-				);
-				inspector.open(taskId as TaskId | undefined);
-				return {
-					invalidate: () => inspector?.invalidate(),
-					render: (width: number) => {
-						const height = Math.max(1, tui.terminal.rows);
-						const lines = inspector?.renderViewport(width, height) ?? [];
-						// Overlay maxHeight is only a cap. Pad short views so no parent
-						// chat or prompt cells remain visible beneath the inspector.
-						return Array.from({ length: height }, (_, row) => {
-							const line = truncateToWidth(lines[row] ?? "", width);
-							return line + " ".repeat(Math.max(0, width - visibleWidth(line)));
-						});
-					},
-					handleInput: (data: string) => {
-						// Local overlays receive safety keys directly. The isolated host
-						// dismisses this remote view through its ordinary Ctrl+C route.
-						if (isPhysicalCtrlC(data)) done();
-						else inspector?.handleInput(data);
-						// A declined key is replayed into the main transcript by the host.
-						// The fullscreen inspector owns even keys its current view ignores.
-						return true;
-					},
-				};
-			},
-			{
-				overlay: true,
-				deferInlineCustomUiFocus: true,
-				handlesInternalUiAction: true,
-				overlayOptions: { anchor: "center", width: "100%", maxHeight: "100%", margin: 0 },
-			},
-		);
+		while (!closed) {
+			fullscreen = inspector.fullscreen;
+			await ui.custom<void>(
+				(tui, _theme, _keys, done) => {
+					requestRender = () => tui.requestRender();
+					finishView = () => done();
+					return {
+						invalidate: () => inspector.invalidate(),
+						render: (width: number) => {
+							const height = Math.max(1, tui.terminal.rows);
+							if (!fullscreen) return inspector.renderPicker(width, height);
+							const lines = inspector.renderViewport(width, height);
+							// Fullscreen detail pages cover all parent chat and prompt cells.
+							return Array.from({ length: height }, (_, row) => {
+								const line = truncateToWidth(lines[row] ?? "", width);
+								return line + " ".repeat(Math.max(0, width - visibleWidth(line)));
+							});
+						},
+						handleInput: (data: string) => {
+							if (isPhysicalCtrlC(data)) {
+								closed = true;
+								done();
+							} else inspector.handleInput(data);
+							return true;
+						},
+					};
+				},
+				{
+					overlay: fullscreen,
+					purpose: "navigation",
+					handlesCtrlC: true,
+					deferInlineCustomUiFocus: true,
+					handlesInternalUiAction: true,
+					...(fullscreen
+						? {
+								overlayOptions: {
+									anchor: "center" as const,
+									width: "100%" as const,
+									maxHeight: "100%" as const,
+									margin: 0,
+								},
+							}
+						: {}),
+				},
+			);
+			// Host dismissal without a navigation transition must not reopen the view.
+			if (inspector.fullscreen === fullscreen) closed = true;
+		}
 	} finally {
 		inspector?.dispose();
 	}

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added replay-safe model and reasoning activity reports and retained model and thinking fields on task snapshots, including settled tasks.
 - Added an environment-local `TaskSupervisor` actor with owner-sealed admission, stable task/attempt identities, replay-safe reports, observation waits, cancellation and independently acknowledged cleanup. Generated bindings expose atomic snapshot subscriptions with a byte-bounded event journal; total task/report history and output storage are not bounded by this journal ([#2884](https://github.com/bastani-inc/atomic/pull/2884)).
 - Added supervised Unix pipe/PTY commands with process-group cleanup, observation-independent execution deadlines, replay-safe byte-credit stdin, resize and retained output paging. Drained output stays live beyond its cap; background file-spool overflow settles `OutputLimitExceeded` ([#2884](https://github.com/bastani-inc/atomic/pull/2884)).
 - Added Windows pipe task containment with suspended launch, explicit inherited handles and kill-on-close Job Objects. Assignment failure refuses execution and confirms suspended-process cleanup; failed cleanup retains diagnostic resources. Supervised Windows PTY remains unavailable ([#2884](https://github.com/bastani-inc/atomic/pull/2884)).

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -133,6 +133,7 @@ export declare class WaitLease {
 
 export type ActivityChange =
   | { kind: 'action', tool: string, text: string }
+  | { kind: 'model', model?: string, thinking?: string }
   | { kind: 'metrics', elapsedMs?: number, toolCount?: number, tokenCount?: number }
   | { kind: 'output', offset: string, bytesBase64: string }
   | { kind: 'attention-set', attention: Attention }
@@ -800,6 +801,8 @@ export interface TaskRecord {
   kind: string
   title: string
   agentName?: string
+  model?: string
+  thinking?: string
   execution: Execution
   observation: HostObservation
   /** True after a designated observation yields; retained after settlement and snapshot resets. */

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Changed
 
+- Owner-bound task reports and foreground/background result receipts now retain resolved model and reasoning settings across fallback and completion. Live transcript viewers subscribe to session events without publishing high-frequency task-status updates.
 - Session-bound launches now return task observations immediately by default. Independent parallel launches admit queued slots under their concurrency limit; explicit foreground groups retain Intercom yielding. Owner-scoped `action:"wait"` observes the same child; terminal completion uses a nonvisual persisted envelope ([#2884](https://github.com/bastani-inc/atomic/pull/2884)).
 - Subagent tool results now summarize launch observations and agent discovery instead of displaying raw task receipts or full catalog dumps by default. Parallel receipts show numbered sibling rows and errors; expanded results retain task identities. Owner-task progress includes recorded elapsed time, tool/token counts, and concise current-tool arguments.
 - In-process status cards now show compact, theme-aware agent rows with state symbols instead of repeated run IDs and raw residency text. Expanding reveals all children and diagnostic metadata; narrow terminals preserve readable status labels.

--- a/packages/subagents/src/extension/tool-rendering.ts
+++ b/packages/subagents/src/extension/tool-rendering.ts
@@ -3,6 +3,7 @@ import type { AgentToolResult } from "@earendil-works/pi-agent-core";
 import { type Component, Container, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { getBurstDisplay } from "../runs/foreground/subagent-executor-burst-display.js";
 import type { SubagentParamsLike } from "../runs/foreground/subagent-executor-types.js";
+import { formatModelThinking } from "../shared/formatters.js";
 import type { Details } from "../shared/types.js";
 import { renderLiveSubagentResult } from "../tui/render.js";
 
@@ -59,11 +60,19 @@ export function renderSubagentToolResult(
 	result = burst?.result ?? result;
 	if (result.details?.taskError)
 		return new Text(theme.fg("error", `✗ ${displayText(result.details.taskError)}`), 0, 0);
-	if (result.details?.taskRecords) {
+	if (result.details?.taskRecords && !result.details.taskResponse) {
 		const lines = result.details.taskRecords.flatMap((task) => {
 			const state = task.execution.kind === "settled" ? task.execution.result.kind : task.execution.kind;
 			return [
 				theme.bold(`${displayText(task.agentName ?? "bash")} · ${state}`),
+				...(task.kind === "agent"
+					? [
+							theme.fg(
+								"dim",
+								displayText(formatModelThinking(task.model, task.thinking) || "model / thinking unavailable"),
+							),
+						]
+					: []),
 				theme.fg("muted", displayText(task.title)),
 				...(options.expanded ? [theme.fg("dim", task.ref.taskId)] : []),
 				...(task.execution.kind === "settled" && task.execution.result.kind === "failed"
@@ -124,6 +133,11 @@ export function renderSubagentToolResult(
 			const identity = labels[index];
 			const name = outcomes.length > 1 ? `${index + 1}. ${identity ? displayText(identity.agent) : "Agent"} · ` : "";
 			const summary = theme.fg(color, `${icon} ${name}${state}`);
+			const task = result.details?.taskRecords?.find((task) => task.ref.taskId === observation.taskId);
+			const model = theme.fg(
+				"dim",
+				`\n   ${displayText(formatModelThinking(task?.model, task?.thinking) || "model / thinking unavailable")}`,
+			);
 			const metadata = options.expanded
 				? theme.fg("dim", `\n   ${observation.taskId}${identity?.task ? ` · ${displayText(identity.task)}` : ""}`)
 				: "";
@@ -131,7 +145,7 @@ export function renderSubagentToolResult(
 				observation.kind === "settled" && observation.result.kind === "failed"
 					? `\n   ${theme.fg("error", displayText(observation.result.message))}`
 					: "";
-			return summary + metadata + error;
+			return summary + model + metadata + error;
 		});
 		const heading = outcomes.length > 1 ? [theme.bold(`${outcomes.length} agent tasks`)] : [];
 		return new Text(

--- a/packages/subagents/src/runs/foreground/subagent-executor-parallel.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-parallel.ts
@@ -44,6 +44,7 @@ import {
 	findDuplicateParallelOutputPath,
 	resolveParallelTaskCwd,
 } from "./subagent-executor-worktree.js";
+import { taskResponseRecords } from "./task-execution.js";
 
 export async function runParallelPath(
 	data: ExecutionContextData,
@@ -251,7 +252,12 @@ export async function runParallelPath(
 			);
 			return {
 				content: [{ type: "text", text: JSON.stringify(response) }],
-				details: { mode: "parallel", results: [], taskResponse: response },
+				details: {
+					mode: "parallel",
+					results: [],
+					taskResponse: response,
+					taskRecords: taskResponseRecords(response, ctx.getAgentTaskHost()),
+				},
 			};
 		}
 		for (let i = 0; i < results.length; i++) {

--- a/packages/subagents/src/runs/foreground/subagent-executor-single.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor-single.ts
@@ -266,7 +266,7 @@ export async function runSinglePath(
 							})
 						: getSingleResultOutput(child),
 			});
-			if (!parentAsk || !settledChild?.interrupted) return taskToolResult(response);
+			if (!parentAsk || !settledChild?.interrupted) return taskToolResult(response, ctx.getAgentTaskHost());
 			r = settledChild;
 		} else r = await deps.runtime.runSync(ctx.cwd, agents, params.agent!, task, runOptions);
 	} catch (error) {

--- a/packages/subagents/src/runs/foreground/subagent-executor.ts
+++ b/packages/subagents/src/runs/foreground/subagent-executor.ts
@@ -17,6 +17,7 @@ import {
 	type ResolvedExecutorDeps,
 	type SubagentParamsLike,
 } from "./subagent-executor-types.js";
+import { taskResponseRecords } from "./task-execution.js";
 
 const MUTATING_MANAGEMENT_ACTIONS = new Set(["create", "update", "delete"]);
 /** Observing management actions do not start or mutate child execution. */
@@ -80,7 +81,13 @@ async function handleManagementRequest(input: {
 				mode: "management",
 				results: [],
 				...(observed.ok
-					? { taskResponse: { kind: "admitted", observation: observed.value } as const }
+					? {
+							taskResponse: { kind: "admitted", observation: observed.value } as const,
+							taskRecords: taskResponseRecords(
+								{ kind: "admitted", observation: observed.value },
+								ctx.getAgentTaskHost?.(),
+							),
+						}
 					: { taskError: observed.error.message }),
 			},
 			...(!observed.ok ? { isError: true } : {}),

--- a/packages/subagents/src/runs/foreground/task-execution.ts
+++ b/packages/subagents/src/runs/foreground/task-execution.ts
@@ -1,8 +1,10 @@
 import type { AgentTaskHost, OperationId, WaitPolicy } from "@bastani/atomic";
 import type {
 	Cleanup,
+	ModelParallelResponse,
 	ModelSingleResponse,
 	Result,
+	TaskRecord,
 	TaskResult,
 	WaitOutcome,
 	YieldError,
@@ -13,12 +15,35 @@ import type { RunSyncOptions, SingleResult, SubagentToolResult } from "../../sha
 import { getSingleResultOutput } from "../../shared/utils.js";
 import type { SubagentExecutorRuntimeDeps } from "./subagent-executor-types.js";
 
-export function taskToolResult(response: ModelSingleResponse): SubagentToolResult {
+export function taskToolResult(response: ModelSingleResponse, host?: AgentTaskHost): SubagentToolResult {
 	return {
 		content: [{ type: "text", text: JSON.stringify(response) }],
-		details: { mode: "single", results: [], taskResponse: response },
+		details: {
+			mode: "single",
+			results: [],
+			taskResponse: response,
+			taskRecords: taskResponseRecords(response, host),
+		},
 		...(response.kind === "unstarted" ? { isError: true } : {}),
 	};
+}
+
+/** Snapshot execution metadata for receipt playback, scoped to this response only. */
+export function taskResponseRecords(
+	response: ModelSingleResponse | ModelParallelResponse,
+	host?: AgentTaskHost,
+): TaskRecord[] {
+	const outcomes = response.kind === "parallel" ? response.slots.map((slot) => slot.outcome) : [response];
+	const ids = new Set(
+		outcomes.flatMap((outcome) => (outcome.kind === "admitted" ? [outcome.observation.taskId] : [])),
+	);
+	const watched = host?.watchOwnerTasks();
+	if (!watched?.ok) return [];
+	try {
+		return watched.value.snapshot.tasks.filter((task) => ids.has(task.ref.taskId));
+	} finally {
+		watched.value.dispose();
+	}
 }
 
 /** Bind the real foreground runner once; only its registered observation may yield. */
@@ -57,6 +82,10 @@ export async function runAgentTask(input: {
 								context.bindTranscript({
 									getSessionId: () => session.getSessionId(),
 									getEntries: () => session.getEntries(),
+									...(session.subscribe ? { subscribe: session.subscribe.bind(session) } : {}),
+									...(session.getStreamingMessage
+										? { getStreamingMessage: session.getStreamingMessage.bind(session) }
+										: {}),
 									...(input.options.intercomSessionName
 										? {
 												completionSource: {
@@ -81,6 +110,11 @@ export async function runAgentTask(input: {
 							},
 						},
 					});
+					if (child.model !== undefined || child.thinking !== undefined)
+						context.reportActivity({
+							reportId: "terminal-model",
+							change: { kind: "model", model: child.model, thinking: child.thinking },
+						});
 					input.onTerminal?.(child);
 					const text = input.outputText?.(child) ?? getSingleResultOutput(child);
 					const bytes = Buffer.from(text);

--- a/packages/subagents/src/runs/inprocess/control-status.ts
+++ b/packages/subagents/src/runs/inprocess/control-status.ts
@@ -31,10 +31,16 @@ function statusGroup(control: NonNullable<ReturnType<typeof findSubagentControl>
 		parentPath: control.parent.path,
 		children: canonicalChildren(control)
 			.filter((child) => !id || id === control.parent.path || child.path === id)
-			.map((child) => ({
-				...child,
-				sessionFile: control.getDeliveredResult(child.path)?.sessionFile,
-			})),
+			.map((child) => {
+				const delivered = control.getDeliveredResult(child.path);
+				const metadata = control.getChildMetadata(child.path) ?? delivered;
+				return {
+					...child,
+					sessionFile: delivered?.sessionFile,
+					...(metadata?.model === undefined ? {} : { model: metadata.model }),
+					...(metadata?.thinking === undefined ? {} : { thinking: metadata.thinking }),
+				};
+			}),
 	};
 }
 

--- a/packages/subagents/src/runs/inprocess/runner.ts
+++ b/packages/subagents/src/runs/inprocess/runner.ts
@@ -5,6 +5,8 @@ import {
 	type AgentSession,
 	type AgentSessionEvent,
 	type AgentSessionEventListener,
+	applyAssistantMessageDelta,
+	beginStreamingAssistantMessage,
 	type CreateAgentSessionOptions,
 	createAgentSession,
 	DefaultResourceLoader,
@@ -24,7 +26,7 @@ import {
 	type TerminationCause as NativeTerminationCause,
 	SubagentControl,
 } from "@bastani/atomic-natives";
-import type { Api, Model } from "@bastani/pi-ai/compat";
+import type { Api, AssistantMessage, Model } from "@bastani/pi-ai/compat";
 import type { Cleanup } from "../../../../coding-agent/src/core/tasks/contracts.js";
 import type { AgentConfig } from "../../agents/agent-types.js";
 import {
@@ -967,6 +969,15 @@ export class SubagentControlRuntime {
 				await created.session.extensionRunner.emit({ type: "session_start", reason: "startup" });
 			}
 			session = created.session;
+			const transcriptSession = session;
+			// Snapshot at the public session-event boundary, never ahead of its queued events.
+			let observedStreamingMessage: AssistantMessage | undefined;
+			taskHooks?.bindTranscript?.({
+				getSessionId: () => sessionManager.getSessionId(),
+				getEntries: () => sessionManager.getEntries(),
+				subscribe: (listener) => transcriptSession.subscribe(listener),
+				getStreamingMessage: () => observedStreamingMessage,
+			});
 			const initialModelId = modelIdForSession(session) ?? candidateModelId;
 			effectiveModelId = initialModelId;
 			effectiveThinking =
@@ -1010,8 +1021,20 @@ export class SubagentControlRuntime {
 				onProgress?.({ ...progressState, recentTools: [...progressState.recentTools] });
 			};
 			let activitySequence = 0;
+			const reportModel = () =>
+				taskHooks?.reportActivity({
+					reportId: `${activityPrefix}:model-${++activitySequence}`,
+					change: { kind: "model", model: effectiveModelId, thinking: effectiveThinking },
+				});
+			reportModel();
 			unsubscribe = session.subscribe((event) => {
 				writeEvent(admitted.spec.artifactJsonlPath, event);
+				if (event.type === "message_start" && event.message.role === "assistant")
+					observedStreamingMessage = beginStreamingAssistantMessage(event.message);
+				else if (event.type === "message_update" && observedStreamingMessage)
+					applyAssistantMessageDelta(observedStreamingMessage, event.assistantMessageEvent);
+				else if (event.type === "message_end" && event.message.role === "assistant")
+					observedStreamingMessage = undefined;
 				const emission = progressEmissionFor(event.type);
 				if (event.type === "tool_execution_start") {
 					taskHooks?.reportActivity({
@@ -1053,10 +1076,13 @@ export class SubagentControlRuntime {
 					effectiveModelId = event.to;
 					progressState.model = event.to;
 					onModelChange?.(effectiveModelId, effectiveThinking);
+					reportModel();
+					emitProgress(true);
 				} else if (event.type === "thinking_level_changed") {
 					effectiveThinking = event.level;
 					progressState.thinking = effectiveThinking;
 					onModelChange?.(effectiveModelId, effectiveThinking);
+					reportModel();
 					emitProgress(true);
 				}
 			});

--- a/packages/subagents/src/shared/types-results.ts
+++ b/packages/subagents/src/shared/types-results.ts
@@ -217,7 +217,7 @@ export interface SingleResult {
 /** Read-only control-plane snapshot for status cards; text output stays unchanged. */
 export interface SubagentStatusGroup {
 	parentPath: string;
-	children: Array<ChildIdentity & { sessionFile?: string }>;
+	children: Array<ChildIdentity & { sessionFile?: string; model?: string; thinking?: string }>;
 }
 
 export interface Details {

--- a/packages/subagents/src/tui/render-status.ts
+++ b/packages/subagents/src/tui/render-status.ts
@@ -1,5 +1,6 @@
 import { keyHintIfBound } from "@bastani/atomic";
 import { type Component, stripTerminalSequences, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { formatModelThinking } from "../shared/formatters.js";
 import type { SubagentStatusGroup } from "../shared/types.js";
 import type { Theme } from "./render-layout.js";
 
@@ -28,9 +29,12 @@ function childStatusLines(
 		? name
 		: displayText(truncateToWidth(name, Math.max(1, width - visibleWidth(style.label) - 5), "…"));
 	const heading = `${theme.fg(style.color, style.glyph)} ${theme.fg("toolTitle", theme.bold(label))}${theme.fg("dim", " · ")}${theme.fg(style.color, style.label)}`;
-	if (!expanded) return [heading];
+	const model = formatModelThinking(child.model, child.thinking);
+	const metadata = model ? [theme.fg("dim", `  ${displayText(model)}`)] : [];
+	if (!expanded) return [heading, ...metadata];
 	return [
 		heading,
+		...metadata,
 		theme.fg("dim", `  Path: ${displayText(child.path)}`),
 		theme.fg("dim", `  Parent: ${displayText(child.parentPath)} · Depth: ${child.depth}`),
 		theme.fg("dim", `  Task: ${displayText(child.taskName)}`),

--- a/test/fixtures/task-s1-utf16.ts
+++ b/test/fixtures/task-s1-utf16.ts
@@ -19,11 +19,13 @@ function changes(raw: string): C.ActivityReport["change"][] {
 		{ kind: "attention-set", attention: { kind: "input-needed", requestId: raw, prompt: raw, route: { sessionId: raw, promptId: raw, stageAttemptId: raw } } },
 		{ kind: "attention-set", attention: { kind: "no-recent-activity", lastActivityAt: raw } },
 		{ kind: "attention-clear", requestId: raw },
+		{ kind: "model", model: raw, thinking: raw },
 	];
 }
 function mutations(change: C.ActivityReport["change"], raw: string): C.ActivityReport["change"][] {
 	switch (change.kind) {
 		case "action": return [{ ...change, tool: raw }, { ...change, text: raw }];
+		case "model": return [{ ...change, model: raw }, { ...change, thinking: raw }];
 		case "output": return [{ ...change, offset: raw }, { ...change, bytesBase64: raw }];
 		case "attention-clear": return [{ ...change, requestId: raw }];
 		case "attention-set": {
@@ -134,6 +136,7 @@ for (const raw of strings) {
 			if (event.kind === "task-activity") assert.deepEqual(event.activity, report);
 			const record = snapshot();
 			if (change.kind === "action") assert.deepEqual(record.currentAction, { tool: raw, text: raw });
+			if (change.kind === "model") { assert.equal(record.model, raw); assert.equal(record.thinking, raw); }
 			if (change.kind === "attention-set") assert.deepEqual(record.attention, change.attention);
 		}
 		// Different code-unit report IDs neither collide nor become terminal identity.

--- a/test/integration/task-supervisor-native.test.ts
+++ b/test/integration/task-supervisor-native.test.ts
@@ -820,7 +820,7 @@ test("Node and Bun preserve UTF-16 code units across S1 records and replay", () 
 		assert.equal(result.exitCode, 0, `${runtime}\n${result.stdout}\n${result.stderr}`);
 		assert.match(
 			result.stdout.toString(),
-			/UTF16 PRESERVED 9 strings 45 variant reports 387 conflicts 27 facade launches/,
+			/UTF16 PRESERVED 9 strings 54 variant reports 405 conflicts 27 facade launches/,
 		);
 	}
 });

--- a/test/unit/engine-task-ui-bridge.test.ts
+++ b/test/unit/engine-task-ui-bridge.test.ts
@@ -75,7 +75,7 @@ test("engine task widget follows the real lazy owner through activity, settlemen
 	}
 });
 
-test("engine task inspector requests an opaque fullscreen overlay using live host geometry", async () => {
+test("engine task picker opens inline and detail uses an opaque fullscreen overlay with live geometry", async () => {
 	initTheme("dark");
 	const previousKeys = getKeybindings();
 	const keys = new KeybindingsManager();
@@ -96,13 +96,40 @@ test("engine task inspector requests an opaque fullscreen overlay using live hos
 		await fixture.start("Fullscreen background review");
 		completion = showEngineTaskInspector(session, { custom: service.custom.bind(service) });
 		await new Promise<void>((resolve) => setImmediate(resolve));
-		const open = messages.find((message) => message.type === "engine_custom_open");
+		const picker = messages.find((message) => message.type === "engine_custom_open");
+		assert.ok(picker && picker.type === "engine_custom_open");
+		assert.equal(picker.overlay, false);
+		assert.equal(picker.overlayOptions, undefined);
+		service.handleLine(
+			serializeInteractiveEngineFrame({
+				type: "engine_custom_render",
+				componentId: picker.componentId,
+				requestId: 1,
+				width: 80,
+				rows: 24,
+			}),
+		);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		const pickerFrame = messages.findLast((message) => message.type === "engine_custom_frame");
+		assert.ok(pickerFrame && pickerFrame.type === "engine_custom_frame");
+		assert.ok(pickerFrame.lines.length <= 12);
+		service.handleLine(
+			serializeInteractiveEngineFrame({
+				type: "engine_custom_input",
+				componentId: picker.componentId,
+				requestId: 2,
+				data: "\r",
+			}),
+		);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		const open = messages.findLast((message) => message.type === "engine_custom_open");
 		assert.ok(open && open.type === "engine_custom_open");
-		assert.equal(open.overlay, true, "task inspection must not replace the editor inline");
+		assert.notEqual(open.componentId, picker.componentId);
+		assert.equal(open.overlay, true);
 		assert.deepEqual(open.overlayOptions, { anchor: "center", width: "100%", maxHeight: "100%", margin: 0 });
 		assert.equal(open.deferInlineCustomUiFocus, true);
 		assert.equal(open.handlesInternalUiAction, true);
-		assert.notEqual(open.handlesCtrlC, true, "keep the host's first-press Ctrl+C dismissal");
+		assert.equal(open.handlesCtrlC, true);
 		for (const [width, rows] of [
 			[80, 24],
 			[31, 9],

--- a/test/unit/main-task-inspector-overlay.test.ts
+++ b/test/unit/main-task-inspector-overlay.test.ts
@@ -191,11 +191,14 @@ async function mountMainInspector(isolated: boolean) {
 }
 
 for (const isolated of [false, true]) {
-	test(`${isolated ? "isolated engine" : "in-process"} /tasks covers the host, owns keys, and escapes without cancelling`, async () => {
+	test(`${isolated ? "isolated engine" : "in-process"} /tasks opens inline, drills down fullscreen, and escapes without cancelling`, async () => {
 		const previousKeys = getKeybindings();
 		const host = await mountMainInspector(isolated);
 		try {
-			assert.equal(host.tui.hasOverlay(), true, "/tasks must mount an overlay, not an inline selector");
+			assert.equal(host.tui.hasOverlay(), false, "/tasks opens in the editor slot like /workflow connect");
+			const picker = await host.paint();
+			assert.ok(picker.length <= 12 && picker.length < host.terminal.rows);
+			assert.match(stripVTControlCharacters(picker.join("\n")), /Background tasks/);
 			const assertFrame = async () => {
 				const frame = await host.paint();
 				assert.equal(frame.length, host.terminal.rows);
@@ -203,7 +206,9 @@ for (const isolated of [false, true]) {
 				assert.doesNotMatch(stripVTControlCharacters(frame.join("\n")), /MAIN-CHAT/);
 				return stripVTControlCharacters(frame.join("\n"));
 			};
-			await assertFrame();
+			await host.input("\x05"); // configured inspect opens fullscreen detail
+			assert.equal(host.tui.hasOverlay(), true);
+			assert.match(await assertFrame(), /Inspect transcript/);
 			const scrollTop = host.scroll.scrollTop;
 			assert.ok(scrollTop > 0, "fixture must have scrollable main chat history");
 			const assertKeysOwned = async () => {
@@ -231,9 +236,6 @@ for (const isolated of [false, true]) {
 				}
 			};
 			await assertKeysOwned();
-			await host.input("\x05"); // configured inspect, not hardcoded Enter
-			assert.match(await assertFrame(), /Inspect transcript/);
-			await assertKeysOwned();
 			// Restore the first detail action after the arrow-key checks.
 			await host.input("\x1b");
 			await host.input("\x05");
@@ -254,7 +256,9 @@ for (const isolated of [false, true]) {
 			await host.input("\x1b");
 			assert.match(await assertFrame(), /Inspect transcript/);
 			await host.input("\x1b");
-			assert.match(await assertFrame(), /Background tasks/);
+			assert.equal(host.tui.hasOverlay(), false);
+			assert.match(stripVTControlCharacters((await host.paint()).join("\n")), /Background tasks/);
+			assert.ok((await host.paint()).length <= 12);
 			await host.input("\x1b");
 			await host.completion;
 			assert.equal(host.tui.hasOverlay(), false);

--- a/test/unit/task-inspector-detail-race.test.ts
+++ b/test/unit/task-inspector-detail-race.test.ts
@@ -144,7 +144,8 @@ test("store updates do not replace a pending shell transcript with a detail refr
 	const read = vi
 		.spyOn(supervisor, "readTaskOutput")
 		.mockResolvedValueOnce(output)
-		.mockReturnValueOnce(pending.promise);
+		.mockReturnValueOnce(pending.promise)
+		.mockResolvedValue(output);
 	const inspector = new TaskInspector(
 		store,
 		() => {},
@@ -159,6 +160,7 @@ test("store updates do not replace a pending shell transcript with a detail refr
 		pending.resolve(output);
 		await settle();
 		assert.match(text(inspector), /Retained shell output/);
+		assert.equal(read.mock.calls.length, 3, "pending state updates trigger one follow-up transcript read");
 		assert.doesNotMatch(text(inspector), /› Inspect transcript/);
 	} finally {
 		inspector.dispose();

--- a/test/unit/task-live-transcript.test.ts
+++ b/test/unit/task-live-transcript.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import type { AssistantMessage } from "@bastani/pi-ai/compat";
+import { getKeybindings, setKeybindings } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import type { AgentSessionEvent } from "../../packages/coding-agent/src/core/agent-session.js";
+import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.js";
+import { SessionManager } from "../../packages/coding-agent/src/core/session-manager.js";
+import { TaskInspector } from "../../packages/coding-agent/src/modes/interactive/components/task-inspector.js";
+import { initTheme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.js";
+import { taskFixture } from "../helpers/task-projection.js";
+
+const assistant = (text: string): AssistantMessage => ({
+	role: "assistant",
+	content: [{ type: "text", text }],
+	api: "openai-responses",
+	provider: "openai",
+	model: "fixture",
+	usage: {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	},
+	stopReason: "stop",
+	timestamp: 1,
+});
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+test("open agent transcript streams text and tool results without task activity or reopening", async () => {
+	initTheme("dark");
+	const keys = getKeybindings();
+	setKeybindings(new KeybindingsManager());
+	const fixture = taskFixture();
+	const session = SessionManager.inMemory();
+	session.appendMessage({ role: "user", content: "Inspect streaming", timestamp: 0 });
+	const listeners = new Set<(event: AgentSessionEvent) => void>();
+	const emit = (event: AgentSessionEvent) => {
+		for (const listener of listeners) listener(event);
+	};
+	let renders = 0;
+	const inspector = new TaskInspector(
+		fixture.store,
+		() => {
+			renders++;
+		},
+		() => {},
+	);
+	const text = () => stripVTControlCharacters(inspector.renderViewport(100, 100).join("\n"));
+	try {
+		await fixture.start();
+		fixture.runners[0].context.bindTranscript({
+			getSessionId: () => session.getSessionId(),
+			getEntries: () => session.getEntries(),
+			getStreamingMessage: () => assistant("Already streaming"),
+			subscribe: (listener) => {
+				listeners.add(listener);
+				return () => {
+					listeners.delete(listener);
+				};
+			},
+		});
+		inspector.handleInput("\r");
+		await flush();
+		inspector.handleInput("\r");
+		await flush();
+		assert.equal(listeners.size, 1);
+		assert.match(text(), /Already streaming/);
+		const before = renders;
+		emit({
+			type: "message_update",
+			message: assistant(""),
+			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: " live delta", partial: assistant("") },
+		});
+		assert.ok(renders > before);
+		assert.match(text(), /Already streaming live delta/);
+		emit({ type: "message_end", message: assistant("Final response") });
+		emit({ type: "tool_execution_start", toolCallId: "call-1", toolName: "bash", args: { command: "echo test" } });
+		emit({
+			type: "tool_execution_update",
+			toolCallId: "call-1",
+			toolName: "bash",
+			args: {},
+			partialResult: { content: [{ type: "text", text: "Partial tool output" }] },
+		});
+		assert.match(text(), /Partial tool output/);
+		emit({
+			type: "tool_execution_end",
+			toolCallId: "call-1",
+			toolName: "bash",
+			result: { content: [{ type: "text", text: "Final tool output" }] },
+			isError: false,
+		});
+		assert.match(text(), /Final tool output/);
+		assert.doesNotMatch(text(), /Partial tool output/);
+		assert.equal((text().match(/Final response/g) ?? []).length, 1);
+		await fixture.settle();
+		assert.match(text(), /Final tool output/);
+		inspector.handleInput("\x1b");
+		assert.equal(listeners.size, 0);
+		const closedRenders = renders;
+		emit({ type: "agent_end", messages: [] });
+		assert.equal(renders, closedRenders);
+	} finally {
+		inspector.dispose();
+		await fixture.dispose();
+		setKeybindings(keys);
+	}
+});
+
+test("live transcript keeps earlier pages and scroll position while new state arrives", async () => {
+	initTheme("dark");
+	const keys = getKeybindings();
+	setKeybindings(new KeybindingsManager());
+	const fixture = taskFixture();
+	const session = SessionManager.inMemory();
+	for (let i = 0; i < 120; i++)
+		session.appendMessage({ role: "user", content: `HISTORY-${String(i).padStart(3, "0")}`, timestamp: i });
+	let listener: ((event: AgentSessionEvent) => void) | undefined;
+	const inspector = new TaskInspector(
+		fixture.store,
+		() => {},
+		() => {},
+	);
+	const text = () => stripVTControlCharacters(inspector.renderViewport(80, 12).join("\n"));
+	try {
+		await fixture.start();
+		fixture.runners[0].context.bindTranscript({
+			getSessionId: () => session.getSessionId(),
+			getEntries: () => session.getEntries(),
+			subscribe: (callback) => {
+				listener = callback;
+				return () => {
+					listener = undefined;
+				};
+			},
+		});
+		inspector.handleInput("\r");
+		await flush();
+		inspector.handleInput("\r");
+		await flush();
+		inspector.handleInput("\x1b[5~");
+		await flush();
+		assert.match(text(), /HISTORY-000/);
+		const before = text();
+		listener?.({ type: "message_start", message: assistant("New live response") });
+		assert.match(text(), /HISTORY-000/);
+		assert.equal(text().split("Lines ")[0], before.split("Lines ")[0]);
+		inspector.handleInput("\x1b[F");
+		assert.match(text(), /New live response/);
+		inspector.dispose();
+		assert.equal(listener, undefined);
+	} finally {
+		inspector.dispose();
+		await fixture.dispose();
+		setKeybindings(keys);
+	}
+});

--- a/test/unit/task-model-labels.test.ts
+++ b/test/unit/task-model-labels.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { stripVTControlCharacters } from "node:util";
+import { getKeybindings, setKeybindings, visibleWidth } from "@earendil-works/pi-tui";
+import { test } from "vitest";
+import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.js";
+import { taskCompletionNotice } from "../../packages/coding-agent/src/core/tasks/completion.js";
+import {
+	completionNoticeFromDetails,
+	TaskCompletionMessage,
+} from "../../packages/coding-agent/src/modes/interactive/components/task-completion-message.js";
+import { TaskDetail } from "../../packages/coding-agent/src/modes/interactive/components/task-detail.js";
+import { TaskInspector } from "../../packages/coding-agent/src/modes/interactive/components/task-inspector.js";
+import { TaskRow } from "../../packages/coding-agent/src/modes/interactive/components/task-row.js";
+import { initTheme, theme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.js";
+import { renderSubagentToolResult } from "../../packages/subagents/src/extension/tool-rendering.js";
+import { taskToolResult } from "../../packages/subagents/src/runs/foreground/task-execution.js";
+import { taskFixture, taskValue } from "../helpers/task-projection.js";
+
+for (const background of [false, true]) {
+	test(`${background ? "background" : "foreground"} model settings survive fallback, settlement and snapshots`, async () => {
+		initTheme("dark");
+		const keys = getKeybindings();
+		setKeybindings(new KeybindingsManager());
+		const fixture = taskFixture();
+		try {
+			await fixture.start("Review", undefined, background);
+			const context = fixture.runners[0].context;
+			const report = {
+				reportId: "model",
+				change: { kind: "model" as const, model: "provider/first", thinking: "high" },
+			};
+			taskValue(context.reportActivity(report));
+			assert.equal(taskValue(context.reportActivity(report)).disposition, "duplicate");
+			assert.equal(context.reportActivity({ ...report, change: { ...report.change, thinking: "low" } }).ok, false);
+			taskValue(
+				context.reportActivity({
+					reportId: "fallback",
+					change: { kind: "model", model: "provider/fallback", thinking: "off" },
+				}),
+			);
+			fixture.store.drain();
+			for (const completed of [false, true]) {
+				if (completed) await fixture.settle();
+				const task = fixture.store.tasks[0];
+				assert.equal(task.model, "provider/fallback");
+				assert.equal(task.thinking, "off");
+				const snapshot = taskValue(fixture.supervisor.watchOwnerTasks(fixture.owner));
+				assert.equal(snapshot.snapshot.tasks[0].model, task.model);
+				assert.equal(snapshot.snapshot.tasks[0].thinking, task.thinking);
+				snapshot.dispose();
+				const result = taskToolResult({
+					kind: "admitted",
+					observation: completed
+						? { kind: "settled", taskId: task.ref.taskId, result: { kind: "completed", output: task.output } }
+						: {
+								kind: "yielded",
+								taskId: task.ref.taskId,
+								waitId: "wait" as import("../../packages/coding-agent/src/core/tasks/contracts.js").WaitId,
+								reason: "explicit",
+							},
+				});
+				result.details!.taskRecords = [task];
+				const notification = taskCompletionNotice(
+					{
+						completionId: "completion",
+						ownerId: task.ref.ownerId,
+						taskId: task.ref.taskId,
+						terminalSequence: "1" as import("../../packages/coding-agent/src/core/tasks/contracts.js").Sequence,
+						result: { kind: "completed", output: task.output },
+						display: false,
+					},
+					task,
+				);
+				const restored = completionNoticeFromDetails(JSON.parse(JSON.stringify({ notification })));
+				assert.ok(restored);
+				for (const expanded of [false, true]) {
+					const row = new TaskRow(task, { expanded });
+					const receipt = renderSubagentToolResult(result, { expanded, isPartial: false }, theme, {
+						toolCallId: "fixture",
+						state: {},
+						invalidate() {},
+					});
+					for (const component of [
+						row,
+						receipt,
+						new TaskDetail(task, { stdinAvailable: false }),
+						new TaskCompletionMessage(restored, expanded),
+					]) {
+						const text = stripVTControlCharacters(component.render(100).join("\n"));
+						assert.match(text, /provider\/fallback/);
+						assert.match(text, /thinking off/);
+						assert.doesNotMatch(text, /provider\/first/);
+					}
+					for (const width of [20, 48, 100])
+						assert.ok(row.render(width).every((line) => visibleWidth(line) <= width));
+				}
+				if (background) {
+					const inspector = new TaskInspector(
+						fixture.store,
+						() => {},
+						() => {},
+					);
+					assert.match(
+						stripVTControlCharacters(inspector.renderPicker(100, 24).join("\n")),
+						/provider\/fallback.*thinking off/,
+					);
+					inspector.dispose();
+				}
+			}
+		} finally {
+			await fixture.dispose();
+			setKeybindings(keys);
+		}
+	});
+}

--- a/test/unit/task-transcript-subscription-races.test.ts
+++ b/test/unit/task-transcript-subscription-races.test.ts
@@ -1,0 +1,309 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { stripVTControlCharacters } from "node:util";
+import { createAgentSession, DefaultResourceLoader } from "@bastani/atomic";
+import { type AssistantMessage, getModel } from "@bastani/pi-ai/compat";
+import { AssistantMessageEventStream } from "@bastani/pi-ai/utils/event-stream";
+import { Agent, type AgentMessage } from "@earendil-works/pi-agent-core";
+import { getKeybindings, setKeybindings } from "@earendil-works/pi-tui";
+import { test, vi } from "vitest";
+import { AgentSession, type AgentSessionEvent } from "../../packages/coding-agent/src/core/agent-session.js";
+import { AuthStorage } from "../../packages/coding-agent/src/core/auth-storage.js";
+import type { MessageStartEvent, MessageUpdateEvent } from "../../packages/coding-agent/src/core/extensions/index.js";
+import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.js";
+import { ModelRuntime } from "../../packages/coding-agent/src/core/model-runtime.js";
+import { SessionManager } from "../../packages/coding-agent/src/core/session-manager.js";
+import { SettingsManager } from "../../packages/coding-agent/src/core/settings-manager.js";
+import type { TaskTranscriptSource } from "../../packages/coding-agent/src/core/tasks/supervisor.js";
+import { readTaskTranscript } from "../../packages/coding-agent/src/core/tasks/transcript.js";
+import { TaskInspector } from "../../packages/coding-agent/src/modes/interactive/components/task-inspector.js";
+import { TaskLiveTranscript } from "../../packages/coding-agent/src/modes/interactive/components/task-live-transcript.js";
+import { initTheme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.js";
+import { createTestExtensionsResult, createTestResourceLoader } from "../../packages/coding-agent/test/utilities.js";
+import { SubagentControlRuntime } from "../../packages/subagents/src/runs/inprocess/runner.js";
+import { taskFixture } from "../helpers/task-projection.js";
+
+// Only replace SDK discovery/construction: each run below uses the actual Agent,
+// AgentSession event queue, extension dispatch, persistence and subagent runner.
+vi.mock("@bastani/atomic", async (original) => ({
+	...(await original<typeof import("@bastani/atomic")>()),
+	createAgentSession: vi.fn(),
+}));
+
+const assistant = (text: string): AssistantMessage => ({
+	role: "assistant",
+	content: [{ type: "text", text }],
+	api: "anthropic-messages",
+	provider: "anthropic",
+	model: "fixture",
+	usage: {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	},
+	stopReason: "stop",
+	timestamp: 1,
+});
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+const rendered = (inspector: TaskInspector) => stripVTControlCharacters(inspector.renderViewport(100, 100).join("\n"));
+
+test("opening a transcript receives the final message queued during its history read", async () => {
+	initTheme("dark");
+	const keys = getKeybindings();
+	setKeybindings(new KeybindingsManager());
+	const fixture = taskFixture();
+	const session = SessionManager.inMemory();
+	session.appendMessage({ role: "user", content: "Inspect the subscription race", timestamp: 0 });
+	const listeners = new Set<(event: AgentSessionEvent) => void>();
+	let finalDuringRead: string | undefined;
+	let listenersAtFinal = -1;
+	let finalId: string | undefined;
+	const inspector = new TaskInspector(
+		fixture.store,
+		() => {},
+		() => {},
+	);
+	try {
+		const lease = await fixture.start();
+		fixture.runners[0].context.bindTranscript({
+			getSessionId: () => session.getSessionId(),
+			getEntries: () => {
+				const entries = session.getEntries();
+				const text = finalDuringRead;
+				finalDuringRead = undefined;
+				if (text !== undefined)
+					queueMicrotask(() => {
+						const message = assistant(text);
+						listenersAtFinal = listeners.size;
+						for (const listener of listeners) listener({ type: "message_end", message });
+						// AgentSession persists after notifying public listeners.
+						finalId = session.appendMessage(message);
+					});
+				return entries;
+			},
+			subscribe: (listener) => {
+				listeners.add(listener);
+				return () => {
+					listeners.delete(listener);
+				};
+			},
+		});
+
+		// Negative control: the former awaited API returns the old page after
+		// message_end has already passed, with no streaming message left to hydrate.
+		finalDuringRead = "BEFORE-SUBSCRIBE";
+		const oldPage = await readTaskTranscript(lease);
+		assert.ok(oldPage.ok);
+		assert.ok(finalId);
+		assert.equal(listenersAtFinal, 0);
+		assert.ok(oldPage.value.items.every((item) => item.source.entryId !== finalId));
+
+		inspector.handleInput("\r");
+		await flush();
+		finalDuringRead = "FINAL-AT-HISTORY-BOUNDARY";
+		inspector.handleInput("\r");
+		await flush();
+		assert.equal(listenersAtFinal, 1, "the viewer must subscribe before yielding to the queued final");
+		assert.equal((rendered(inspector).match(/FINAL-AT-HISTORY-BOUNDARY/g) ?? []).length, 1);
+		await fixture.settle();
+		assert.equal((rendered(inspector).match(/FINAL-AT-HISTORY-BOUNDARY/g) ?? []).length, 1);
+		inspector.handleInput("\x1b");
+		assert.equal(listeners.size, 0);
+	} finally {
+		inspector.dispose();
+		await fixture.dispose();
+		setKeybindings(keys);
+	}
+});
+
+const messageText = (message: AgentMessage | undefined) => {
+	if (!message || !("content" in message)) return "";
+	return typeof message.content === "string"
+		? message.content
+		: message.content
+				.filter((block) => block.type === "text")
+				.map((block) => block.text)
+				.join("");
+};
+const liveText = (viewer: TaskLiveTranscript) => stripVTControlCharacters(viewer.render(100).join("\n"));
+
+async function queuedRunner() {
+	const root = mkdtempSync(join(tmpdir(), "atomic-transcript-races-"));
+	const model = getModel("anthropic", "claude-sonnet-4-5")!;
+	const credentials = AuthStorage.inMemory();
+	await credentials.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+	const modelRuntime = await ModelRuntime.create({ credentials, modelsPath: null, allowModelNetwork: false });
+	const settings = SettingsManager.inMemory({ compaction: { enabled: false }, retry: { enabled: false } });
+	vi.spyOn(SettingsManager, "create").mockReturnValue(settings);
+	vi.spyOn(DefaultResourceLoader.prototype, "reload").mockResolvedValue(undefined);
+	const stream = new AssistantMessageEventStream();
+	const ready = Promise.withResolvers<void>();
+	let session!: AgentSession;
+	let source!: TaskTranscriptSource;
+	const held: Array<ReturnType<typeof Promise.withResolvers<void>>> = [];
+	let intercept: (event: MessageStartEvent | MessageUpdateEvent) => void | Promise<void> = () => {};
+	const extensionsResult = await createTestExtensionsResult(
+		[
+			(pi) => {
+				pi.on("message_start", (event) => intercept(event));
+				pi.on("message_update", (event) => intercept(event));
+			},
+		],
+		root,
+	);
+	vi.mocked(createAgentSession).mockImplementation(async (options) => {
+		const agent = new Agent({
+			initialState: { model, systemPrompt: "Test", tools: [] },
+			getApiKey: () => "test-key",
+			streamFn: () => {
+				ready.resolve();
+				return stream;
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: options!.sessionManager!,
+			settingsManager: settings,
+			cwd: root,
+			modelRuntime,
+			resourceLoader: createTestResourceLoader({ extensionsResult }),
+			initialActiveToolNames: [],
+		});
+		return { session, extensionsResult };
+	});
+	const runtime = new SubagentControlRuntime({ path: "transcript-races", depth: 0 }, join(root, "sessions"));
+	const agent = {
+		name: "worker",
+		description: "Transcript fixture",
+		systemPrompt: "",
+		systemPromptMode: "append" as const,
+		source: "user" as const,
+		filePath: join(root, "worker.md"),
+		inheritSkills: false,
+		inheritProjectContext: false,
+	};
+	runtime.registerAgents([agent]);
+	const admission = runtime.admitChildSession({ taskName: "race", task: "Stream a response", cwd: root, agent });
+	assert.ok(admission.admitted);
+	const running = runtime.runChildAttempt(
+		admission.admitted,
+		{ model },
+		{
+			abort: new AbortController().signal,
+			interrupt: new AbortController().signal,
+		},
+		undefined,
+		{
+			reportActivity: () => {},
+			bindTranscript: (bound) => {
+				if (bound.subscribe) source = bound;
+			},
+		},
+	);
+	await Promise.race([
+		ready.promise,
+		running.then((result) => {
+			throw new Error(`Runner ended before provider stream: ${JSON.stringify(result)}`);
+		}),
+	]);
+	assert.ok(source?.subscribe);
+	return {
+		session,
+		source,
+		stream,
+		block(predicate: (event: MessageStartEvent | MessageUpdateEvent) => boolean) {
+			const entered = Promise.withResolvers<void>();
+			const release = Promise.withResolvers<void>();
+			held.push(release);
+			intercept = async (event) => {
+				if (!predicate(event)) return;
+				entered.resolve();
+				await release.promise;
+			};
+			return { entered: entered.promise, release: () => release.resolve() };
+		},
+		once(predicate: (event: AgentSessionEvent) => boolean) {
+			const done = Promise.withResolvers<void>();
+			const unsubscribe = session.subscribe((event) => {
+				if (!predicate(event)) return;
+				// Do not splice the live dispatch array while other listeners need this event.
+				queueMicrotask(unsubscribe);
+				done.resolve();
+			});
+			return done.promise;
+		},
+		async finish(text: string) {
+			for (const release of held) release.resolve();
+			stream.push({ type: "done", reason: "stop", message: assistant(text) });
+			return running;
+		},
+		async dispose() {
+			for (const release of held) release.resolve();
+			stream.push({ type: "done", reason: "stop", message: assistant("cleanup") });
+			await running;
+			vi.restoreAllMocks();
+			rmSync(root, { recursive: true, force: true });
+		},
+	};
+}
+
+test("late subscribers hydrate only public deltas while the real AgentSession queue is blocked", async () => {
+	initTheme("dark");
+	const run = await queuedRunner();
+	const viewers: TaskLiveTranscript[] = [];
+	try {
+		const partial = assistant("");
+		const started = run.once((event) => event.type === "message_start" && event.message.role === "assistant");
+		run.stream.push({ type: "start", partial });
+		await started;
+		const first = run.once(
+			(event) => event.type === "message_update" && event.assistantMessageEvent.type === "text_delta",
+		);
+		assert.equal(partial.content[0].type, "text");
+		partial.content[0].text = "alpha";
+		run.stream.push({ type: "text_delta", contentIndex: 0, delta: "alpha", partial });
+		await first;
+		const blocked = run.block(
+			(event) => event.type === "message_update" && event.assistantMessageEvent.type === "text_delta",
+		);
+		partial.content[0].text = "alpha beta";
+		run.stream.push({ type: "text_delta", contentIndex: 0, delta: " beta", partial });
+		await blocked.entered;
+		assert.equal(messageText(run.session.agent.state.streamingMessage), "alpha beta", "raw state really is ahead");
+		assert.equal(
+			messageText(run.source.getStreamingMessage?.()),
+			"alpha",
+			"snapshot must stop at the public boundary",
+		);
+		for (let i = 0; i < 2; i++) viewers.push(new TaskLiveTranscript(run.source, [], () => {}));
+		for (const viewer of viewers) {
+			assert.match(liveText(viewer), /alpha/);
+			assert.doesNotMatch(liveText(viewer), /beta/);
+		}
+		const delivered = run.once(
+			(event) => event.type === "message_update" && event.assistantMessageEvent.type === "text_delta",
+		);
+		blocked.release();
+		await delivered;
+		assert.equal(messageText(run.source.getStreamingMessage?.()), "alpha beta");
+		for (const viewer of viewers) {
+			assert.equal(
+				(liveText(viewer).match(/beta/g) ?? []).length,
+				1,
+				"queued delta must not be replayed atop raw hydration",
+			);
+			assert.match(liveText(viewer), /alpha beta/);
+		}
+		assert.equal((await run.finish("alpha beta")).status, "ok");
+		assert.equal(run.source.getStreamingMessage?.(), undefined);
+		for (const viewer of viewers) assert.equal((liveText(viewer).match(/alpha beta/g) ?? []).length, 1);
+	} finally {
+		for (const viewer of viewers) viewer.dispose();
+		await run.dispose();
+	}
+});


### PR DESCRIPTION
## Summary

Make `/tasks` a compact inline picker like `/workflow connect`, with fullscreen drill-down pages. Show resolved model and reasoning settings for foreground/background agents and completed results, and refresh open transcripts without reopening them.

## Changes

- Preserve selection through inline picker → fullscreen detail/transcript/input/confirmation → picker navigation, in both in-process and isolated hosts.
- Carry resolved model/thinking through replay-safe native activity reports, snapshots, task rows, status/result cards and persisted completion notifications.
- Subscribe transcript viewers to child session events for streaming text and partial/final tool results. Preserve historical scroll position and release subscriptions when leaving.
- Close history/subscription and queued-event hydration races; coalesce shell-output refreshes received during an outstanding read.
- Update user documentation and package changelogs.

## Validation

- Rebased onto `origin/main` at `b95a5a2bac`.
- `npm run build` and `npm run check` passed.
- Full unit suite: 788 files passed, 7,863 tests passed, 23 skipped. After correcting the shipped helper import boundary, 26 affected tests passed again.
- Native supervisor integration: 32 tests passed, including Node/Bun UTF-16 replay identity coverage.
- Commit hooks passed, including Cargo formatting, Clippy, Biome and repository checks.
- Interactive tmux fixture exercised compact picker, fullscreen detail/transcript, immediate tool output, back navigation and narrow resize. Local text captures: `/tmp/atomic-tasks-evidence/`.

## Reference

Consulted the requested `mehmoodosman/claude-code` DeepWiki reference for compact task/model presentation. Reasoning labels use actual execution settings, not token counts. Early launch receipts can precede model resolution; live task rows display the current settings.

The separately reported Herdr indicator disappearance is being investigated separately and is not changed here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791450403&installation_model_id=10562&pr_number=2924&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2924&signature=645e1cf9ed243ec82d9c1c2b59c0d760e1eb9a356d32487bddffdd5d43030d75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary

The task-inspection and metadata work is otherwise ready, but one repository import-convention requirement remains. The new local TypeScript imports must use `.js` specifiers before this can merge.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until the explicit repository import-specifier requirement is satisfied.

One confirmed repository-rule violation remains; there are no higher-impact findings.

**Files Needing Attention:** packages/coding-agent/src/index.ts and packages/coding-agent/src/modes/interactive/components/task-live-transcript.ts

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/index.ts:11
**Use JavaScript Import Specifiers**

This new export uses a `.ts` local module specifier. The new `task-live-transcript.ts` component likewise imports `chat-message-renderer.ts`. These violate the repository directive requiring `.js` ESM extensions for local TypeScript modules. Change both new specifiers to `.js`; this repository requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tasks): add inline picker, model la..."](https://github.com/bastani-inc/atomic/commit/14bc27e9d42811774c6dee2f740788153517070a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61522087)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->