### PR TITLE
docs(release): prepare 0.9.19-alpha.2 changelogs

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
+## [0.9.19-alpha.2] - 2026-09-08
+
 ### Fixed
 
 - Fixed Anthropic Messages tool requests advertising root object-union parameter schemas without fields by projecting their branch fields into Anthropic-compatible object schemas ([#2190](https://github.com/bastani-inc/atomic/pull/2190) by [@elefthei](https://github.com/elefthei)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.2] - 2026-09-08
+
 ### Added
 
 - Added host-side workflow activity observation with ordered snapshots, publisher epochs, bounded observer queues and diagnostics, plus workflow_lifecycle, workflow_activity_changed, workflow_stage_completed, and workflow_heartbeat extension hooks typed as `WorkflowLifecycleEvent`, `WorkflowActivityChangedEvent`, `WorkflowStageCompletedEvent`, and `WorkflowHeartbeatEvent`. Initialization-time publications are retained until runner binding. Publisher and observer leases are fenced on reload, including pending hook handlers when an earlier handler is awaiting. Workflow runtime publication is a separate integration ([#2891](https://github.com/bastani-inc/atomic/issues/2891)).

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.19-alpha.2] - 2026-09-08
+
 ### Breaking Changes
 
 - Removed the model-facing `retryToken` parameter and result field. Callers must stop carrying tokens between calls; Intercom now owns bounded reconnect retries. Each new call remains a distinct operation, including identical messages.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.19-alpha.2] - 2026-09-08
+
 ### Fixed
 
 - MCP call headers now identify the server before results arrive, including pending direct tools and gateway calls with explicit or unambiguous targets.

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.2] - 2026-09-08
+
 ### Added
 
 - Added replay-safe model and reasoning activity reports and retained model and thinking fields on task snapshots, including settled tasks.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.2] - 2026-09-08
+
 ### Added
 
 - Added `/agents` to browse and filter effective agent definitions by source, with model, tool, description, and prompt details.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.19-alpha.2] - 2026-09-08
+
 ### Added
 
 - Connected workflow activity to the host extension observer stream, independently of lifecycle-notification settings and attribution filters. Root activity is projected from workflow snapshots plus run-qualified runtime execution ownership: nested runs fold into full root replacements; independent execution is distinguished from human waits; runnable handoffs, retries, stop draining, pauses, and acknowledged failures are accounted for without treating historical running stages as execution. Tool-only execution, parallel human-input waits, pause, cancellation drain, and unresolved failures publish root activity replacements; late attachment receives current state, and durable hydration announces recovering before ready. Typed lifecycle hooks cover run, stage, tool, prompt, and control transitions with canonical nested identities; successful-stage completion hooks exclude failed/skipped outcomes, explicit execution replay is tagged, and restored history creates no synthetic completions. Heartbeat hooks follow the existing configured cadence without adding timers or graph nodes. Because the workflows extension publishes root activity to the host, Atomic's built-in Herdr reporter reflects workflow execution and human-input waits in the owning pane; the end-to-end path is covered by an integration test against a fake Herdr CLI ([#2891](https://github.com/bastani-inc/atomic/issues/2891)).


### PR DESCRIPTION
## Summary

Prepare the seven package changelogs for prerelease 0.9.19-alpha.2. Existing notes and released history are preserved.

## Validation

- Bun validation passed for the exact seven-file changelog-only diff, unique release headings, and unchanged existing content.
- All eight release-base package manifests and workspace lock entries remain at 0.0.0.
- git diff --check and Bun shrinkwrap validation passed.
- The initial manifest glob included nested example fixtures; the corrected release-base scope passed without modifying those fixtures.

## Notes

No manifests, lockfiles, Cargo files, or generated version files changed. Only scripts/cut-release.ts may stamp the detached Release commit after merge. This PR does not merge, tag, publish, or dispatch publication.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791513199&installation_model_id=10562&pr_number=2950&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2950&signature=f839bd1e96204ade522c3dee16e62f4b2e8f60ffc2fe9dbc88e9433f06061492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61921694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/bastani-inc/-/pull-requests/bastani-inc/atomic/2950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: the changelog updates consistently preserve the intended release-note structure and content.

What we checked:
- Compared the base and updated changelogs for all seven changed packages and confirmed each file has an empty Unreleased section followed by a 0.9.19-alpha.2 heading dated 2026-09-08. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Verified the pending notes were preserved byte-for-byte and that content outside the inserted heading and blank line remained unchanged. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validation completed successfully for all changed changelogs. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Captured that the only head additions are the required release heading and a blank line in each changed changelog. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Ran the runtime validator and confirmed exit code 0 with PASS for every changed changelog, with the after-state output produced. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details><summary><h3>Summary</h3></summary>

- Prepared `0.9.19-alpha.2` release sections in the seven affected package changelogs.
- The pending release notes were preserved, each changelog retains an empty Unreleased section, and prior release history is unchanged.
- Safe to merge.
</details>

<!-- /greptile_comment -->