### PR TITLE
fix(tasks): notify parent chat when subagents are stopped

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -86,6 +86,7 @@
 - Tree navigation rejects active compaction or branch summarization before replacing the current operation's UI, leaving the active branch intact ([#9179](https://github.com/earendil-works/pi/pull/9179)).
 - Radius login now prefers the discovered balanced model and falls back to the account's first available model after catalog refresh.
 - Direct steering and follow-up calls now run extension input handlers before queue admission, preserving transformed text/images and RPC input-source attribution while consuming handled inputs.
+- Fixed subagents stopped with `x` in `/tasks` failing to notify the parent chat. Running and queued cancellations now deliver their confirmed terminal receipt once, without requiring a final child response, duplicating completion notices, or overwriting an outcome that already settled.
 
 ## [0.9.19-alpha.1] - 2026-09-06
 

--- a/packages/coding-agent/docs/background-tasks.md
+++ b/packages/coding-agent/docs/background-tasks.md
@@ -106,6 +106,8 @@ Completion creates a shaded notification card in the owning chat without dependi
 
 The parent model also receives the result context. The internal receipt stays in structured message details, rather than becoming raw JSON in chat. The same persisted completion identity handles delivery retries without relaunching the child. Workflow completions remain in their owning stage chat, not the main conversation.
 
+Stopping a subagent through `/tasks` (`x`, then `y`) also delivers a **stopped** card and stop context to the parent model. The notice arrives after termination is confirmed, not while the task is merely **Stopping**, and does not require a final response from the child. Cancelling queued work notifies without starting it. Repeated stop requests or late child results do not duplicate the notice or overwrite the recorded outcome; a task that finished before cancellation keeps its actual result. Closing the owning session or workflow stage still suppresses late notices.
+
 Restored completions may have only an outcome and task identity if the original live task or transcript is unavailable. Atomic does not invent missing output. Excerpts are bounded; inspect retained history for more detail.
 
 Long titles and previews are truncated or wrapped within the card width. Its background covers the ellipsis, expand hint, and trailing padding on every row.

--- a/packages/coding-agent/docs/subagents.md
+++ b/packages/coding-agent/docs/subagents.md
@@ -33,6 +33,8 @@ Open live transcripts subscribe to child-session events, so streaming text and p
 
 Detail views pin task identity, state, available metrics, and the selected action while PageUp/PageDown scrolls the body. Recent activity shows up to five retained tool actions; errors and input requests appear explicitly. Left returns to the previous view. `x` requests cancellation without bypassing confirmation or configured task bindings. Shell inspection shows a bounded output tail with omission markers.
 
+After a confirmed `x` stop settles, the owning chat receives a visible **stopped** notification and the parent model receives the stop context, even if the child returns no final message. Repeated stops do not duplicate notifications or replace an already-recorded terminal result. Closing the owner still suppresses late completion delivery.
+
 ## Start with natural language
 
 Ask Atomic to coordinate subagents in plain language:

--- a/packages/coding-agent/src/core/tasks/supervisor.ts
+++ b/packages/coding-agent/src/core/tasks/supervisor.ts
@@ -73,6 +73,7 @@ type OwnerState = {
 	host: HostState;
 	tasks: Map<C.TaskId, TaskLease>;
 	watches: Set<TaskSubscription>;
+	settledTasks: Set<C.TaskId>;
 };
 type TaskState = {
 	native: native.TaskLease;
@@ -563,11 +564,17 @@ export class TaskSupervisor {
 				if (existing) return existing;
 				const owner = new OwnerCapability();
 				Object.freeze(owner);
-				this.#owners.set(owner, { native: lease, host: state, tasks: new Map(), watches: new Set() });
+				const ownerState: OwnerState = {
+					native: lease,
+					host: state,
+					tasks: new Map(),
+					watches: new Set(),
+					settledTasks: new Set(),
+				};
+				this.#owners.set(owner, ownerState);
 				this.#ownerIds.set(id, owner);
 				const watched = this.watchOwnerTasks(owner);
 				if (!watched.ok) throw new Error(watched.error.message);
-				const settledCommands = new Set<C.TaskId>();
 				watched.value.onReconcile = (projection) => {
 					if (projection.state === "closed") this.#ownerIds.delete(projection.ownerId);
 					for (const record of projection.tasks) {
@@ -584,27 +591,19 @@ export class TaskSupervisor {
 					let failure: Error | undefined;
 					for (const record of projection.tasks) {
 						if (
-							record.kind !== "command" ||
 							record.execution.kind !== "settled" ||
-							settledCommands.has(record.ref.taskId) ||
+							ownerState.settledTasks.has(record.ref.taskId) ||
 							!state.binding.onTaskSettled
 						)
 							continue;
 						try {
-							// The journal may have reset, and native setup may finish before its JS lease exists.
+							// Cancellation settles at cleanup (or while queued), without a runner outcome.
+							// Recover its authentic receipt even when the bounded journal has reset.
 							const task = this.#native.lookupTask(lease, record.ref.taskId);
 							if (!task.ok) throw new Error(task.error.message);
 							const settled = this.#native.taskSettlement(task.value);
 							if (!settled.ok) throw new Error(settled.error.message);
-							const receipt = settled.value;
-							// Mark before entering host code: reentrant drains and callback failures must not redeliver.
-							settledCommands.add(record.ref.taskId);
-							state.binding.onTaskSettled(record.ref, {
-								taskId: receipt.taskId as C.TaskId,
-								cursor: cursor(receipt.cursor),
-								result: taskResult(receipt.result),
-								completionId: receipt.completionId,
-							});
+							this.#notifyTaskSettled(ownerState, record.ref, settled.value);
 						} catch (error) {
 							failure ??= new Error(rejectionMessage(error));
 						}
@@ -616,6 +615,18 @@ export class TaskSupervisor {
 			},
 			ownerErrors,
 		);
+	}
+	#notifyTaskSettled(state: OwnerState, ref: C.NativeTaskRef, receipt: native.SettlementReceipt): void {
+		if (!state.host.binding.onTaskSettled || state.settledTasks.has(ref.taskId)) return;
+		// Runner outcomes and snapshot recovery share one delivery door. Mark before
+		// host code so reentrant drains or callback failures cannot redeliver.
+		state.settledTasks.add(ref.taskId);
+		state.host.binding.onTaskSettled(ref, {
+			taskId: receipt.taskId as C.TaskId,
+			cursor: cursor(receipt.cursor),
+			result: taskResult(receipt.result),
+			completionId: receipt.completionId,
+		});
 	}
 	async startCommandTask(
 		owner: OwnerLease,
@@ -752,14 +763,7 @@ export class TaskSupervisor {
 				.then((result) => {
 					return mapped(
 						this.#native.reportRunnerOutcome(runner.value, result),
-						(receipt) => {
-							state.host.binding.onTaskSettled?.(taskState.ref, {
-								taskId: receipt.taskId as C.TaskId,
-								cursor: cursor(receipt.cursor),
-								result: taskResult(receipt.result),
-								completionId: receipt.completionId,
-							});
-						},
+						(receipt) => this.#notifyTaskSettled(state, taskState.ref, receipt),
 						reportErrors,
 					);
 				});

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -164,6 +164,8 @@ Workflow invocations receive a stable, non-`default` Intercom group automaticall
 
 Background agents appear in the compact count below the prompt in main and workflow-stage chat. Run `/tasks` to open the grouped inspector; updates never open it automatically. Parallel receipts identify individual siblings. Completion produces a shaded notification card with outcome and available response preview, without depending on a model reply. `/agents` browses definitions, while `subagent({ action: "list" })` shows the catalog with the configured expand-key hint.
 
+To stop a task, select it in `/tasks`, press `x`, and confirm with `y`. Once termination is confirmed, the owning chat receives a stopped notification and the parent model receives the stop context, even when the child has no final response. Repeated stop requests do not duplicate the notice or change an already-settled result. Closing the owner still suppresses late notifications.
+
 You can ask naturally:
 
 ```text

--- a/test/integration/task-command-settlement.test.ts
+++ b/test/integration/task-command-settlement.test.ts
@@ -267,7 +267,12 @@ test.runIf(process.platform !== "win32").each(["completed", "cancelled"] as cons
 			value(await h.supervisor.closeTaskOwner(h.owner, "session-close"));
 			h.actor.disposeSubscription(h.journal.lease);
 		}
-		assert.equal(h.settlements.length, 1);
+		// Owner reconciliation also delivers the journal-noise agent's real teardown outcome.
+		assert.equal(h.settlements.length, 2);
+		assert.deepEqual(h.settlements[1], {
+			ref: value(h.actor.taskReference(noise)),
+			receipt: value(h.actor.taskSettlement(noise)),
+		});
 	},
 );
 

--- a/test/integration/task-completion-delivery.test.ts
+++ b/test/integration/task-completion-delivery.test.ts
@@ -4,16 +4,20 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { stripVTControlCharacters } from "node:util";
+import { getKeybindings, setKeybindings } from "@earendil-works/pi-tui";
 import { test, vi } from "vitest";
-import { getAgentTaskHost } from "../../packages/coding-agent/src/core/agent-session-tasks.js";
+import { closeSessionTasks, getAgentTaskHost } from "../../packages/coding-agent/src/core/agent-session-tasks.js";
+import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.js";
 import { SessionManager } from "../../packages/coding-agent/src/core/session-manager.js";
 import { AgentTaskHost } from "../../packages/coding-agent/src/core/tasks/agent-adapter.js";
 import { TaskCompletionOutbox } from "../../packages/coding-agent/src/core/tasks/completion.js";
-import type { OperationId, TaskResult } from "../../packages/coding-agent/src/core/tasks/contracts.js";
+import type { Cleanup, OperationId, TaskResult } from "../../packages/coding-agent/src/core/tasks/contracts.js";
+import { getOwnerTaskStore } from "../../packages/coding-agent/src/core/tasks/owner-store.js";
 import {
 	completionNoticeFromDetails,
 	TaskCompletionMessage,
 } from "../../packages/coding-agent/src/modes/interactive/components/task-completion-message.js";
+import { TaskInspector } from "../../packages/coding-agent/src/modes/interactive/components/task-inspector.js";
 import { initTheme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.js";
 
 // RFC PR #2884: task settlement is separate from persisted model delivery.
@@ -245,6 +249,117 @@ test("session completion delivers readable text once while preserving the receip
 		await session._taskCompletionOutbox?.flush();
 		assert.equal(sendCustomMessage.mock.calls.length, 1);
 	} finally {
+		await host.close("session-close");
+	}
+});
+
+test("confirmed inspector x stop notifies the parent once after cleanup, without a runner result", async () => {
+	initTheme("dark");
+	const previousKeys = getKeybindings();
+	setKeybindings(new KeybindingsManager());
+	const sessionManager = SessionManager.inMemory();
+	const sendCustomMessage = vi.fn(async () => {});
+	const session = { sessionManager, sendCustomMessage } as unknown as ThisParameterType<typeof getAgentTaskHost>;
+	const host = getAgentTaskHost.call(session);
+	const store = getOwnerTaskStore(session)!;
+	const inspector = new TaskInspector(
+		store,
+		() => {},
+		() => {},
+	);
+	const result = Promise.withResolvers<TaskResult>();
+	const cleanup = Promise.withResolvers<Cleanup>();
+	let signal: AbortSignal | undefined;
+	try {
+		const started = await host.startAgentTask(
+			{ kind: "agent", agent: "reviewer", task: "Review the stop path" },
+			"inspector-stop" as OperationId,
+			(context) => {
+				signal = context.signal;
+				return { result: result.promise, cleanup: cleanup.promise };
+			},
+		);
+		assert.ok(started.ok);
+		assert.ok((await host.observeAgentLaunch(started.value.taskId)).ok);
+		store.drain();
+		inspector.open(started.value.taskId);
+		inspector.handleInput("x");
+		assert.match(stripVTControlCharacters(inspector.render(100).join("\n")), /Review the stop path/);
+		assert.equal(signal?.aborted, false, "x alone must not cancel");
+		inspector.handleInput("n");
+		await Promise.resolve();
+		assert.equal(signal?.aborted, false, "declining confirmation keeps the child running");
+		inspector.handleInput("x");
+		inspector.handleInput("y");
+		await vi.waitFor(() => assert.equal(signal?.aborted, true));
+		assert.equal(signal?.reason, "user");
+		store.drain();
+		assert.equal(store.tasks[0].execution.kind, "cancelling");
+		assert.equal(sendCustomMessage.mock.calls.length, 0, "a stop request is not a terminal notification");
+		cleanup.resolve({ kind: "reaped" });
+		await vi.waitFor(() => {
+			store.drain();
+			assert.equal(store.tasks[0].execution.kind, "settled");
+		});
+		const terminal = { kind: "cancelled", cause: "user" };
+		assert.deepEqual(store.tasks[0].execution, { kind: "settled", result: terminal });
+		await vi.waitFor(() => assert.equal(sendCustomMessage.mock.calls.length, 1));
+		const [message, options] = sendCustomMessage.mock.calls[0] as unknown as Parameters<
+			ThisParameterType<typeof getAgentTaskHost>["sendCustomMessage"]
+		>;
+		assert.equal(message.customType, "task-completion");
+		assert.equal(message.display, true);
+		assert.equal(options?.triggerTurn, true, "the parent model also receives the stop context");
+		assert.match(String(message.content), /Subagent reviewer stopped: Review the stop path/);
+		assert.match(String(message.content), /Stop reason: user/);
+		assert.equal(completionNoticeFromDetails(message.details)?.status, "cancelled");
+		await session._taskCompletionOutbox!.flush();
+		const intents = sessionManager
+			.getEntries()
+			.filter((entry) => entry.type === "custom" && entry.customType === "task-completion-intent");
+		assert.equal(intents.length, 1);
+		assert.ok(intents[0].type === "custom");
+		assert.deepEqual((intents[0].data as { result: TaskResult }).result, terminal);
+		// A late result and repeated stop must neither replace cancellation nor redeliver it.
+		result.resolve({ kind: "failed", code: "LateResult", message: "arrived after stop" });
+		assert.ok((await host.cancelTask(started.value.taskId, "shutdown")).ok);
+		await host.close("session-close");
+		await session._taskCompletionOutbox!.flush();
+		store.drain();
+		assert.deepEqual(store.tasks[0].execution, { kind: "settled", result: terminal });
+		assert.equal(sendCustomMessage.mock.calls.length, 1);
+	} finally {
+		cleanup.resolve({ kind: "reaped" });
+		inspector.dispose();
+		store.dispose();
+		await host.close("session-close");
+		setKeybindings(previousKeys);
+	}
+});
+
+test("session closure still suppresses its children's cancellation notifications", async () => {
+	const sessionManager = SessionManager.inMemory();
+	const sendCustomMessage = vi.fn(async () => {});
+	const session = { sessionManager, sendCustomMessage } as unknown as ThisParameterType<typeof getAgentTaskHost>;
+	const host = getAgentTaskHost.call(session);
+	const result = Promise.withResolvers<TaskResult>();
+	try {
+		const started = await host.startAgentTask(
+			{ kind: "agent", agent: "reviewer", task: "Work until owner closes" },
+			"closed-owner" as OperationId,
+			() => ({ result: result.promise, cleanup: Promise.resolve({ kind: "reaped" }) }),
+		);
+		assert.ok(started.ok);
+		assert.ok((await host.observeAgentLaunch(started.value.taskId)).ok);
+		await closeSessionTasks.call(session);
+		await session._taskCompletionOutbox!.flush();
+		assert.deepEqual(
+			session._taskCompletionOutbox!.pending.map((entry) => entry.result),
+			[{ kind: "cancelled", cause: "owner-close" }],
+		);
+		assert.equal(sendCustomMessage.mock.calls.length, 0);
+	} finally {
+		getOwnerTaskStore(session)?.dispose();
 		await host.close("session-close");
 	}
 });

--- a/test/unit/task-agent-adapter.test.ts
+++ b/test/unit/task-agent-adapter.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import { AgentTaskHost } from "../../packages/coding-agent/src/core/tasks/agent-adapter.js";
 import type {
 	Cleanup,
 	OperationId,
+	SettlementReceipt,
 	TaskResult,
 	WaitPolicy,
 } from "../../packages/coding-agent/src/core/tasks/contracts.js";
@@ -258,3 +259,95 @@ for (const [label, policy, reason] of [
 		}
 	});
 }
+
+test("queued agent cancellation notifies once without dispatching a child", async () => {
+	const receipts: SettlementReceipt[] = [];
+	const owner = new AgentTaskHost({
+		scope: { kind: "session", sessionId: randomUUID() },
+		authorizeLaunch() {},
+		onTaskSettled: (_ref, receipt) => receipts.push(receipt),
+	});
+	let dispatch: (() => Promise<void>) | undefined;
+	let starts = 0;
+	try {
+		const started = await owner.startAgentTask(
+			intent,
+			operation(),
+			() => {
+				starts++;
+				throw new Error("cancelled queued child must not start");
+			},
+			(run) => {
+				dispatch = run;
+			},
+		);
+		assert.ok(started.ok);
+		assert.ok((await owner.observeAgentLaunch(started.value.taskId)).ok);
+		assert.ok((await owner.cancelTask(started.value.taskId, "user")).ok);
+		assert.ok(dispatch);
+		await dispatch();
+		await vi.waitFor(() => assert.equal(receipts.length, 1));
+		assert.equal(receipts[0].taskId, started.value.taskId);
+		assert.deepEqual(receipts[0].result, { kind: "cancelled", cause: "user" });
+		assert.ok((await owner.cancelTask(started.value.taskId, "shutdown")).ok);
+		assert.ok((await owner.close("session-close")).ok);
+		assert.equal(receipts.length, 1);
+		assert.equal(starts, 0);
+	} finally {
+		await owner.close("session-close");
+	}
+});
+
+test.each(["completed", "failed", "cancelled"] as const)(
+	"runner %s outcome is delivered once and survives a later stop",
+	async (kind) => {
+		const receipts: SettlementReceipt[] = [];
+		const owner = new AgentTaskHost({
+			scope: { kind: "session", sessionId: randomUUID() },
+			authorizeLaunch() {},
+			onTaskSettled: (_ref, receipt) => receipts.push(receipt),
+		});
+		const result = deferred<TaskResult>();
+		try {
+			const started = await owner.startAgentTask(intent, operation(), () => ({
+				result: result.promise,
+				cleanup: Promise.resolve({ kind: "reaped" }),
+			}));
+			assert.ok(started.ok);
+			assert.ok((await owner.observeAgentLaunch(started.value.taskId)).ok);
+			const terminal: TaskResult =
+				kind === "completed"
+					? {
+							kind,
+							output: {
+								ownerId: owner.ownerBinding.supervisor.taskReference(started.value.lease).ownerId,
+								taskId: started.value.taskId,
+								artifactId: "test-output",
+								byteCount: "0",
+								omittedRanges: [],
+							},
+						}
+					: kind === "failed"
+						? { kind, code: "TaskFailed", message: "Original failure" }
+						: { kind, cause: "parent-handoff" };
+			result.resolve(terminal);
+			await owner.waitForTask(started.value.taskId);
+			await vi.waitFor(() => assert.equal(receipts.length, 1));
+			const original = receipts[0];
+			assert.equal(original.taskId, started.value.taskId);
+			assert.deepEqual(original.result, terminal);
+			const cancelled = await owner.cancelTask(started.value.taskId, "user");
+			assert.ok(cancelled.ok);
+			assert.equal(cancelled.value.decision, "already-settled");
+			assert.deepEqual(await owner.waitForTask(started.value.taskId), {
+				ok: true,
+				value: { kind: "settled", taskId: started.value.taskId, result: terminal },
+			});
+			// Closure drains the owner snapshot too, exercising both delivery paths.
+			assert.ok((await owner.close("session-close")).ok);
+			assert.deepEqual(receipts, [original]);
+		} finally {
+			await owner.close("session-close");
+		}
+	},
+);


### PR DESCRIPTION
## Summary

Fix missing parent-chat notifications when a running subagent is stopped with `x` in `/tasks`. Cancellation settled in the native supervisor but bypassed the runner-outcome notification path.

## Changes

- Recover authoritative agent settlement receipts during owner reconciliation.
- Deduplicate recovered receipts against direct runner completions.
- Cover confirmed UI stops, queued cancellations, late results, and closed-owner suppression.
- Update task/subagent documentation and the changelog.

## Validation

- Regression reproduced before the fix using the real TaskInspector `x`/`y` flow.
- 146 unit tests passed across 25 focused files.
- 82 integration tests passed across 12 task files.
- `npm run check`, `git diff --check`, and commit hooks passed.
- Validated on macOS with controlled runners and the real UI component/native supervisor. No live-provider manual session or full-repository suite run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791500323&installation_model_id=10562&pr_number=2940&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2940&signature=ee50f646509ebaac77784b4b6cfb3328e52c99edc9e94189fecf38766b094d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61854295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/bastani-inc/-/pull-requests/bastani-inc/atomic/2940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

No merge-blocking defect was established. Windows-specific behavior still requires execution in Windows CI before release.

What we checked:
- The verification run completed, but local artifact references were not uploaded. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The Windows command builder validation workflow was examined, with the before/after logs and the validator script reviewed. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- A Windows process launch could not be executed due to a platform/toolchain blocker. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details><summary><h3>Summary</h3></summary>

- Adds Windows supervised-terminal support, configurable command shells, and explicit child-environment isolation.
- Updates native process lifecycle handling, command encoding, documentation, package metadata, and CI time limits.

## T-Rex validation blocked
- Native Windows launch and terminal behavior could not be exercised because the available environment is Linux and lacks a Windows runtime, Wine, PowerShell, and the MSVC `lib.exe` linker.
</details>

<!-- /greptile_comment -->