### PR TITLE
fix(herdr): keep background tasks non-idle

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 
+- Fixed Herdr reporting idle while standalone subagents or background shell tasks are running. The parent reporter now observes owner-scoped task activity and reattaches on reload, retaining working status until all tasks settle without granting children pane ownership.
 - Open subagent transcripts now refresh from live session events, including streaming text and partial/final tool results. Shell transcript reads coalesce pending state updates instead of requiring the view to be reopened.
 - Discarded stale command detail results and read errors after task selection, focus, or inspector lifetime changes, preventing another task's output from appearing in the current view ([#2908](https://github.com/bastani-inc/atomic/pull/2908)).
 - Connected isolated interactive sessions to the engine's compact background-task indicator below the prompt box and command-opened `/tasks` inspector instead of opening an empty host-local task owner. Added `/tasks` autocomplete and live subagent activity, tool/token counts, and response previews inside task details.

--- a/packages/coding-agent/docs/herdr.md
+++ b/packages/coding-agent/docs/herdr.md
@@ -1,6 +1,6 @@
 # Herdr
 
-Atomic includes a built-in Herdr reporter. In an eligible pane it reports agent, extension approval, and observed workflow activity using source `custom:atomic` and agent label `atomic`. No community extension is required.
+Atomic includes a built-in Herdr reporter. In an eligible pane it reports agent, subagent, extension approval, and observed workflow activity using source `custom:atomic` and agent label `atomic`. No community extension is required.
 
 ## Prerequisites and environment
 
@@ -17,11 +17,12 @@ The reporter captures these values on activation, not at module import. It runs 
 
 ## States and reasons
 
-The reporter uses `agent_start`, `agent_settled`, `ui_prompt_start`, `ui_prompt_end`, and the owning session's `observeWorkflowActivity` stream. It does not infer execution from screen text or use `agent_end` as the idle boundary.
+The reporter uses `agent_start`, `agent_settled`, `ui_prompt_start`, `ui_prompt_end`, the owning session's task subscription, and its `observeWorkflowActivity` stream. It does not infer execution from screen text or use `agent_end` as the idle boundary.
 
 | Contribution | Reported state | Internal reason | Message |
 |---|---|---|---|
 | Agent executing without an open approval prompt | `working` | `executing` | None unless a workflow needs attention |
+| Owned subagent or shell task queued, running, or cancelling | `working` | `executing` | None unless a workflow needs attention |
 | Workflow execution, automatic continuation, retry, or stop-drain | `working` | Workflow's `executing`, `automatic_continuation`, `retrying`, or `stopping` | `Workflow needs attention` when a root is blocked or needs attention |
 | Approval prompt is the only remaining work, including an agent parked on that prompt | `blocked` | `awaiting_input` | `Waiting for approval` |
 | Workflow waiting for input, an active intervention, or budget approval, with no independent execution | `blocked` | Workflow's `awaiting_input` or `manual_intervention` | `Workflow needs attention` |
@@ -31,6 +32,8 @@ The reporter uses `agent_start`, `agent_settled`, `ui_prompt_start`, `ui_prompt_
 | Workflow source `unavailable` or `recovering`, no known contribution | No new report | Unknown | None |
 
 Independent workflow execution keeps the pane working even after the parent agent settles or while another contribution waits for approval. Reasons are internal reducer values, not extra CLI fields. Missing workflow knowledge is never treated as an empty ready snapshot, so an unavailable provider can leave the last reported state unchanged until a ready snapshot arrives.
+
+Standalone subagents and background shell tasks also keep the pane working after the parent settles. The reporter reads the owner's task snapshot on activation and follows task events until shutdown. Reload reattaches to existing tasks; one task completing, failing, or being cancelled cannot clear another task's activity. Settled tasks retained in `/tasks` do not count as running. Children never claim the pane or overwrite the parent's session identity.
 
 A failed review or cleanup can leave a workflow outcome marked `blocked` after execution ends. That outcome remains inspectable and retains `needsAttention`, but does not by itself keep the pane red. A pending decision or exhausted budget still reports `blocked`; independent execution still reports `working`. Reporting `idle` neither acknowledges the failure nor resumes it. The parent session retains pane ownership until it exits, so a child stopping does not call `release-agent` for the parent.
 

--- a/packages/coding-agent/src/extensions/herdr/activity.ts
+++ b/packages/coding-agent/src/extensions/herdr/activity.ts
@@ -12,6 +12,7 @@ export interface SessionActivity {
 
 export interface SessionActivityInput {
 	agentRunning: boolean;
+	tasksRunning?: boolean;
 	openPromptCount: number;
 	roots: readonly WorkflowRootActivity[];
 	availability: "ready" | "recovering" | "unavailable";
@@ -20,7 +21,7 @@ export interface SessionActivityInput {
 export function deriveSessionActivity(input: SessionActivityInput): SessionActivity | undefined {
 	const working = input.roots.find((root) => root.state === "working");
 	const attention = input.roots.some((root) => root.needsAttention || root.state === "blocked");
-	if (working || (input.agentRunning && input.openPromptCount === 0)) {
+	if (working || input.tasksRunning || (input.agentRunning && input.openPromptCount === 0)) {
 		return {
 			state: "working",
 			reason: working?.reason ?? "executing",

--- a/packages/coding-agent/src/extensions/herdr/index.ts
+++ b/packages/coding-agent/src/extensions/herdr/index.ts
@@ -2,6 +2,7 @@ import { getExtensionContextOwner, publishExtensionContextEffect } from "../../c
 import type { ExtensionAPI, ExtensionContext, ExtensionFactory } from "../../core/extensions/types.ts";
 import type { WorkflowRootActivity } from "../../core/extensions/workflow-events.js";
 import { SettingsManager } from "../../core/settings-manager.ts";
+import { OwnerTaskStore } from "../../core/tasks/owner-store.js";
 import { deriveSessionActivity } from "./activity.js";
 import { captureHerdrEnvironment } from "./environment.js";
 import {
@@ -34,6 +35,8 @@ export function createHerdrExtension(options: HerdrExtensionOptions = {}): Exten
 		const ownsBinding = (ctx: ExtensionContext) =>
 			boundSessionManager !== undefined && getExtensionContextOwner(ctx) === boundRunner;
 		let lease: { dispose(): void } | undefined;
+		let taskStore: OwnerTaskStore | undefined;
+		let unsubscribeTasks: (() => void) | undefined;
 		let agentRunning = false;
 		let openPromptCount = 0;
 		let availability: "ready" | "unavailable" | "recovering" = "unavailable";
@@ -47,10 +50,12 @@ export function createHerdrExtension(options: HerdrExtensionOptions = {}): Exten
 			if (options.diagnostic) options.diagnostic(value);
 			else console.error(`[Herdr] ${value.kind}${value.owner ? `: deferring to ${value.owner}` : ""}`);
 		};
+		const tasksRunning = () => taskStore?.tasks.some((task) => task.execution.kind !== "settled") ?? false;
 		const report = () => {
 			if (!owner) return;
 			const activity = deriveSessionActivity({
 				agentRunning,
+				tasksRunning: tasksRunning(),
 				openPromptCount,
 				roots: [...roots.values()],
 				availability,
@@ -77,6 +82,10 @@ export function createHerdrExtension(options: HerdrExtensionOptions = {}): Exten
 			const current = ++generation;
 			lease?.dispose();
 			lease = undefined;
+			unsubscribeTasks?.();
+			taskStore?.dispose();
+			unsubscribeTasks = undefined;
+			taskStore = undefined;
 			openPromptCount = 0;
 			roots.clear();
 			availability = "unavailable";
@@ -91,6 +100,20 @@ export function createHerdrExtension(options: HerdrExtensionOptions = {}): Exten
 			}
 			owner = claimed;
 			agentRunning = !ctx.isIdle();
+			const taskHost = ctx.getAgentTaskHost?.();
+			if (taskHost) {
+				const { supervisor, owner: taskOwner } = taskHost.ownerBinding;
+				taskStore = new OwnerTaskStore(supervisor, taskOwner);
+				taskStore.connect();
+				let running = tasksRunning();
+				unsubscribeTasks = taskStore.subscribe(() => {
+					if (current !== generation) return;
+					const next = tasksRunning();
+					if (next === running) return;
+					running = next;
+					report();
+				});
+			}
 			lease = ctx.observeWorkflowActivity((frame) => {
 				if (current !== generation) return;
 				if (frame.kind === "snapshot") {
@@ -130,6 +153,10 @@ export function createHerdrExtension(options: HerdrExtensionOptions = {}): Exten
 			generation++;
 			lease?.dispose();
 			lease = undefined;
+			unsubscribeTasks?.();
+			taskStore?.dispose();
+			unsubscribeTasks = undefined;
+			taskStore = undefined;
 			const previous = owner;
 			owner = undefined;
 			// Clear before awaiting transport: a successor can bind while retirement drains,

--- a/packages/coding-agent/test/herdr-background-command.test.ts
+++ b/packages/coding-agent/test/herdr-background-command.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { createEventBus } from "../src/core/event-bus.js";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../src/core/extensions/loader.js";
+import { ExtensionRunner } from "../src/core/extensions/runner.js";
+import { noOpUIContext } from "../src/core/extensions/runner-ui.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { AgentTaskHost } from "../src/core/tasks/agent-adapter.js";
+import { createHerdrExtension } from "../src/extensions/herdr/index.js";
+import { arg, fakeHerdr } from "./helpers/herdr.js";
+
+// Supervised shell execution is currently a POSIX host path.
+test.runIf(process.platform !== "win32")("Herdr keeps a background shell working until native settlement", async () => {
+	const fake = await fakeHerdr();
+	const runtime = createExtensionRuntime();
+	const publisher = runtime.workflowActivityHub.registerWorkflowActivityPublisher();
+	publisher.publishSnapshot({ availability: "ready", roots: [] });
+	const session = SessionManager.inMemory();
+	const host = new AgentTaskHost({
+		scope: { kind: "session", sessionId: session.getSessionId() },
+		authorizeLaunch() {},
+	});
+	const extension = await loadExtensionFromFactory(
+		createHerdrExtension({ env: fake.env, enabled: () => true }),
+		fake.dir,
+		createEventBus(),
+		runtime,
+		"herdr",
+	);
+	const runner = new ExtensionRunner([extension], runtime, fake.dir, session, {} as never);
+	runner.bindTaskHost(() => host);
+	runner.setUIContext({ ...noOpUIContext }, "tui");
+	try {
+		await runner.emit({ type: "session_start" });
+		await fake.waitFor(1);
+		const { supervisor, owner } = host.ownerBinding;
+		const started = await supervisor.startCommandTask(
+			owner,
+			{ kind: "command", command: "cat", terminal: { kind: "pipe" } },
+			"shell",
+		);
+		assert.ok(started.ok);
+		const observed = await supervisor.initialObservation(started.value, { kind: "background" });
+		assert.ok(observed.ok && observed.value.kind === "yielded");
+		assert.equal(arg((await fake.waitFor(2))[1].args, "--state"), "working");
+		await runner.emit({ type: "agent_settled" });
+		assert.equal(arg((await fake.waitFor(3))[2].args, "--state"), "working");
+		const input = supervisor.taskStdin(started.value);
+		assert.ok(input.ok);
+		assert.ok((await supervisor.writeTaskInput(input.value, "eof", { kind: "eof" })).ok);
+		assert.equal(arg((await fake.waitFor(4))[3].args, "--state"), "idle");
+	} finally {
+		await runner.emit({ type: "session_shutdown", reason: "quit" });
+		runner.invalidate();
+		await host.close("session-close");
+		await fake.dispose();
+	}
+});

--- a/packages/coding-agent/test/herdr-subagents.test.ts
+++ b/packages/coding-agent/test/herdr-subagents.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import { createEventBus } from "../src/core/event-bus.js";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../src/core/extensions/loader.js";
+import { ExtensionRunner } from "../src/core/extensions/runner.js";
+import { noOpUIContext } from "../src/core/extensions/runner-ui.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { AgentTaskHost } from "../src/core/tasks/agent-adapter.js";
+import type { TaskResult } from "../src/core/tasks/contracts.js";
+import { deriveSessionActivity } from "../src/extensions/herdr/activity.js";
+import { createHerdrExtension } from "../src/extensions/herdr/index.js";
+import { arg, fakeHerdr } from "./helpers/herdr.js";
+
+test("independent subagents keep Herdr working while the parent is settled or awaiting approval", () => {
+	for (const availability of ["ready", "recovering", "unavailable"] as const) {
+		for (const openPromptCount of [0, 1]) {
+			assert.deepEqual(
+				deriveSessionActivity({
+					agentRunning: false,
+					tasksRunning: true,
+					openPromptCount,
+					roots: [],
+					availability,
+				}),
+				{ state: "working", reason: "executing" },
+			);
+		}
+	}
+});
+
+test("Herdr observes overlapping owner tasks and reattaches without losing running subagents", async () => {
+	const fake = await fakeHerdr();
+	const runtime = createExtensionRuntime();
+	const publisher = runtime.workflowActivityHub.registerWorkflowActivityPublisher();
+	publisher.publishSnapshot({ availability: "ready", roots: [] });
+	const session = SessionManager.inMemory();
+	const host = new AgentTaskHost({
+		scope: { kind: "session", sessionId: session.getSessionId() },
+		authorizeLaunch() {},
+	});
+	const extension = await loadExtensionFromFactory(
+		createHerdrExtension({ env: fake.env, enabled: () => true }),
+		fake.dir,
+		createEventBus(),
+		runtime,
+		"herdr",
+	);
+	const runner = new ExtensionRunner([extension], runtime, fake.dir, session, {} as never);
+	runner.bindTaskHost(() => host);
+	runner.setUIContext({ ...noOpUIContext }, "tui");
+	let finishFirst!: (result: TaskResult) => void;
+	let finishSecond!: (result: TaskResult) => void;
+	try {
+		await runner.emit({ type: "session_start" });
+		await fake.waitFor(1);
+		const first = await host.startAgentTask({ kind: "agent", agent: "first", task: "test" }, "first", () => ({
+			result: new Promise<TaskResult>((resolve) => {
+				finishFirst = resolve;
+			}),
+			cleanup: Promise.resolve({ kind: "reaped" }),
+		}));
+		assert.equal(first.ok, true);
+		assert.equal(arg((await fake.waitFor(2))[1].args, "--state"), "working");
+		const second = await host.startAgentTask({ kind: "agent", agent: "second", task: "test" }, "second", () => ({
+			result: new Promise<TaskResult>((resolve) => {
+				finishSecond = resolve;
+			}),
+			cleanup: Promise.resolve({ kind: "reaped" }),
+		}));
+		assert.equal(second.ok, true);
+		finishFirst({ kind: "failed", code: "test", message: "test" });
+		if (first.ok) await host.waitForTask(first.value.taskId);
+		await runner.emit({ type: "agent_settled" });
+		await runner.emit({ type: "session_shutdown", reason: "reload" });
+		const beforeReload = (await fake.calls()).filter((call) => call.phase === "end");
+		assert.equal(beforeReload.at(-1)?.args[1], "release-agent");
+		await runner.emit({ type: "session_start" });
+		const reloadCalls = await fake.waitFor(beforeReload.length + 1);
+		assert.equal(reloadCalls[beforeReload.length].args[1], "report-agent");
+		assert.equal(arg(reloadCalls[beforeReload.length].args, "--state"), "working");
+		for (const call of reloadCalls.slice(1).filter((call) => call.args[1] === "report-agent")) {
+			assert.equal(arg(call.args, "--state"), "working", "no false idle while the second task is running");
+		}
+		finishSecond({ kind: "cancelled", cause: "user" });
+		if (second.ok) await host.waitForTask(second.value.taskId);
+		await vi.waitFor(
+			async () => {
+				const calls = (await fake.calls()).filter((call) => call.phase === "end");
+				assert.ok(calls.length > reloadCalls.length);
+				assert.equal(arg(calls.at(-1)!.args, "--state"), "idle");
+			},
+			{ timeout: 5_000 },
+		);
+	} finally {
+		finishFirst?.({ kind: "cancelled", cause: "shutdown" });
+		finishSecond?.({ kind: "cancelled", cause: "shutdown" });
+		await runner.emit({ type: "session_shutdown", reason: "quit" });
+		runner.invalidate();
+		await host.close("session-close");
+		await fake.dispose();
+	}
+});


### PR DESCRIPTION
## Summary

Keep Herdr non-idle while Atomic-owned subagents or background shell tasks are running, even after the parent agent settles. Activity comes from Atomic's native task subscription, not terminal screen inference.

## Changes

- Include queued, running, and cancelling owner tasks in the existing Herdr activity reducer.
- Seed task activity from a snapshot, subscribe to changes, and reattach on reload. Dispose subscriptions on shutdown and fence stale callbacks.
- Report task activity only when the aggregate running state changes, avoiding reports for every progress event.
- Preserve parent pane ownership, workflow aggregation, approval reporting, and parent session identity.
- Add overlapping-subagent/reload regression coverage and a real supervised background-shell test; update user docs and changelog.

## Validation

- All 28 Herdr tests passed across 9 files.
- Root `npm run typecheck` passed; final coding-agent typecheck passed after the shell-task change.
- Biome checks and `git diff --check` passed.
- Tests exercise a fake Herdr CLI and real native task/shell execution. Live Herdr UI was not tested. The shell test follows the existing POSIX-only supervised shell path.

No breaking changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791497316&installation_model_id=10562&pr_number=2935&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2935&signature=76a9b39c049d590a6d1f6d2881402952646a3a2e31fabcdcc3fcabae840bfd7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61831175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/bastani-inc/-/pull-requests/bastani-inc/atomic/2935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

No confirmed blocking issue was found; the focused runtime path remains unverified in this checkout because its native dependency is unavailable.

What we checked:
- Validation checks were blocked because the required Atomic native binding is unavailable, preventing task launch. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- A base reducer check completed and showed the prior settled-parent behavior. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Focused tests were invoked for overlapping subagents, reload reattachment, parent settlement, and final task settlement, but the TaskSupervisor could not be constructed due to the missing native bindings. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details><summary><h3>Summary</h3></summary>

- ## T-Rex validation blocked
- The focused runtime checks for Herdr task activity could not complete because the required Atomic native binding is absent from this checkout. No confirmed issue was found in the changed code.
- This change extends Herdr activity aggregation to account for owner-scoped subagent and background shell tasks, preserves activity across reporter reloads, and adds focused regression coverage for overlapping tasks and task settlement.
</details>

<!-- /greptile_comment -->