### PR TITLE
fix(herdr): acknowledge workflow blocks on user input

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Fixed
 
+- Fixed Herdr turning red again after every response for an already-observed workflow block. Interactive messages now acknowledge existing pane attention without resuming workflows; new blocks and open approval prompts still report blocked.
 - Prevented internal-URL shell expansion from turning quoted paths into executable syntax. Expansion now rejects commands containing quotes, substitutions, escapes, heredocs or other non-plain syntax; bare URLs remain safely quoted, and commands without resolved URLs are unchanged.
 - Fixed Herdr reporting idle while standalone subagents or background shell tasks are running. The parent reporter now observes owner-scoped task activity and reattaches on reload, retaining working status until all tasks settle without granting children pane ownership.
 - Open subagent transcripts now refresh from live session events, including streaming text and partial/final tool results. Shell transcript reads coalesce pending state updates instead of requiring the view to be reopened.

--- a/packages/coding-agent/docs/herdr.md
+++ b/packages/coding-agent/docs/herdr.md
@@ -17,7 +17,7 @@ The reporter captures these values on activation, not at module import. It runs 
 
 ## States and reasons
 
-The reporter uses `agent_start`, `agent_settled`, `ui_prompt_start`, `ui_prompt_end`, the owning session's task subscription, and its `observeWorkflowActivity` stream. It does not infer execution from screen text or use `agent_end` as the idle boundary.
+The reporter uses interactive `input`, `agent_start`, `agent_settled`, `ui_prompt_start`, `ui_prompt_end`, live `workflow_lifecycle` events, the owning session's task subscription, and its `observeWorkflowActivity` stream. It does not infer execution from screen text or use `agent_end` as the idle boundary.
 
 Quiet work is still work: waiting for a provider response, tool completion, retry backoff, or another automatic continuation does not become `idle` because output stops. Repeated output-cap continuations remain part of the same owning prompt until the entire chain finishes. Reporting is lifecycle-driven, with no inactivity-to-idle timer or heartbeat requirement.
 
@@ -38,6 +38,8 @@ Independent workflow execution keeps the pane working even after the parent agen
 Standalone subagents and background shell tasks also keep the pane working after the parent settles. The reporter reads the owner's task snapshot on activation and follows task events until shutdown. Reload reattaches to existing tasks; one task completing, failing, or being cancelled cannot clear another task's activity. Settled tasks retained in `/tasks` do not count as running. Children never claim the pane or overwrite the parent's session identity.
 
 A failed review or cleanup can leave a workflow outcome marked `blocked` after execution ends. That outcome remains inspectable and retains `needsAttention`, but does not by itself keep the pane red. A pending decision or exhausted budget still reports `blocked`; independent execution still reports `working`. Reporting `idle` neither acknowledges the failure nor resumes it. The parent session retains pane ownership until it exits, so a child stopping does not call `release-agent` for the parent.
+
+Sending a message acknowledges currently observed workflow blocks for the pane indicator only. The next settled response can return to `idle` instead of repeatedly turning red for the same block; workflow states and budget approvals are not changed. Repeated activity snapshots do not re-arm that attention. A changed workflow activity or a new live block/prompt does, and open approval widgets remain blocking until answered. Extension-generated messages and automatic agent starts do not acknowledge blocks. This acknowledgement is local to the reporter and resets on reload or restart.
 
 Opening or closing the host-owned `/tasks` inspector or the `/agents` catalog is navigation and does not emit an approval span or change Herdr activity. Genuine extension approval prompts still report `blocked`. This follows [Herdr's custom-agent contract](https://herdr.dev/docs/integrations/#integrate-your-own-agent), which defines `blocked` as needing a user decision. [Prime Agent's reporter](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/src/core/extensions/builtin/herdr-agent-state.ts) likewise observes explicit block notifications. Atomic retains its settled-event and workflow aggregation instead of copying Prime's retry grace timers.
 

--- a/packages/coding-agent/src/extensions/herdr/index.ts
+++ b/packages/coding-agent/src/extensions/herdr/index.ts
@@ -41,6 +41,20 @@ export function createHerdrExtension(options: HerdrExtensionOptions = {}): Exten
 		let openPromptCount = 0;
 		let availability: "ready" | "unavailable" | "recovering" = "unavailable";
 		const roots = new Map<string, WorkflowRootActivity>();
+		const acknowledgedBlocks = new Map<string, WorkflowRootActivity>();
+		const updateRoot = (root: WorkflowRootActivity) => {
+			const acknowledged = acknowledgedBlocks.get(root.rootRunId);
+			if (
+				acknowledged &&
+				(root.state !== acknowledged.state ||
+					root.reason !== acknowledged.reason ||
+					root.actionableBlockCount !== acknowledged.actionableBlockCount ||
+					root.activeExecutionCount !== acknowledged.activeExecutionCount ||
+					root.needsAttention !== acknowledged.needsAttention)
+			)
+				acknowledgedBlocks.delete(root.rootRunId);
+			roots.set(root.rootRunId, root);
+		};
 		const seenDiagnostics = new Set<string>();
 		let generation = 0;
 		const diagnostic = (value: HerdrDiagnostic) => {
@@ -57,7 +71,7 @@ export function createHerdrExtension(options: HerdrExtensionOptions = {}): Exten
 				agentRunning,
 				tasksRunning: tasksRunning(),
 				openPromptCount,
-				roots: [...roots.values()],
+				roots: [...roots.values()].filter((root) => !acknowledgedBlocks.has(root.rootRunId)),
 				availability,
 			});
 			if (activity) reportPaneActivity(owner, activity);
@@ -88,6 +102,7 @@ export function createHerdrExtension(options: HerdrExtensionOptions = {}): Exten
 			taskStore = undefined;
 			openPromptCount = 0;
 			roots.clear();
+			acknowledgedBlocks.clear();
 			availability = "unavailable";
 			const claimed = await claimPaneReporting(
 				environment,
@@ -119,13 +134,41 @@ export function createHerdrExtension(options: HerdrExtensionOptions = {}): Exten
 				if (frame.kind === "snapshot") {
 					availability = frame.availability;
 					roots.clear();
-					if (frame.availability === "ready") for (const root of frame.roots) roots.set(root.rootRunId, root);
-				} else if (frame.kind === "changed") roots.set(frame.root.rootRunId, frame.root);
-				else roots.delete(frame.rootRunId);
+					if (frame.availability === "ready") {
+						for (const root of frame.roots) updateRoot(root);
+						for (const id of acknowledgedBlocks.keys()) if (!roots.has(id)) acknowledgedBlocks.delete(id);
+					}
+				} else if (frame.kind === "changed") updateRoot(frame.root);
+				else {
+					roots.delete(frame.rootRunId);
+					acknowledgedBlocks.delete(frame.rootRunId);
+				}
 				report();
 			});
 		};
 		pi.on("session_start", (_event, ctx) => publishExtensionContextEffect(ctx, () => start(ctx)));
+		pi.on("input", (event, ctx) => {
+			if (!ownsBinding(ctx) || event.source !== "interactive") return;
+			let changed = false;
+			for (const root of roots.values()) {
+				if (root.state === "blocked" && !acknowledgedBlocks.has(root.rootRunId)) {
+					acknowledgedBlocks.set(root.rootRunId, { ...root });
+					changed = true;
+				}
+			}
+			if (changed) report();
+		});
+		pi.on("workflow_lifecycle", (event, ctx) => {
+			if (!ownsBinding(ctx) || event.delivery !== "live") return;
+			const target = event.target;
+			const newBlock =
+				target.kind === "prompt"
+					? target.status === "opened"
+					: (target.kind === "run" || target.kind === "stage") &&
+						(target.status === "blocked" || target.status === "awaiting_input") &&
+						target.previousStatus !== target.status;
+			if (newBlock && acknowledgedBlocks.delete(event.rootRunId)) report();
+		});
 		pi.on("agent_start", (_event, ctx) => {
 			if (!ownsBinding(ctx)) return;
 			agentRunning = true;

--- a/packages/coding-agent/test/herdr-acknowledgement.test.ts
+++ b/packages/coding-agent/test/herdr-acknowledgement.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+import { createEventBus } from "../src/core/event-bus.js";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../src/core/extensions/loader.js";
+import { ExtensionRunner } from "../src/core/extensions/runner.js";
+import { noOpUIContext } from "../src/core/extensions/runner-ui.js";
+import type { WorkflowRootActivity } from "../src/core/extensions/workflow-events.js";
+import { SessionManager } from "../src/core/session-manager.js";
+import { createHerdrExtension } from "../src/extensions/herdr/index.js";
+import { arg, fakeHerdr } from "./helpers/herdr.js";
+
+test("interactive input acknowledges old workflow blocks without suppressing fresh blocks or approvals", async () => {
+	const fake = await fakeHerdr();
+	const runtime = createExtensionRuntime();
+	const publisher = runtime.workflowActivityHub.registerWorkflowActivityPublisher();
+	const root: WorkflowRootActivity = {
+		rootRunId: "run",
+		ownerSessionId: "owner",
+		state: "blocked",
+		reason: "manual_intervention",
+		activeExecutionCount: 0,
+		actionableBlockCount: 1,
+		needsAttention: true,
+	};
+	publisher.publishSnapshot({ availability: "ready", roots: [root] });
+	const extension = await loadExtensionFromFactory(
+		createHerdrExtension({ env: fake.env, enabled: () => true }),
+		fake.dir,
+		createEventBus(),
+		runtime,
+		"herdr",
+	);
+	const runner = new ExtensionRunner([extension], runtime, fake.dir, SessionManager.inMemory(), {} as never);
+	runner.setUIContext({ ...noOpUIContext }, "tui");
+	const expectState = async (state: string) => {
+		await vi.waitFor(async () => {
+			const calls = (await fake.calls()).filter((call) => call.phase === "end");
+			assert.equal(arg(calls.at(-1)?.args ?? [], "--state"), state);
+		});
+	};
+	try {
+		await runner.emit({ type: "session_start" });
+		await expectState("blocked");
+		await runner.emitInput("notice", undefined, "extension");
+		await runner.emit({ type: "agent_start" });
+		await expectState("working");
+		await runner.emit({ type: "agent_settled" });
+		await expectState("blocked");
+		await runner.emitInput("continue here", undefined, "interactive");
+		await expectState("idle");
+		publisher.publishSnapshot({ availability: "ready", roots: [{ ...root }] });
+		await runner.emit({ type: "agent_start" });
+		await expectState("working");
+		await runner.emit({ type: "agent_settled" });
+		await expectState("idle");
+		await runner.emit({ type: "ui_prompt_start" });
+		await expectState("blocked");
+		await runner.emitInput("another message", undefined, "interactive");
+		await runner.emit({ type: "ui_prompt_end" });
+		await expectState("idle");
+		publisher.publishChanged({ ...root, state: "working", reason: "executing", activeExecutionCount: 1 });
+		await expectState("working");
+		publisher.publishChanged({ ...root });
+		await expectState("blocked");
+		await runner.emitInput("acknowledged", undefined, "interactive");
+		await expectState("idle");
+		await runner.emit({
+			type: "workflow_lifecycle",
+			cursor: { epoch: "test", revision: 2 },
+			eventId: "new-prompt",
+			runId: "run",
+			rootRunId: "run",
+			ownerSessionId: "owner",
+			occurredAt: 1,
+			observedAt: 1,
+			delivery: "live",
+			target: { kind: "prompt", runId: "run", promptId: "second", status: "opened" },
+		});
+		await expectState("blocked");
+	} finally {
+		await runner.emit({ type: "session_shutdown", reason: "quit" });
+		runner.invalidate();
+		publisher.dispose();
+		await fake.dispose();
+	}
+});


### PR DESCRIPTION
## Summary

Stop Herdr turning red again after every response because an old workflow remains blocked. An interactive user message now acknowledges existing workflow blocks for the pane indicator without resuming workflows or overriding budget approvals.

## Changes

- Track acknowledged blocked roots in the reporter and ignore unchanged repeated activity snapshots.
- Re-arm attention on semantic activity changes and new live workflow block/prompt events.
- Preserve blocking approval widgets and working-state precedence. Background extension messages and automatic agent starts do not acknowledge blocks.
- Document that acknowledgement is reporter-local and resets on reload/restart.

## Validation

- New regression reproduced the missing idle report before the fix.
- 21 tests across eight focused Herdr suites passed, including user input/settlement, extension notices, repeated snapshots, fresh blocks, and live prompts.
- `npm run check`, scoped Biome, and `git diff --check` passed.
- `npm run build` passed.

Windows and an actual Herdr pane were not exercised. Tests use the real extension runner with a fake Herdr executable. Workflow aggregate roots have no individual block IDs, so semantic activity changes and live lifecycle events re-arm attention.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791503540&installation_model_id=10562&pr_number=2945&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2945&signature=5782248123c1302769b62167ac3e14641b54c530492750c3b14e3bb3199d98e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61874569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/bastani-inc/-/pull-requests/bastani-inc/atomic/2945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Not safe to merge: recovery can leave newly restored actionable workflow blocks unreported in the Herdr pane.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Reset recovery acknowledgements** <a href="https://github.com/bastani-inc/atomic/pull/2945#discussion_r3963347516">▶</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/src/extensions/herdr/index.ts:47-54
During same-session recovery, `acknowledgedBlocks` survives the recovery snapshot. When a newly restored prompt or budget block has the same state, reason, counts, and attention flag as the previously acknowledged block, `updateRoot` retains that acknowledgement. The later reporting path filters the restored block out, so the pane can remain idle despite fresh actionable work until another aggregate field changes. Clear acknowledgements during recovery or identify them by lifecycle instance so restored work cannot inherit an earlier acknowledgement.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Same-session recovery can keep an old acknowledgement attached to a newly restored workflow block when its aggregate fields are unchanged.
- This can leave fresh actionable work hidden from the Herdr pane until another state field changes.

## T-Rex validation blocked

- The focused recovery regression could not begin because the workspace package `@bastani/pi-ai` could not be resolved before tests registered.
</details>

<!-- /greptile_comment -->