### PR TITLE
docs(models): discourage max reasoning as a workflow default

### DIFF
--- a/packages/coding-agent/docs/models/evals.md
+++ b/packages/coding-agent/docs/models/evals.md
@@ -22,6 +22,8 @@ No single benchmark is the source of truth. Validate these inputs against Atomic
 
 Start here when a stage needs a model. Each row names a relevant benchmark and selected candidates, not a universal winner or a guarantee that the cheaper option stays close. "Measured" means the exact configuration named; a different effort level or agent is a different experiment.
 
+For practical workflow selection, `max` reasoning is usually overkill and is not the preferred default. Start with `medium` for routine work and `high` for demanding analysis or coding, where the configured model supports those levels. Reserve `max` for exceptional high-cost-of-error judgments or an explicit user request. The `max` rows below record benchmark settings, not production recommendations; more effort can add cost and latency without improving task success. See [role-based thinking effort](/models/model-selection#role-based-thinking-effort).
+
 | Task type | Benchmark to read | Selected measured candidates | Cost-conscious alternative |
 | --- | --- | --- | --- |
 | Implementing features and fixing bugs | September 3 Datacurve DeepSWE | Astra xhigh, Gemini 3.8 Flash high and Opus 5 max display 74% | Luna max 67% / $0.61; GLM-5.3-Flash max 63% / $0.24 |

--- a/packages/coding-agent/docs/models/evals.md
+++ b/packages/coding-agent/docs/models/evals.md
@@ -22,7 +22,7 @@ No single benchmark is the source of truth. Validate these inputs against Atomic
 
 Start here when a stage needs a model. Each row names a relevant benchmark and selected candidates, not a universal winner or a guarantee that the cheaper option stays close. "Measured" means the exact configuration named; a different effort level or agent is a different experiment.
 
-For practical workflow selection, `max` reasoning is usually overkill and is not the preferred default. Start with `medium` for routine work and `high` for demanding analysis or coding, where the configured model supports those levels. Reserve `max` for exceptional high-cost-of-error judgments or an explicit user request. The `max` rows below record benchmark settings, not production recommendations; more effort can add cost and latency without improving task success. See [role-based thinking effort](/models/model-selection#role-based-thinking-effort).
+Practical workflow default: use `low` or `medium` for coding, and `high` or `xhigh` for code review, test design and failure analysis, where the configured model supports those levels. Run actual tests as tool calls, not model judgments. `max` is usually overkill and is not preferred in practice. These are starting recommendations, not conclusions that every benchmark proves; the rows below preserve the exact measured settings. See [role-based thinking effort](/models/model-selection#role-based-thinking-effort).
 
 | Task type | Benchmark to read | Selected measured candidates | Cost-conscious alternative |
 | --- | --- | --- | --- |

--- a/packages/coding-agent/docs/models/model-selection.md
+++ b/packages/coding-agent/docs/models/model-selection.md
@@ -29,7 +29,7 @@ If live results cannot be retrieved, use the dated docs snapshot and say it was 
 
 The thinking level in brackets in the chart is the **measurement configuration used for that benchmark result**, not a universal workflow default. A score measured at `max` does not mean every stage using that model should use `max`; benchmark model identity and production thinking effort are separate choices. When authoring a workflow, choose effort from the stage role and cost of being wrong, then check the returned `availableThinkingLevels` for the configured catalog model.
 
-In practice, `max` reasoning is usually overkill and is not the preferred workflow default. Start with `medium` for routine work and `high` for demanding analysis or coding, subject to catalog support. Treat `max` as an exception for high-cost-of-error judgments or an explicit user request, not a general quality upgrade. Compare task success, latency and cost on representative work before adopting it more broadly; a higher effort level does not guarantee a better result.
+Practical default: use `low` or `medium` for coding, and `high` or `xhigh` for code review, test design and failure analysis, subject to catalog support. Run actual tests as tool calls. `max` is usually overkill and is not preferred in practice. These are starting recommendations to validate on your workflow, not a claim that lower effort reproduces the benchmark scores below.
 
 ## Pin model identity
 
@@ -114,25 +114,26 @@ Use this table when the user has not requested a thinking level. It is a product
 
 | Stage role | Default thinking level | Why |
 | --- | --- | --- |
-| Security, identity, adversarial challenge, final approval | `max` | A wrong judgment can create a high-risk false approval or waste a full downstream loop. |
-| Codebase mapping, lifecycle analysis, compatibility, planning, synthesis, triage, repair | `high` | These stages must resolve demanding uncertainty and preserve evidence across handoffs; routine synthesis may use `medium` when evidence quality holds. |
+| Coding, implementation, routine fixes | `low` or `medium` | Keep implementation fast; use review and tests to catch defects. |
+| Code review, test design, failure analysis, security, identity, adversarial challenge, final approval | `high` or `xhigh` | Spend more reasoning on finding defects, probing edge cases and judging evidence. |
+| Codebase mapping, lifecycle analysis, compatibility, planning, synthesis, triage | `high` | These stages must resolve demanding uncertainty and preserve evidence across handoffs; routine synthesis may use `medium` when evidence quality holds. |
 | User-impact review and final reporting | `medium` | Clear evidence-backed summaries usually do not need the deepest reasoning. |
 | Deterministic checks | No model call | Run typechecks, tests, schema checks, runtime probes, and artifact checks as durable tool nodes. |
 
-Reserve `max` for a high-cost-of-error role or an explicit user request. An explicit request wins over this role default, but the requested level still must appear in the configured catalog; do not invent an unsupported suffix. For each primary and fallback, choose a level for the same stage role independently. A fallback is not a reason to inherit `max` mechanically: use the role default at a supported level, choose another catalog model when needed, or leave the stage unpinned rather than guessing.
+`max` is an exception, not a role default. Consider it only when task-specific evidence justifies the extra effort or the user explicitly requests it. An explicit request wins over these defaults, but the requested level still must appear in the configured catalog; do not invent an unsupported suffix. For each primary and fallback, choose a supported level for the same stage role independently. If `xhigh` is unavailable, use `high` rather than automatically promoting to `max`; choose another catalog model or leave the stage unpinned if neither is supported.
 
 ## Scenario-based guidance
 
 Pick by the cost of being wrong in each role, not by raw accuracy. The AA evidence below was read on 2026-09-08; the Datacurve evidence remains the September 3 snapshot. See [Evals](/models/evals) for measurement settings, normalized Elo versus pass-rate units and source links.
 
-- **Reviewer / judgment gates.** Use `max` for a high-cost-of-error security, identity, adversarial or final-approval decision, subject to the configured model's supported efforts. No external benchmark here establishes security-review reliability. Claude Code + Fable 5.1 max with fallback and Claude Code + Opus 5 xhigh score 56% and 55% on SWE-Atlas-QnA, versus 51% for Codex + Astra max, but those harness-specific results need validation in Atomic.
+- **Reviewer / judgment gates.** Use `high` or `xhigh` for code review and approval decisions, subject to the configured model's supported efforts. No external benchmark here establishes security-review reliability. Claude Code + Fable 5.1 max with fallback and Claude Code + Opus 5 xhigh score 56% and 55% on SWE-Atlas-QnA, versus 51% for Codex + Astra max, but those harness-specific results need validation in Atomic.
 - **Codebase mapping / planner.** Start at `high`. For knowledge-work deliverables, Fable 5.1 max with fallback scores 58% normalized Elo on AA-Briefcase, Opus 5 max 57%, and GLM-5.3-Flash 48% at $0.25 per Index task. These are candidates, not measured repository-planning pass rates. Raise effort only for the role's cost of error or the user's request.
-- **Debugger / triage / repair.** Start at `high`. The new Terminal-Bench v4.0 is no longer flat near 90%: Astra xhigh scores 60%, Fable 5.1 xhigh with fallback 55%, Opus 5 max 49%, and Gemini 3.8 Flash high 20%. Keep Datacurve cost and steps as separate evidence; do not transfer its 74% Gemini result into this benchmark.
+- **Debugger / triage / repair.** Use `high` or `xhigh` for failure analysis and test design, then `low` or `medium` to implement a diagnosed fix. The new Terminal-Bench v4.0 is no longer flat near 90%: Astra xhigh scores 60%, Fable 5.1 xhigh with fallback 55%, Opus 5 max 49%, and Gemini 3.8 Flash high 20%. Keep Datacurve cost and steps as separate evidence; do not transfer its 74% Gemini result into this benchmark.
 - **Research / synthesis.** Use `high` for demanding reconciliation and `medium` for routine synthesis. Luna max scores 84% on AA-LCR at $0.18 per Index task, but its 7% non-hallucination rate counts partial answers or not attempted among non-correct responses, not all answers. Verify factual claims. Astra xhigh leads the displayed GDP.pdf rows at 32%; GLM-5.3-Flash and GLM-5.3 max score 72% and 70% non-hallucination.
 - **Orchestrator / worker / cheap loops.** Use AutomationBench-AA for SaaS tool workflows: Astra max 68%, GLM-5.3-Flash 60%, Luna max 50%. GLM-5.3-Flash and Luna remain budget candidates on the separately dated Datacurve frontier. Gemini 3.8 Flash's 166 steps and 143k output tokens in that snapshot argue against choosing workers on pass rate alone. Validate the tradeoff on the actual workflow.
-- **User-impact review / final reporting** — use `medium` for impact summaries and reports that preserve the evidence needed by the user. Do not spend `max` here unless the user explicitly requests it or the role has become a high-cost-of-error approval.
+- **User-impact review / final reporting.** Use `medium` for impact summaries and reports that preserve the evidence needed by the user. If the stage makes an approval decision, use the reviewer guidance instead.
 - **Design** — a quality-first domain not directly measured by these coding tables. Choose effort by the review or approval role. Fable 5.1's AA-Briefcase results make it a candidate for knowledge-work deliverables, not proof of product-design quality; evaluate it on the intended design tasks and do not carry Fable 5's DeepSWE row over to it.
-- **Interactive coding sessions** — use `high` for complex, multi-step coding and `medium` for routine edits; reserve `max` for a high-cost-of-error judgment or an explicit user request.
+- **Interactive coding sessions.** Use `low` or `medium` for implementation, switching to `high` or `xhigh` for code review, test design and failure analysis. Choose only levels supported by the configured model.
 - **Deterministic checks** — make typechecks, tests, schema validation, runtime probes, and artifact inspection tool nodes with no model call. Model self-report is not verification evidence.
 
 ## Related

--- a/packages/coding-agent/docs/models/model-selection.md
+++ b/packages/coding-agent/docs/models/model-selection.md
@@ -29,6 +29,8 @@ If live results cannot be retrieved, use the dated docs snapshot and say it was 
 
 The thinking level in brackets in the chart is the **measurement configuration used for that benchmark result**, not a universal workflow default. A score measured at `max` does not mean every stage using that model should use `max`; benchmark model identity and production thinking effort are separate choices. When authoring a workflow, choose effort from the stage role and cost of being wrong, then check the returned `availableThinkingLevels` for the configured catalog model.
 
+In practice, `max` reasoning is usually overkill and is not the preferred workflow default. Start with `medium` for routine work and `high` for demanding analysis or coding, subject to catalog support. Treat `max` as an exception for high-cost-of-error judgments or an explicit user request, not a general quality upgrade. Compare task success, latency and cost on representative work before adopting it more broadly; a higher effort level does not guarantee a better result.
+
 ## Pin model identity
 
 When a workflow needs an exact model, call `workflow({ action: "models" })` and pin a returned `fullId`. Do not pin a


### PR DESCRIPTION
## Summary
Distill practical reasoning defaults: use `low`/`medium` for coding and `high`/`xhigh` for code review and testing. `max` is usually overkill and is not preferred in practice.

## Changes
- Align the evals task picker, model-selection overview, role table and scenarios.
- Distinguish test design and failure analysis from actual test execution, which stays tool-only.
- Keep effort choices subject to catalog support; do not promote unsupported `xhigh` to `max`.
- Preserve benchmark measurements and runtime defaults. These are practical recommendations to validate on actual workflows, not new benchmark findings.

## Notes
- Applied the prompt-engineer skill to make the role defaults explicit and remove conflicting guidance.
- Validation: `git diff --check` and pre-commit hooks passed, including `npm run check`.
- Tests not run separately because this is a documentation-only change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary

The updated model-selection guidance treats `max` as exceptional and recommends `high` or `xhigh` for final approval, but the Reliable Design template still makes `max` the default for that stage. Aligning those documents will prevent workflow authors from receiving conflicting guidance.

<h3>Confidence Score: 4/5</h3>

Safe to merge from a product-behavior perspective, but the documentation should be aligned to avoid conflicting workflow-author defaults.

One confirmed, non-blocking documentation-consistency concern remains.

**Files Needing Attention:** packages/coding-agent/docs/workflows/reliable-design.md and packages/coding-agent/docs/models/model-selection.md

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P2 finding.
- A second proof for the same P2 finding was produced.
- T-Rex executed the conflict-check script model-selection-final-approval-conflict-check.py from the repository, observed an exit code 0, and the output ended with RESULT: CONFLICT CONFIRMED.

<a href="https://app.greptile.com/trex/runs/23404608/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Reliable Design template makes max the default for final approval**

   - **Bug**
     - `packages/coding-agent/docs/workflows/reliable-design.md:110` instructs authors to configure the `approve`/final-approval stage with `max`. The linked Model Selection role-default table instead assigns final approval `high` or `xhigh`, and its exception policy says not to promote unsupported `xhigh` automatically to `max`. Thus following the supplied workflow template conflicts with the canonical role-default guidance.
   - **Cause**
     - The concrete approval-stage template hard-codes `max` despite the referenced Model Selection policy classifying `max` as an exception rather than a role default.
   - **Fix**
     - Change the approval template at `packages/coding-agent/docs/workflows/reliable-design.md:110` to use `high` or `xhigh` (with catalog-support guidance), or explicitly qualify `max` there as requiring task-specific high-cost-of-error evidence or an explicit user request.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/docs/models/model-selection.md:123
**Align final approval guidance**

This page treats `max` as exceptional and assigns final approval to `high` or `xhigh`, but the Reliable Design workflow template still configures its final-approval stage with `max`. Workflow authors following the template therefore receive a conflicting default. This is a non-blocking documentation concern, but it can cause unnecessarily expensive workflows or inconsistent reasoning-effort choices. Update the template or explicitly qualify when `max` is warranted.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(models): split coding and verificat..."](https://github.com/bastani-inc/atomic/commit/6806f79952bcff5b89e2a2c05be1fa234a1b8ea1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62242803)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->