### PR TITLE
fix(workflows): stop freezing execution-owned stage output

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Workflow-stage `/tasks` now retains the shared compact picker and the stage's model, reasoning, cwd/branch, and MCP footer. Detail pages stay fullscreen. Task navigation no longer triggers the main-chat input notice, and pending-prompt notices clear when the graph hides, closes, or changes host.
 - Resume ended recoverable blocks through the existing continuation path rather than returning an unchanged snapshot as success. Non-resumable targets and unchanged blocked snapshots report no progress.
 - Settled failed or blocked runs retain attention without reporting an active user-decision wait to Herdr. Pending prompts and exhausted budgets remain blocked.
+- Stopped the workflow graph projection from retaining and deep-freezing a completed stage's structured result, and gave input defaulting a resolver-owned copy, so a stage's structured output can still be handed to a typed child workflow ([#2936](https://github.com/bastani-inc/atomic/issues/2936)).
 
 ## [0.9.19-alpha.1] - 2026-09-06
 

--- a/packages/workflows/src/runs/foreground/executor-inputs.ts
+++ b/packages/workflows/src/runs/foreground/executor-inputs.ts
@@ -19,9 +19,16 @@ export function resolveInputs(
 		if (value !== undefined) resolved[key] = value as WorkflowSerializableValue;
 	}
 
+	// `Value.Default` writes defaults straight into the value it is handed,
+	// nested objects included, so it must never see caller-owned references —
+	// a graph observer may have deep-frozen them. `Value.Clone` deep-copies
+	// plain objects and arrays and returns anything else (Date, Map, class
+	// instances, functions) by reference, so non-serializable inputs still
+	// reach `validateInputs` unchanged and are still rejected there.
+	const ownedInputs = Value.Clone(resolved);
 	const withDefaults = Value.Default(
 		Type.Object(schema as Record<string, TSchema>, { additionalProperties: true }),
-		resolved,
+		ownedInputs,
 	) as Record<string, WorkflowSerializableValue>;
 	for (const [key, value] of Object.entries(withDefaults)) {
 		if (value !== undefined) resolved[key] = value;

--- a/packages/workflows/src/shared/graph-store-snapshot.ts
+++ b/packages/workflows/src/shared/graph-store-snapshot.ts
@@ -128,6 +128,11 @@ function compactStage(stage: StageSnapshot): StageSnapshot {
 		// for status surfaces while the bounded full payload below backs the
 		// read-only detail view.
 		result: _result,
+		// `structured` aliases the object the executor handed back to author
+		// code, and this projection is deep-frozen below. Re-exporting it would
+		// freeze execution-owned state that a later stage still has to mutate.
+		// `store.snapshot()` and durable checkpoints keep the complete value.
+		structured: _structured,
 		...metadata
 	} = stage;
 	return {

--- a/test/unit/executor-phase-c.test.ts
+++ b/test/unit/executor-phase-c.test.ts
@@ -377,6 +377,34 @@ describe("executor input resolution — Phase C", () => {
 			/ctx\.workflow\(definition\) requires a workflow definition produced by workflow\(\{\.\.\.\}\); hand-rolled __piWorkflow objects are not supported/,
 		);
 	});
+
+	// Regression: https://github.com/bastani-inc/atomic/issues/2936
+	test("graph observation leaves a completed stage's structured output usable as child inputs", () => {
+		const store = createStore();
+		const setup = { summaryMarkdown: "saved setup" };
+		store.recordRunStart({
+			id: "run-handoff",
+			name: "handoff",
+			inputs: {},
+			status: "running",
+			stages: [
+				{
+					id: "setup",
+					name: "setup",
+					status: "completed",
+					parentIds: [],
+					toolEvents: [],
+					structured: setup,
+				},
+			],
+			startedAt: Date.now(),
+		});
+
+		store.graphSnapshot();
+
+		const resolved = resolveInputs({ setup: Type.Object({ summaryMarkdown: Type.String() }) }, { setup });
+		assert.deepEqual(resolved.setup, { summaryMarkdown: "saved setup" });
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/executor-resolve-inputs.test.ts
+++ b/test/unit/executor-resolve-inputs.test.ts
@@ -34,6 +34,33 @@ describe("resolveInputs", () => {
 		const result = resolveInputs({ prompt: Type.String() }, { prompt: "hello" });
 		assert.equal(result.prompt, "hello");
 	});
+
+	// Regression: https://github.com/bastani-inc/atomic/issues/2936
+	test("applies nested defaults to a resolver-owned copy of a frozen input", () => {
+		const setup = Object.freeze({
+			summaryMarkdown: "saved setup",
+			artifacts: Object.freeze([Object.freeze({ path: "report.md" })]),
+		});
+
+		const resolved = resolveInputs(
+			{
+				setup: Type.Object({
+					summaryMarkdown: Type.String(),
+					mode: Type.String({ default: "plan" }),
+					artifacts: Type.Array(Type.Object({ path: Type.String(), kind: Type.String({ default: "file" }) })),
+				}),
+			},
+			{ setup },
+		);
+
+		assert.deepEqual(resolved.setup, {
+			summaryMarkdown: "saved setup",
+			mode: "plan",
+			artifacts: [{ path: "report.md", kind: "file" }],
+		});
+		assert.notStrictEqual(resolved.setup, setup);
+		assert.deepEqual(setup, { summaryMarkdown: "saved setup", artifacts: [{ path: "report.md" }] });
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/store-payload-observation.test.ts
+++ b/test/unit/store-payload-observation.test.ts
@@ -291,6 +291,35 @@ describe("payload-bounded store observation", () => {
 		assert.equal(Object.isFrozen(snapshot.runs[0]!.stages[0]!), true);
 	});
 
+	// Regression: https://github.com/bastani-inc/atomic/issues/2936
+	test("keeps execution-owned structured stage output out of the frozen graph projection", () => {
+		const store = createStore();
+		const structured = { summaryMarkdown: "setup summary", artifacts: [{ path: "report.md" }] };
+		store.recordRunStart({
+			id: "run-structured",
+			name: "structured",
+			inputs: {},
+			status: "running",
+			stages: [
+				{
+					id: "setup-stage",
+					name: "setup-stage",
+					status: "completed",
+					parentIds: [],
+					toolEvents: [],
+					structured,
+				},
+			],
+			startedAt: Date.now(),
+		});
+
+		const graph = store.graphSnapshot();
+		assert.equal(graph.runs[0]?.stages[0]?.structured, undefined);
+		assert.equal(Object.isFrozen(structured), false);
+		assert.equal(Object.isFrozen(structured.artifacts[0]), false);
+		assert.deepEqual(store.snapshot().runs[0]?.stages[0]?.structured, structured);
+	});
+
 	test("isolates invalidation and snapshot subscribers from listener failures", () => {
 		const store = createStore();
 		const calls: string[] = [];


### PR DESCRIPTION
## Summary

- `compactStage()` re-exported the live `StageSnapshot.structured` reference through `...metadata`, and `createGraphStoreSnapshot()` deep-froze it — freezing the object the executor had handed back to workflow author code. Graph observation is read-only by contract, and the graph widget requests snapshots on its own, so no user interaction was needed to trigger it.
- `resolveInputs()` then passed that still-shared object to TypeBox `Value.Default`, which executes `value[key] = propertyValue` unconditionally (`typebox/build/value/default/from_object.mjs:20`), so forwarding a completed stage's structured output into a typed child workflow failed with `TypeError: Cannot assign to read only property '<key>' of object '#<Object>'`.
- `compactStage` now drops `structured` alongside `result`. No graph consumer reads it: `graphSnapshot()` callers use only run id/status and the activity projection, while durable checkpoints (`durable/dbos-envelope.ts`, `durable/stage-topology.ts`) and full inspection (`store.snapshot()`, `cloneStage`) read the live store objects and keep the complete value.
- `resolveInputs` now applies defaults to `Value.Clone(resolved)`. `Value.Clone` deep-copies plain objects and arrays but returns class instances, `Date`s and functions by reference, so non-serializable inputs still reach `validateInputs` and are still rejected there — `structuredClone` would have turned a class instance into a plain object and silently made those inputs valid.

Closes #2936

## Validation

- `npx vitest --run --project unit test/unit/store-payload-observation.test.ts test/unit/executor-resolve-inputs.test.ts test/unit/executor-phase-c.test.ts` — the three new regression tests fail on `main` (two with the exact `TypeError`) and pass with this change.
- `npx vitest --run --project unit test/unit/validate-inputs.test.ts test/unit/workflow-tool-detail.test.ts test/unit/executor-run-1.test.ts test/unit/executor-run-2.test.ts` plus the three files above — 122/122 pass.
- `npm run check` — pass.
- `npm run test:unit` — the same 43 pre-existing failures occur with and without this change on the same Windows workstation (stale `@earendil-works/pi-tui` `setLayoutRoot`, live-child test timeouts, Windows temp-path/`jiti` resolution, one `EPERM`); none are in the workflows store or executor suites.
- Not validated: `npm run test:integration`, and no packaged-runtime install or live-run recovery was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791500616&installation_model_id=10562&pr_number=2941&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2941&signature=a9416e167180579216a0ff1401157f1fa42741a0380841309c1be945e356637a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61855853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/bastani-inc/-/pull-requests/bastani-inc/atomic/2941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: the completed-stage handoff works after graph observation, preserves durable output, and leaves execution-owned data mutable.

What we checked:
- Validated the historical frozen-output regression test and the completed-stage handoff regression test, confirming the expected TypeError when applying defaults to a frozen nested value and that graph projection omits structured while the snapshot retains it. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Observed the graph-snapshot-structured-handoff tests (02-after and 01-before) passed with exit code 0, confirming the intended behavior for graph projection, snapshot preservation, and copied-objects defaults across nested structures. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details><summary><h3>Summary</h3></summary>

- This change prevents read-only workflow graph observation from freezing execution-owned structured stage output. Completed-stage data remains available in full snapshots and can be passed to typed child inputs, where defaults are applied to a resolver-owned copy without changing the original value.
</details>

<!-- /greptile_comment -->