### PR TITLE
fix(shell): quote generated paths for PowerShell

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `Failed to initialize class constructor` when npm-installed Node sessions create multiple task supervisors, preventing shell commands and subagent launches from failing during task-host initialization.
+- Fixed PowerShell internal-URL path quoting so apostrophes and smart single quotes in resolved paths remain literal instead of allowing injected commands. Bash quoting, deliberate shell commands, and balanced command prefixes are unchanged.
 
 ## [0.9.19-alpha.2] - 2026-09-08
 

--- a/packages/coding-agent/docs/tools.md
+++ b/packages/coding-agent/docs/tools.md
@@ -32,6 +32,10 @@ When explicitly enabled in settings, built-in bash interceptor rules block commo
 
 Shell internal-URL expansion is intentionally conservative: commands containing a resolved URL must use only plain unquoted words, spaces/tabs, and basic `;`, `|`, or `&` operators. For example, `printf %s local://notes.txt` is supported and the resolved path is shell-quoted automatically, including paths containing spaces or shell metacharacters. Quotes anywhere in such a command, substitutions, escapes, newlines, redirections and heredocs are rejected before execution; use a filesystem path instead for those forms. Commands without resolved internal URLs retain normal shell syntax. URL expansion in structured `cwd` and `env` values is unchanged.
 
+The `powershell` tool uses PowerShell single-quoted literals for resolved paths, doubling both ASCII apostrophes and PowerShell's smart single-quote delimiters (U+2018–U+201B). Bash keeps POSIX quoting, including when Bash runs on Windows. SDK adapters using `createBashToolDefinition` with custom PowerShell operations can set `shellDialect: "powershell"` for generated path literals; this option does not select the executable or rewrite deliberate shell code.
+
+Configured command prefixes and SDK `spawnHook` rewrites remain executable shell syntax, not a sandbox. Balanced setup commands such as quoted exports remain supported. A prefix that leaves a quote, substitution, or heredoc open across the following command can invalidate the generated path quoting; automatic URL expansion does not validate that composed shell context. Do not combine URL expansion with such wrappers. Use structured `cwd` and `env` for path data instead.
+
 ```json
 {
   "bashInterceptor": { "enabled": true }

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -240,6 +240,8 @@ export interface BashToolOptions {
 	commandPrefix?: string;
 	/** Override shell executable resolution for local bash operations. */
 	shellPath?: string;
+	/** Dialect for generated internal-URL path literals. Defaults to POSIX; does not select the executable. */
+	shellDialect?: "posix" | "powershell";
 	/** Last-mile hook for rewriting the command/cwd/env spawn context. */
 	spawnHook?: BashSpawnHook;
 	/** Optional command interceptor used by extensions and parity tests. */
@@ -454,7 +456,13 @@ export function createBashToolDefinition(
 					? await expandShellInternalUrls(bashCommand.cwd!, executionCwd, resourceCtx)
 					: executionCwd,
 				requestedCwd = resolvePath(executionCwd, cwdInput);
-			const expandedCommand = await expandShellInternalUrls(command, executionCwd, resourceCtx, true);
+			const expandedCommand = await expandShellInternalUrls(
+				command,
+				executionCwd,
+				resourceCtx,
+				true,
+				options?.shellDialect,
+			);
 			const strippedExpandedContext = hasExplicitCwd
 				? undefined
 				: stripLeadingCdCommand(expandedCommand, requestedCwd);

--- a/packages/coding-agent/src/core/tools/powershell.ts
+++ b/packages/coding-agent/src/core/tools/powershell.ts
@@ -111,6 +111,7 @@ export function createPowerShellToolDefinition(cwd: string, options: PowerShellT
 		cwd,
 		{
 			...options,
+			shellDialect: "powershell",
 			operations: options.operations ?? createLocalPowerShellOperations({ taskOwner: options.taskOwner }),
 		},
 		POWERSHELL_PRESENTATION,

--- a/packages/coding-agent/src/core/tools/resource-selectors.ts
+++ b/packages/coding-agent/src/core/tools/resource-selectors.ts
@@ -771,14 +771,18 @@ export async function searchInternalSelector(
 		contextAfter,
 	).join("\n");
 }
-function shellQuote(value: string): string {
-	return `'${value.replace(/'/g, `'\\''`)}'`;
+function shellQuote(value: string, dialect: "posix" | "powershell"): string {
+	// PowerShell also treats U+2018–U+201B as single-quote delimiters.
+	return dialect === "powershell"
+		? `'${value.replace(/['\u2018-\u201b]/g, "$&$&")}'`
+		: `'${value.replace(/'/g, `'\\''`)}'`;
 }
 export async function expandShellInternalUrls(
 	text: string,
 	cwd: string,
 	context?: InternalResourceContext,
 	quote = false,
+	dialect: "posix" | "powershell" = "posix",
 ): Promise<string> {
 	const pattern = /(?<![a-z0-9+.-])[a-z][a-z0-9+.-]*:\/\/[^\s'"`$)]+/gi;
 	const replacements = new Map<string, string>();
@@ -793,7 +797,7 @@ export async function expandShellInternalUrls(
 				"Internal URL shell expansion requires plain unquoted words; use a filesystem path for quotes, substitutions, escapes or heredocs.",
 			);
 		}
-		replacements.set(match, quote ? shellQuote(resolved) : resolved);
+		replacements.set(match, quote ? shellQuote(resolved, dialect) : resolved);
 	}
 	// Replace original occurrences only; never reinterpret a router's result.
 	return text.replace(pattern, (match) => replacements.get(match) ?? match);

--- a/packages/coding-agent/test/bash-internal-url-quoting.test.ts
+++ b/packages/coding-agent/test/bash-internal-url-quoting.test.ts
@@ -1,4 +1,6 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -51,6 +53,41 @@ describe.skipIf(process.platform === "win32")("bash internal URL safety", () => 
 			const result = await bash.execute("bare", args, undefined, undefined, { resolveInternalUrl: () => path });
 			expect(result.content).toEqual([{ type: "text", text: `prefix:${path}` }]);
 		}
+	});
+
+	// Code scanning #195/#196: balanced setup syntax must survive both prefix paths.
+	it.each([
+		`export VALUE='balanced value'; printf '%s:' "$VALUE"`,
+		`VALUE="$(printf 'balanced value')"; printf '%s:' "$VALUE"`,
+		`f() { printf 'balanced value:'; }\nf`,
+		`VALUE=$(cat <<'EOF'\nbalanced value\nEOF\n)\nprintf '%s:' "$VALUE"`,
+	])("preserves balanced prefix syntax with bare URLs: %s", async (commandPrefix) => {
+		const bash = createBashToolDefinition(cwd, { commandPrefix });
+		const path = join(cwd, "odd ' ‘ ’ ‚ ‛ space ; $(printf injected)`printf injected`\nline");
+		for (const args of [
+			{ command: "printf %s artifact://path", cwd },
+			{ command: "cd . && printf %s artifact://path" },
+		]) {
+			const result = await bash.execute("balanced", args, undefined, undefined, { resolveInternalUrl: () => path });
+			assert.deepEqual(result.content, [{ type: "text", text: `balanced value:${path}` }]);
+		}
+	});
+
+	// Code scanning #197 starts at process.cwd(), not the intentional command input.
+	it("keeps a metacharacter-bearing cwd and structured environment values literal", async () => {
+		const path = join(cwd, "odd ' ; $(touch injected)`touch injected` space");
+		await mkdir(path);
+		const bash = createBashToolDefinition(path);
+		const bare = await bash.execute("bare-cwd", { command: "printf %s local://notes" });
+		assert.deepEqual(bare.content, [{ type: "text", text: join(path, "notes") }]);
+		const structured = await bash.execute("structured", {
+			command: `printf '%s\\n%s' "$PWD" "$VALUE"`,
+			cwd: path,
+			env: { VALUE: "local://notes" },
+		});
+		assert.deepEqual(structured.content, [{ type: "text", text: `${await realpath(path)}\n${join(path, "notes")}` }]);
+		assert.equal(existsSync(join(path, "injected")), false);
+		assert.equal(existsSync(join(cwd, "injected")), false);
 	});
 
 	it("preserves arbitrary shell syntax without resolved URLs", async () => {

--- a/packages/coding-agent/test/powershell-internal-url-quoting.test.ts
+++ b/packages/coding-agent/test/powershell-internal-url-quoting.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { createPowerShellToolDefinition } from "../src/core/tools/powershell.ts";
+import { getPowerShellConfig } from "../src/utils/shell.ts";
+
+// Windows CI uses its real PowerShell; POSIX can opt in with a portable pwsh executable.
+const portablePowerShell = process.env.ATOMIC_TEST_PWSH;
+describe.skipIf(process.platform !== "win32" && !portablePowerShell)("PowerShell internal URL safety", () => {
+	let cwd: string;
+	beforeEach(async () => {
+		cwd = await mkdtemp(join(tmpdir(), "atomic-powershell-url-"));
+	});
+	afterEach(async () => {
+		await rm(cwd, { recursive: true, force: true });
+	});
+
+	// Code scanning #195–197: generated paths are data, not deliberate shell code.
+	it.each(
+		["-Command", "-EncodedCommand"].flatMap((transport) =>
+			["'", "\u2018", "\u2019", "\u201a", "\u201b"].map((quote) => ({ transport, quote })),
+		),
+	)("keeps resolved paths containing $quote literal via $transport", async ({ transport, quote }) => {
+		const shell = portablePowerShell ?? getPowerShellConfig().shell;
+		const tool = createPowerShellToolDefinition(cwd, {
+			operations: {
+				exec: async (command, executionCwd, { onData }) => {
+					const script = `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8\n${command}`;
+					const payload =
+						transport === "-EncodedCommand" ? Buffer.from(script, "utf16le").toString("base64") : script;
+					const result = spawnSync(shell, ["-NoProfile", "-NonInteractive", transport, payload], {
+						cwd: executionCwd,
+						encoding: "utf8",
+						timeout: 5000,
+					});
+					assert.ifError(result.error);
+					assert.equal(result.status, 0, result.stderr);
+					onData(Buffer.from(result.stdout));
+					return { exitCode: result.status };
+				},
+			},
+		});
+		const path = join(cwd, `x${quote}; Set-Content -LiteralPath injected.txt -Value INJECTED; #`);
+		const result = await tool.execute("literal", { command: "Write-Output artifact://path" }, undefined, undefined, {
+			resolveInternalUrl: () => path,
+		});
+		assert.equal(existsSync(join(cwd, "injected.txt")), false, "resolved path executed a second command");
+		assert.deepEqual(result.content, [
+			{ type: "text", text: `${path}${process.platform === "win32" ? "\r\n" : "\n"}` },
+		]);
+		const literalPath = join(cwd, "spaces \t\n $() ` \" € ‘ ’ ‚ ‛ ' ; artifact://other");
+		const literal = await tool.execute(
+			"metacharacters",
+			{ command: "Write-Output artifact://path" },
+			undefined,
+			undefined,
+			{
+				resolveInternalUrl: () => literalPath,
+			},
+		);
+		assert.deepEqual(literal.content, [
+			{ type: "text", text: `${literalPath}${process.platform === "win32" ? "\r\n" : "\n"}` },
+		]);
+	});
+});


### PR DESCRIPTION
## Summary
Fix PowerShell quoting of paths generated by internal-URL expansion. POSIX escaping was being used for PowerShell, allowing apostrophes in resolved paths to terminate the generated literal.

## Changes
- Use PowerShell single-quote escaping for the PowerShell tool, including its smart-quote delimiters.
- Preserve POSIX quoting and intentional shell commands/prefixes.
- Add real PowerShell regression tests and POSIX compatibility coverage; document the quoting behavior.

## Validation
- 26 focused tests passed, including real PowerShell 7.6.6 execution on macOS ARM64.
- npm run check passed, including both typechecks and shrinkwrap validation.
- git diff --check passed.

## Notes
This is deliberately the minimal quoting fix. It adds no shell validator, native parser API, alias analysis, or command-prefix restrictions.

Investigated while reviewing code-scanning alerts 195–197. Those alerts are not claimed resolved by this PR; local CodeQL still reports the shell-command construction flows. No alerts are dismissed or suppressed.

Upstream earendil-works/pi uses direct command-prefix composition but lacks Atomic internal-URL path expansion, so this specific quoting bug is in the Atomic addition.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791567028&installation_model_id=10562&pr_number=2952&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2952&signature=1b6fc310eae1e78f58d7ce8bf48604416bea75ef8e9279b157e791418cd69e42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62216568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/bastani-inc/-/pull-requests/bastani-inc/atomic/2952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Merge is blocked by a repository-required test import convention that must be corrected.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Use JS Import Extensions** <a href="https://github.com/bastani-inc/atomic/pull/2952#discussion_r3971302963">▶</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/test/powershell-internal-url-quoting.test.ts:8-9
These local TypeScript imports use `.ts` specifiers, but tests under `packages/coding-agent/test/` must use `.js` ESM import extensions. Change both specifiers to `.js`; this repository requirement must be satisfied before merging.

```suggestion
import { createPowerShellToolDefinition } from "../src/core/tools/powershell.js";
import { getPowerShellConfig } from "../src/utils/shell.js";
```

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Adds PowerShell internal-URL quoting coverage and related shell-quoting changes.
- One repository-required ESM import convention remains to be corrected before merge.

## Merge safety

Do not merge until the test imports use the required `.js` ESM extensions.
</details>

<!-- /greptile_comment -->