### PR TITLE
fix(tasks): preserve native supervisor construction in emitted JS

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `Failed to initialize class constructor` when npm-installed Node sessions create multiple task supervisors, preventing shell commands and subagent launches from failing during task-host initialization.
+
 ## [0.9.19-alpha.2] - 2026-09-08
 
 ### Added

--- a/packages/coding-agent/docs/herdr.md
+++ b/packages/coding-agent/docs/herdr.md
@@ -79,6 +79,10 @@ The reporter invokes the CLI directly with an argument array, not a shell. It pe
 
 Only the fixed messages in the table are sent. Prompt titles, tool arguments, provider error bodies, transcripts, and workflow outputs are not forwarded. The parent's session ID and, when available, native absolute session path accompany reports until the first successful CLI delivery per claim, using `--agent-session-id` and `--agent-session-path`. Later reports in that claim omit these flags. This is not a once-per-claim attempt: after a transport failure, later activity retries that identity; no retry timer is added. Child sessions do not replace that identity.
 
+## Troubleshooting task initialization
+
+If an npm-installed Atomic reports `Failed to initialize class constructor` when starting shell commands or subagents, the failure is in native task-host initialization, not the Herdr CLI. The reporter also reads that task host during activation. Affected builds construct the first supervisor but fail on subsequent instances in the same process. Use a release containing the task-supervisor construction fix and restart Atomic; changing Herdr settings does not repair that initialization failure.
+
 ## Compatibility
 
 The reporter is tested against Herdr **0.8.2 (protocol 20)**; that is the minimum supported release. The rows below record the observed CLI and server behaviour the reporter is built on, and how Atomic responds.

--- a/packages/coding-agent/docs/herdr.md
+++ b/packages/coding-agent/docs/herdr.md
@@ -79,10 +79,6 @@ The reporter invokes the CLI directly with an argument array, not a shell. It pe
 
 Only the fixed messages in the table are sent. Prompt titles, tool arguments, provider error bodies, transcripts, and workflow outputs are not forwarded. The parent's session ID and, when available, native absolute session path accompany reports until the first successful CLI delivery per claim, using `--agent-session-id` and `--agent-session-path`. Later reports in that claim omit these flags. This is not a once-per-claim attempt: after a transport failure, later activity retries that identity; no retry timer is added. Child sessions do not replace that identity.
 
-## Troubleshooting task initialization
-
-If an npm-installed Atomic reports `Failed to initialize class constructor` when starting shell commands or subagents, the failure is in native task-host initialization, not the Herdr CLI. The reporter also reads that task host during activation. Affected builds construct the first supervisor but fail on subsequent instances in the same process. Use a release containing the task-supervisor construction fix and restart Atomic; changing Herdr settings does not repair that initialization failure.
-
 ## Compatibility
 
 The reporter is tested against Herdr **0.8.2 (protocol 20)**; that is the minimum supported release. The rows below record the observed CLI and server behaviour the reporter is built on, and how Atomic responds.

--- a/packages/coding-agent/src/core/tasks/supervisor.ts
+++ b/packages/coding-agent/src/core/tasks/supervisor.ts
@@ -537,8 +537,15 @@ export class TaskSubscription {
 	}
 }
 
+function createNativeSupervisor(): native.TaskSupervisor {
+	// Keep loading separate from `new`: type-assertion erasure in the build
+	// must not move construction onto createModuleRequire instead of the class.
+	const binding = createModuleRequire(import.meta.url)("@bastani/atomic-natives") as typeof native;
+	return new binding.TaskSupervisor();
+}
+
 export class TaskSupervisor {
-	#native = new (createModuleRequire(import.meta.url)("@bastani/atomic-natives") as typeof native).TaskSupervisor();
+	#native = createNativeSupervisor();
 	#hosts = environment.hosts;
 	#owners = environment.owners;
 	#tasks = environment.tasks;

--- a/test/integration/installed-package-node-extensions.test.ts
+++ b/test/integration/installed-package-node-extensions.test.ts
@@ -138,6 +138,25 @@ runTest(
 		fs.mkdirSync(workDir, { recursive: true });
 
 		assert.ok(nodeExe, "real node executable must be resolved before the smoke runs");
+		// Exercise emitted JavaScript: source-runtime tests hid a constructor-precedence
+		// regression that wrapped the native exports object and failed on the second host.
+		const supervisorProbe = spawnSync(
+			nodeExe,
+			[
+				"--input-type=module",
+				"-e",
+				`import { TaskSupervisor } from "./dist/core/tasks/supervisor.js";
+				for (let i = 0; i < 3; i++) new TaskSupervisor();
+				console.log("repeated supervisor construction passed");`,
+			],
+			{ cwd: atomicDest, encoding: "utf8", timeout: 30_000 },
+		);
+		assert.equal(
+			supervisorProbe.status,
+			0,
+			`installed supervisor construction failed:\n${supervisorProbe.stdout}\n${supervisorProbe.stderr}`,
+		);
+		assert.match(supervisorProbe.stdout, /repeated supervisor construction passed/);
 		const result = spawnSync(nodeExe, [join(atomicDest, "dist", "cli.js"), "--no-session"], {
 			cwd: workDir,
 			input: "",


### PR DESCRIPTION
## Summary

Fix `Failed to initialize class constructor` in npm-installed Node sessions when multiple task supervisors are created. This blocks shell commands and subagent launches after an earlier supervisor has initialized.

## Changes

- Separate lazy native-module loading from `new binding.TaskSupervisor()` so emitted JavaScript preserves constructor precedence.
- Extend the installed-layout Node smoke test to construct three supervisors in one process. This test reproduced the exact error before the fix and passes after rebuilding.
- Add a changelog entry.

The previous expression emitted as `new createModuleRequire(import.meta.url)("@bastani/atomic-natives").TaskSupervisor()`. That constructs the loader instead of the native class, then calls the native constructor on the exports object. The first call appears to succeed; later calls fail while wrapping the same object.

## Validation

- `npm run build --workspace=@bastani/atomic`
- `npm run check`
- Installed-package Node integration smoke: 1 passed, with the regression confirmed red before the fix.
- Task agent/command adapter and supervision suites: 20 passed.
- Herdr extension/background-command/subagent/lifecycle suites: 12 passed.
- Built-JS Node probe: three separate task hosts each executed a real owned shell command and closed successfully.
- Fresh macOS ARM64 Bun 1.4.2 bytecode executable with a release-style split app bundle: six owned shell executions passed, normal and PTY across three sessions in one process, each returning `compiled-shell-ok`. Tested through a temporary extension invoking the bundled shell tool without a provider call. The temporary payload used local dependency links, so this is not a standalone archive-install smoke.
- Constructor audit: 2,460 TypeScript files parsed, 8,254 constructor expressions inspected; no other matching defect found. One parser-excluded autocomplete file was checked manually.

## Notes

Herdr reads the task host during activation, but the separately reported delayed pre-prompt visibility has not been independently proven fixed. This PR does not claim that result. No installed executable was replaced and no release was published.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791559344&installation_model_id=10562&pr_number=2951&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2951&signature=bba970af1def78c5288033340c758714929530652377128e2c8d78aaba5b263f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62155607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/bastani-inc/-/pull-requests/bastani-inc/atomic/2951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: the affected installed-package Node flow completed successfully.

What we checked:
- Authored the node smoke test invocation script to run the installed-node smoke test. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Executed the smoke test and captured the results in the after-log, which records the exact command, working directory, exit code 0, Vitest 4.1.11, and 1 passed (1) test. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<details><summary><h3>Summary</h3></summary>

- This change preserves native `TaskSupervisor` construction in emitted JavaScript and adds installed-package coverage for repeated supervisor creation under Node. The installed package smoke test completed successfully, including creation of three supervisors in one process.
</details>

<!-- /greptile_comment -->