### PR TITLE
fix: repair recent CI regressions and installed Node startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,7 @@ If a user asks to publish a release or prerelease, route the request through the
 ## Docs
 
 - ALWAYS keep the user-facing docs in `packages/coding-agent/docs` up-to-date with the latest changes after you make changes. Prefer to keep other docs up-to-date as well, but the coding-agent docs are the most important since they are user-facing and often consulted by users and other agents.
+- `packages/coding-agent/docs` is user-facing documentation. Explain how to use, configure, and troubleshoot Atomic. Do not include internal implementation details, test infrastructure, debugging histories, verification evidence, or maintainer-only design notes. Keep those in repository-level docs, code/test comments, or PR descriptions. Keep user guides concise and focused on what users need to know.
 - To update docs, prefer using your `release-docs` workflow to thoroughly update all relevant docs with the latest changes. If you need to make a quick fix or update, you can also edit the markdown files directly, but make sure to keep them comprehensive and up-to-date.
 
 ## Changelog

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Capped agent retry backoff with `retry.maxAgentDelayMs` (60 seconds by default), preserving independent provider retry limits ([#8826](https://github.com/earendil-works/pi/issues/8826)).
 - Rejected extension tools with missing or non-object parameter schema containers during registration instead of breaking provider requests ([#9300](https://github.com/earendil-works/pi/issues/9300)).
 - Workflow-stage pause now blocks new task launches, cancels active and admitted queued agents and commands, and waits for in-flight command admission and resource cleanup. Main-chat and sibling tasks stay unaffected; queued user and Intercom messages survive, and resume permits fresh work without restarting cancelled executions.
+- Fixed npm-installed Node startup failing with a missing upstream AI package after the retry-policy update. Core retry imports now use Atomic's declared AI dependency.
+- Fixed an unhandled rejection when session cancellation interrupts an in-flight stage-chat pause, while preserving pause error reporting and rejection for callers awaiting completion.
 
 ## [0.9.19-alpha.2] - 2026-09-08
 

--- a/packages/coding-agent/docs/development.md
+++ b/packages/coding-agent/docs/development.md
@@ -61,7 +61,7 @@ npm run test:scripts             # Repository script tests under Node
 npm run test --workspace=@bastani/atomic -- test/specific.test.ts
 ```
 
-CI runs root unit and integration suites on Linux and Windows. Keep test isolation, concurrency, and shared timeout budgets unchanged. See [CI documentation](https://github.com/bastani-inc/atomic/blob/main/docs/ci.md) for job details and release procedures.
+CI runs root unit and integration suites on Linux and Windows. See [CI documentation](https://github.com/bastani-inc/atomic/blob/main/docs/ci.md) for job details and release procedures.
 
 ### Installed package smoke test
 
@@ -71,7 +71,7 @@ After building, run:
 ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE=1 npx vitest --run --project integration test/integration/installed-package-node-extensions.test.ts
 ```
 
-This checks Node startup and builtin extension loading outside the checkout. It excludes the checkout-only `@earendil-works/pi-ai` alias; core imports must use the declared `@bastani/pi-ai` dependency.
+This checks Node startup and builtin extension loading outside the checkout.
 
 Atomic ships an npm shrinkwrap. After dependency changes, regenerate it with `npm run shrinkwrap:coding-agent` and validate with `npm run check`.
 

--- a/packages/coding-agent/docs/development.md
+++ b/packages/coding-agent/docs/development.md
@@ -8,15 +8,10 @@ See [AGENTS.md](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md) for a
 git clone https://github.com/bastani-inc/atomic
 cd atomic
 npm ci --ignore-scripts
-npm run typecheck
+npm run build
 ```
 
-This monorepo runs a hybrid toolchain matching upstream pi: npm installs, builds, checks, and runs the vitest suites, while Bun compiles the release binaries and runs `scripts/*.ts`. Avoid yarn and pnpm. Run package scripts from the monorepo root or a package directory, for example:
-
-```bash
-npm run test:unit
-npm run build --workspace=@bastani/atomic
-```
+Use npm for installs, builds, checks, and Vitest suites. Bun compiles standalone binaries and runs repository TypeScript scripts. Do not use yarn, pnpm, or `bun install`.
 
 Atomic keeps the caller's current working directory when launched from development wrappers.
 
@@ -33,7 +28,7 @@ Configure via `package.json`:
 }
 ```
 
-Change `name`, `configDir`, and the `bin` field for your fork. The app-specific `<appName>Config` key is preferred; legacy `piConfig` remains a backwards-compatible shim. Atomic sets these to `atomic`, `.atomic`, and the `atomic` executable. Affects CLI banner, config paths, and environment variable names.
+Change `name`, `configDir`, and the `bin` field for your fork. These control the CLI banner, config paths, and environment variable names. Legacy `piConfig` remains a compatibility fallback.
 
 ## Path Resolution
 
@@ -53,88 +48,42 @@ Never use `__dirname` directly for package assets.
 - Rendered TUI lines with ANSI codes
 - Last messages sent to the LLM
 
-## Startup timing probes
-
-Use `scripts/perf/windows-startup/benchmark.ts` for Windows startup claims. It launches the ordinary bare `atomic` command through a real 120x40 ConPTY, feeds ordered output into `@xterm/headless`, and timestamps each receive with `process.hrtime.bigint()`. Complete first paint requires the final `Atomic v<version>` identity, the focused `❯ ` editor, and two identical settled frames at least one 80 ms animation interval apart. `dispatchMs` runs from the Enter write to the first byte observed by a raw TCP loopback provider. The headline `spawnToDispatchMs` is exactly `startupCompleteMs + dispatchMs`; `launchToProviderFirstByteMs` separately retains the contiguous launch-to-provider interval that also contains nonce typing and editor-echo wait. The provider request must contain the nonce and the normal tool schemas, and every accepted sample must pass `/workflow list` after the timed response. See [the benchmark README](https://github.com/bastani-inc/atomic/blob/main/scripts/perf/windows-startup/README.md) for artifact preparation, cache profiles, raw records, and summary commands.
-
-Do not use `time-to-first-frame` as settled-paint evidence, and do not substitute `launchToProviderFirstByteMs` for the contract sum. The first-frame mark records the host's first requested identity frame after the header is mounted; it does not prove terminal receipt, animation settlement, engine resource readiness, or provider readiness. `ATOMIC_STARTUP_BENCHMARK=1`, `--no-extensions`, and `--no-tools` are attribution controls only. They do not run the accepted full CLI path with bundled workflows, normal extensions, tools, and provider dispatch.
-
-The process-local lifecycle timing seams use monotonic nanoseconds and remain disabled until an internal diagnostic adapter installs a synchronous sink. With no sink, they do not read the clock, write output, or schedule work. External ConPTY and TCP marks remain authoritative. Startup now has several deliberate partial orders rather than one cross-process sequence:
-
-```text
-interactive host: process-entry → interactive-engine-spawn → engine-ready
-                  → tui-start → header-mounted → initialize engine-bound state
-                  → chat-output-release → interactive-input-handler-ready
-
-isolated child:   process-entry → engine-ready → engine-bound
-                  → engine-resources-ready
-
-external screen:  first-terminal-write → startup-coherent → startup-complete
-
-first turn:       interactive-first-submit → before-provider-request
-```
-
-The header and editor are mounted before the host waits for `engine-bound`; the child can therefore report binding while the host is applying its theme or requesting that frame. `engine-bound` means RPC control plus the mandatory minimal session are available. `engine-resources-ready` is a separate, generation-scoped child message sent only after a staged optional snapshot containing bundled extensions, tools, providers, skills, prompts, and themes commits. User prompts, extension commands, model/resource commands, session replacement, and tool-dispatching RPC calls wait for that gate. After a readiness failure, `/reload` bypasses the rejected gate to start a fresh transactional attempt; successful retry replaces the gate before later work proceeds. Escape cancels a first submission that is still waiting, so that continuation cannot dispatch later. `session_start` messages are queued against the candidate snapshot and released only after publication. Mandatory Intercom remains in the minimal runtime. A failed transactional candidate leaves host-managed settings, providers, tools, resources, event subscriptions, and system-prompt state unchanged, restores an unadmitted prompt draft exactly, and reports the generation failure once. Extension-owned objects stored with `sessionScopedExtensionState` are deliberately shared across reloads and are not cloned or rolled back.
-
-`engine-resources-ready` is recorded in the isolated engine process; host marks are recorded in the interactive process. The two process clocks are monotonic but must not be subtracted without an external synchronization protocol. `startup-coherent` and `startup-complete` describe internal render composition, not terminal receipt. The external VT predicates decide the reported first-paint marks.
-
-For package-manager installs under Node 22, Atomic enables Node's persistent module compile cache in both the host and isolated child and flushes the host cache before spawning the child. Explicit `NODE_COMPILE_CACHE` and `NODE_DISABLE_COMPILE_CACHE` settings pass through unchanged. This preserves Node's coverage opt-out and avoids forcing a new cache directory or a first-run-only precompile step. SEA, V8 snapshots, and package-install precompilation were not adopted because Atomic's dynamic ESM, native modules, workers, and first-run requirements do not provide a safe portable boundary.
-
-Compiled releases syntax-minify the shared CJS `app.js` sidecar without identifier minification and compile launchers with bytecode on all eight supported targets, including Windows x64 and ARM64. `bun run scripts/probe-windows-bytecode.ts` pins Bun 1.4.2, cross-compiles `bun-windows-x64-baseline` and `bun-windows-arm64` launchers, and verifies their PE machine types. Atomic observed a Bun 1.3.14 Windows startup crash in `llint_entry`, but Bun 1.4.0 already contains the embedded-bytecode alignment fix ([#26299](https://github.com/oven-sh/bun/pull/26299)) and integrity fallback ([#31961](https://github.com/oven-sh/bun/pull/31961)); the separate Bun 1.4.0 Windows report ([#40302](https://github.com/oven-sh/bun/issues/40302)) concerns a general standalone/JIT segfault and has not been shown to be bytecode-specific. Cross-compilation is not runtime validation: release candidates still require full-archive target-machine coverage of the TUI, workflows, tools, extensions, workers, and native add-ons, with Windows ARM64 validated on ARM64 hardware.
-
-Set `ATOMIC_TIMING=1` only for the older human-readable phase diagnostics. Normal interactive launches print that initial timing group before `interactiveMode.run()` starts the TUI loop, so later marks are not printed during ordinary sessions.
+For startup measurements, see the [Windows startup benchmark](https://github.com/bastani-inc/atomic/blob/main/scripts/perf/windows-startup/README.md). Internal timing marks do not prove terminal first paint.
 
 ## Testing
 
 ```bash
-npm run typecheck                 # Type-check the monorepo
-npm run test:unit                 # Run unit tests
-npm run test:integration          # Run integration tests
-npm run test:all                  # Run all tests
-npm run test:scripts              # Run the repository script tests under node --test
-# Run the package Vitest suite (Node-hosted)
+npm run check                    # Typechecks and published-shrinkwrap validation
+npm run test:unit                # Root unit tests
+npm run test:integration         # Root integration tests
+npm run test:all                 # All root test projects
+npm run test:scripts             # Repository script tests under Node
 npm run test --workspace=@bastani/atomic -- test/specific.test.ts
 ```
 
-Root Vitest projects install a fresh in-memory durable backend before every test.
-Durability initialization imports the backend and its process owner rather than
-preloading the DBOS factory or the Atomic host. A test that needs host prototype
-installers must import those real modules explicitly rather than depend on a
-side effect of shared setup. Test-local backend overrides still use the factory's
-injection seam, and the next test receives a fresh backend without resetting
-unrelated initialization or warning state. Keep the global artifact/native setups,
-default isolation, worker sizing and timeout budgets unchanged when measuring
-test cost. See the [CI measurements](https://github.com/bastani-inc/atomic/blob/main/docs/ci.md#current-critical-path-measured-september-5-2026)
-for local gains and the remaining hosted Linux/Windows validation.
+CI runs root unit and integration suites on Linux and Windows. Keep test isolation, concurrency, and shared timeout budgets unchanged. See [CI documentation](https://github.com/bastani-inc/atomic/blob/main/docs/ci.md) for job details and release procedures.
 
-CI runs the complete root unit and integration suites in independent Linux and
-Windows jobs. Each builds its own native and package prerequisites; both required
-result gates wait for every work job and reject failures, cancellations and skips.
-This trades duplicated setup for earlier integration feedback without changing
-test isolation, coverage or retries.
+### Installed package smoke test
 
-## Deterministic installs
-
-`@bastani/atomic` ships `packages/coding-agent/npm-shrinkwrap.json` so package-manager installs resolve the same dependency tree every time. Contributors working from a source checkout can validate that the checked-in shrinkwrap is up to date with:
+After building, run:
 
 ```bash
-bun run scripts/generate-coding-agent-shrinkwrap.mjs --check
+ATOMIC_REQUIRE_INSTALLED_NODE_SMOKE=1 npx vitest --run --project integration test/integration/installed-package-node-extensions.test.ts
 ```
 
-After updating dependencies, run `npm ci --ignore-scripts` and `npm audit`, regenerate the published tree with `npm run shrinkwrap:coding-agent`, and run `npm run check`. Audit the development tree as well as production dependencies. Keep the Vitest packages on the same patched 4.x release; updating only its mocker to 5.x does not preserve the runner contract. Compare shared provider SDK pins with upstream Pi, but retain exact versions required by the installed Pi packages rather than assuming Pi's current source manifests match its published packages.
+This checks Node startup and builtin extension loading outside the checkout. It excludes the checkout-only `@earendil-works/pi-ai` alias; core imports must use the declared `@bastani/pi-ai` dependency.
 
-## Release security boundary
-
-Atomic's release bases remain at the `0.0.0` placeholder. `scripts/cut-release.ts` stamps the real version only on a detached tagged release commit. Tag creation runs an inert signal workflow; a separate `workflow_run` publisher loaded from protected `main` validates the exact upstream repository, source workflow/event/run, tag/SHA, immutable release-base trailers, and deterministic release tree. The privileged trigger checks out only protected workflow code: it treats the tag tree as data, exports it only after deterministic verification, and makes every read-only build verify the protected job's source checksum instead of checking out tag-selected code. Same-run artifact transport failures receive at most one retry after partial-download cleanup and still fail explicitly on the second error; verified source archives are streamed to tar over stdin for portable Windows drive-letter handling. Preparation restores the digest-verified source after documentation validation before producing artifacts. Release-source jobs configure no dependency cache, npm publication has OIDC without repository write, and GitHub Release creation has repository write without OIDC. Never move or recreate a failed release tag or dispatch the privileged publisher. See the repository's [CI/CD pipeline](https://github.com/bastani-inc/atomic/blob/main/docs/ci.md#release-pipeline) for trusted-publisher configuration.
+Atomic ships an npm shrinkwrap. After dependency changes, regenerate it with `npm run shrinkwrap:coding-agent` and validate with `npm run check`.
 
 ## Project Structure
 
-```
+```text
 packages/
-  coding-agent/ # Atomic CLI, agent loop, providers, TUI, and core runtime
-  workflows/    # First-party workflow extension bundled into Atomic
-  subagents/    # Built-in subagent orchestration and reusable agents
-  mcp/          # Built-in MCP adapter extension
-  web-access/   # Built-in web search and content extraction tools
-  intercom/     # Built-in cross-session coordination channel
+  ai/           # Atomic's LLM provider fork
+  coding-agent/ # CLI, interactive mode, and core runtime
+  workflows/    # Workflow execution
+  subagents/    # Subagent orchestration
+  mcp/          # MCP adapter
+  web-access/   # Web search and content extraction
+  intercom/     # Cross-session coordination
 ```

--- a/packages/coding-agent/docs/herdr.md
+++ b/packages/coding-agent/docs/herdr.md
@@ -1,55 +1,30 @@
 # Herdr
 
-Atomic includes a built-in Herdr reporter. In an eligible pane it reports agent, subagent, extension approval, and observed workflow activity using source `custom:atomic` and agent label `atomic`. No community extension is required.
+Atomic reports its status to [Herdr](https://herdr.dev) automatically when you launch it in a Herdr pane. No extra extension is required. The pane identifies the agent as `atomic`.
 
-## Prerequisites and environment
+## Setup
 
-The CLI contract is based on Herdr **0.8.2, protocol 20**. Launch Atomic in a Herdr pane whose environment includes:
+Use Herdr 0.8.2 or newer and launch Atomic inside it. Herdr supplies the pane connection settings automatically; you do not need to configure them yourself.
 
-| Variable | Required value |
+The integration runs only for interactive Atomic sessions. It stays inactive outside Herdr and in print, JSON, or RPC mode.
+
+## Status indicators
+
+| Status | Meaning |
 |---|---|
-| `HERDR_ENV` | Exactly `1` |
-| `HERDR_BIN_PATH` | Nonempty path to Herdr's executable CLI wrapper |
-| `HERDR_PANE_ID` | Nonempty owning pane ID |
-| `HERDR_SOCKET_PATH` | Nonempty server socket path |
+| Working | Atomic, a workflow, a subagent, or a background shell command is still running. |
+| Blocked | Work needs your input or approval, and no independent work is running. |
+| Idle / Done | No work is running. Herdr may show a newly completed turn as Done. |
 
-The reporter captures these values on activation, not at module import. It runs only when the extension context has `mode: "tui"` and `hasUI: true`. Print, JSON, RPC, no-UI, workflow-stage, and subagent contexts never claim a pane merely because they inherited its environment. Missing prerequisites, disabled reporting, or ineligible contexts create no reporter timer, subprocess, or workflow observation lease.
+Quiet periods such as provider waits, retries, and tool execution still count as working. Background work keeps the pane working after Atomic finishes its response.
 
-## States and reasons
+Opening `/tasks`, `/agents`, or `/workflow connect` does not count as an approval request. Neither does a subagent asking its supervisor for guidance. Actual permission requests and workflow budget approvals can show Blocked.
 
-The reporter uses interactive `input`, `agent_start`, `agent_settled`, `ui_prompt_start`, `ui_prompt_end`, live `workflow_lifecycle` events, the owning session's task subscription, and its `observeWorkflowActivity` stream. It does not infer execution from screen text or use `agent_end` as the idle boundary.
+A failed workflow can remain marked blocked in Atomic after its execution ends, while the pane returns to Idle. Check the workflow details for its result; the pane indicator is not a success or failure verdict. Sending a message acknowledges existing workflow attention for the indicator, but does not resume the workflow or approve a budget increase.
 
-Quiet work is still work: waiting for a provider response, tool completion, retry backoff, or another automatic continuation does not become `idle` because output stops. Repeated output-cap continuations remain part of the same owning prompt until the entire chain finishes. Reporting is lifecycle-driven, with no inactivity-to-idle timer or heartbeat requirement.
+## Disable the integration
 
-| Contribution | Reported state | Internal reason | Message |
-|---|---|---|---|
-| Agent executing without an open approval prompt | `working` | `executing` | None unless a workflow needs attention |
-| Owned subagent or shell task queued, running, or cancelling | `working` | `executing` | None unless a workflow needs attention |
-| Workflow execution, automatic continuation, retry, or stop-drain | `working` | Workflow's `executing`, `automatic_continuation`, `retrying`, or `stopping` | `Workflow needs attention` when a root is blocked or needs attention |
-| Approval prompt is the only remaining work, including an agent parked on that prompt | `blocked` | `awaiting_input` | `Waiting for approval` |
-| Workflow waiting for input, an active intervention, or budget approval, with no independent execution | `blocked` | Workflow's `awaiting_input` or `manual_intervention` | `Workflow needs attention` |
-| All observed workflows paused, no agent or prompt work | `idle` | `paused` | None |
-| Settled agent, no prompt, ready workflow source with no work | `idle` | `quiescent` | None |
-| Failed or blocked workflow whose executor has finished, with no pending prompt or budget approval | `idle` | `quiescent` | `Workflow needs attention` |
-| Workflow source `unavailable` or `recovering`, no known contribution | No new report | Unknown | None |
-
-Independent workflow execution keeps the pane working even after the parent agent settles or while another contribution waits for approval. Reasons are internal reducer values, not extra CLI fields. Missing workflow knowledge is never treated as an empty ready snapshot, so an unavailable provider can leave the last reported state unchanged until a ready snapshot arrives.
-
-Standalone subagents and background shell tasks also keep the pane working after the parent settles. The reporter reads the owner's task snapshot on activation and follows task events until shutdown. Reload reattaches to existing tasks; one task completing, failing, or being cancelled cannot clear another task's activity. Settled tasks retained in `/tasks` do not count as running. Children never claim the pane or overwrite the parent's session identity.
-
-A failed review or cleanup can leave a workflow outcome marked `blocked` after execution ends. That outcome remains inspectable and retains `needsAttention`, but does not by itself keep the pane red. A pending decision or exhausted budget still reports `blocked`; independent execution still reports `working`. Reporting `idle` neither acknowledges the failure nor resumes it. The parent session retains pane ownership until it exits, so a child stopping does not call `release-agent` for the parent.
-
-Sending a message acknowledges currently observed workflow blocks for the pane indicator only. The next settled response can return to `idle` instead of repeatedly turning red for the same block; workflow states and budget approvals are not changed. Repeated activity snapshots do not re-arm that attention. A changed workflow activity or a new live block/prompt does, and open approval widgets remain blocking until answered. Extension-generated messages and automatic agent starts do not acknowledge blocks. This acknowledgement is local to the reporter and resets on reload or restart.
-
-Opening or closing the host-owned `/tasks` inspector or the `/agents` catalog is navigation and does not emit an approval span or change Herdr activity. Genuine extension approval prompts still report `blocked`. This follows [Herdr's custom-agent contract](https://herdr.dev/docs/integrations/#integrate-your-own-agent), which defines `blocked` as needing a user decision. [Prime Agent's reporter](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/src/core/extensions/builtin/herdr-agent-state.ts) likewise observes explicit block notifications. Atomic retains its settled-event and workflow aggregation instead of copying Prime's retry grace timers.
-
-`/workflow connect` and its run picker are also navigation. Opening, hiding, reopening, or closing the graph does not create an approval wait. Real workflow input waits and extension approvals still contribute their normal state, including while the graph is hidden.
-
-Prompt notifications reach each observer without waiting for earlier observers to finish. A slow observer cannot delay Herdr's start until after the matching end and leave a false `blocked` state after the user has answered. Notification work never delays prompt display or answers.
-
-## Opt out
-
-Set this in global `~/.atomic/agent/settings.json` or trusted project `.atomic/settings.json`, then reload or restart Atomic:
+Add this to `~/.atomic/agent/settings.json` or trusted project `.atomic/settings.json`, then reload or restart Atomic:
 
 ```json
 {
@@ -59,48 +34,20 @@ Set this in global `~/.atomic/agent/settings.json` or trusted project `.atomic/s
 }
 ```
 
-The default is `true`, subject to the environment and ownership gates. Project settings override global settings using the normal [settings precedence](/settings).
+Reporting is enabled by default. Project settings follow the normal [settings precedence](/settings).
 
-## Reporter conflicts
+## Troubleshooting
 
-If the actually loaded extension paths contain `herdr-atomic-reporter` or the legacy Pi `herdr-agent-state`, the built-in reporter defers without claiming or observing. One `unsupported` diagnostic names the loaded reporter path. Merely having such a package on disk does not cause deferral. The selected community or legacy reporter determines workflow coverage in that mode; Atomic's built-in aggregation is inactive.
+If Atomic does not appear in Herdr:
 
-## Ownership, delivery, and privacy
+- Make sure you launched Atomic inside a Herdr pane, rather than in a separate terminal.
+- Check that Herdr is running and reporting has not been disabled in Atomic's settings.
+- Check for a loaded `herdr-atomic-reporter` or legacy Pi `herdr-agent-state` extension. Atomic defers to these reporters to avoid conflicts; disable the extra extension and reload to use the built-in integration.
 
-One module-owned lease reports each pane. A successor fences and drains the predecessor before reporting, without sending `release-agent`. Sequence numbers use a clock seed and a process-level high-water mark, increasing across extension reloads, runner replacement, and clock rollback within that process. Genuine quit drains the current child and releases authority with a fresh sequence strictly greater than the last report sequence. Late predecessor callbacks cannot report or release a successor.
+For custom launchers, Herdr must provide `HERDR_ENV=1` and nonempty `HERDR_BIN_PATH`, `HERDR_PANE_ID`, and `HERDR_SOCKET_PATH` values. See [Herdr's integration guide](https://herdr.dev/docs/integrations/#integrate-your-own-agent).
 
-Each reporter instance binds to an eligible session's `SessionManager` and its active extension runner before awaiting pane acquisition. Other sessions sharing the loaded instance cannot change its activity, prompts, or lifecycle. In particular, a child quitting cannot release the parent's pane or cancel its pending claim. A transactional reload starts a candidate runner with the same `SessionManager` before retiring the old runner. The candidate takes over the binding and remains the active runner after commit; old shutdown, activity, approval, and repeated start events cannot release or reclaim that binding. The owning runner's shutdown clears the binding before awaiting transport cleanup, allowing a subsequent eligible session to reuse the same already-loaded resource loader. The successor reserves its binding immediately but waits for predecessor retirement before reporting its own identity; neither delayed predecessor events nor completion of the old shutdown can clear the new binding.
+Reloading or compacting a session should not remove Atomic from the pane. If status stops updating, check Herdr's connection and reload Atomic. Reporting failures do not stop your agent or workflow, and reconnect polling is not automatic.
 
-Candidate reporting stays staged until transactional preparation and provider publication succeed. A rejected reload leaves the live runner's pane claim, approval count, and workflow observation intact, so continued work and genuine quit still report normally. Rejected candidate callbacks cannot take ownership. After commit, the candidate claims the pane before the old runner's shutdown and before queued extension side effects run.
+## Privacy
 
-Normal compaction retains the same session and reporter; subsequent work continues reporting without reclaiming authority. Resource reload and in-process session replacement preserve the existing Herdr registration and last reported state while workflow activity is recovering or unavailable. They do not unregister the running agent or invent an idle snapshot, so another prompt is not needed to keep the agent visible. Ready activity resumes normal reporting. Genuine quit releases the inherited registration even if the successor has not sent a report. A non-quit shutdown can restart the same runner if no successor has taken over; late callbacks from superseded runners remain fenced.
-
-The reporter invokes the CLI directly with an argument array, not a shell. It permits one child per pane at a time, keeps only the newest pending state, and uses a five-second timeout plus bounded output buffering. Transport errors produce bounded `spawn_failed`, `timeout`, or `protocol_rejected` diagnostics; obsolete ownership uses `stale_owner`. Errors do not become agent or workflow failures. Child stdout and stderr are never logged raw.
-
-Only the fixed messages in the table are sent. Prompt titles, tool arguments, provider error bodies, transcripts, and workflow outputs are not forwarded. The parent's session ID and, when available, native absolute session path accompany reports until the first successful CLI delivery per claim, using `--agent-session-id` and `--agent-session-path`. Later reports in that claim omit these flags. This is not a once-per-claim attempt: after a transport failure, later activity retries that identity; no retry timer is added. Child sessions do not replace that identity.
-
-## Compatibility
-
-The reporter is tested against Herdr **0.8.2 (protocol 20)**; that is the minimum supported release. The rows below record the observed CLI and server behaviour the reporter is built on, and how Atomic responds.
-
-| Herdr behaviour (0.8.2, protocol 20) | Observed | Atomic behaviour |
-|---|---|---|
-| Custom-source authority | A `custom:*` source authors semantic pane state. `custom:atomic` shows as agent `atomic`. | The built-in reporter uses `custom:atomic` and does not depend on Herdr's own agent detection. |
-| Equal or older `--seq` | Exit 0, silently ignored by the server. The CLI never reports a rejected stale sequence. | Each report uses `max(clock ms, previous + 1)`, tracked in a process-level high-water mark; ordering is enforced by Atomic rather than inferred from exit codes. |
-| Sequence high-water mark after release | Survives `release-agent`. A later report with a lower sequence, even from a new owner, is ignored. | New processes seed from the clock. Ordering across a process restart with a rolled-back clock, or against another reporter's higher sequence, is not promised. |
-| `release-agent` without `--seq` | Exit 0, no change. Release by a non-owner source is also ignored. | Release always carries a fresh sequence strictly greater than the last report sequence. Ownership checks prevent late predecessor releases from retiring a successor. |
-| `idle` after `working` | Surfaced as `agent_status: done`; `idle` on a fresh pane surfaces as `idle`. | Atomic reports `idle`. Consumers reading pane state must accept `idle` or `done` for the idle state. |
-| `--message` | Accepted, but not surfaced by `agent get` (`message: null`). | Only the fixed messages `Waiting for approval` and `Workflow needs attention` are sent. |
-| Session identity for custom sources | `--agent-session-id`, `--agent-session-path`, and `report-agent-session` are accepted, but `agent_session` stays `null`. | The parent session identity is reported once per claim as the documented contract. Retention and automatic restoration are not observable on 0.8.2. |
-| Missing or invalid environment | Not applicable: nothing is invoked. | If `HERDR_ENV` is not exactly `1`, or any of `HERDR_BIN_PATH`, `HERDR_PANE_ID`, `HERDR_SOCKET_PATH` is empty, the reporter never activates and allocates no timer, subprocess, or observation lease. |
-| Server not running | Exit 1 immediately with `server_not_running`; no hang. | The report is dropped with one bounded `protocol_rejected` diagnostic. A hung binary is killed after five seconds and reported as `timeout`. |
-| Older Herdr CLI | Not tested. Commands or flags used here may be rejected. | Rejections surface as bounded `protocol_rejected` or `spawn_failed` diagnostics. They never become agent or workflow failures, and no report is retried until later activity. Older releases are not claimed as compatible. |
-
-Additional limits on this release:
-
-- Reporting is event-driven. This integration adds no reconnect polling or crash-cleanup guarantee.
-- Interactive project-trust decisions also use the prompt lifecycle, including startup/resume and `/trust`; silent saved-policy decisions do not create a block.
-
-The full activity path, from a real workflow run through the host observation stream to the `herdr` CLI invocations, is covered by an integration test against a fake `herdr` executable that records argv. It checks the ordered `working → blocked → working → idle` reports and strictly increasing `--seq` values for a tool-only execution followed by a human-input prompt. The state table it exercises is in [Workflow activity for extensions](/workflows/operations#workflow-activity-for-extensions).
-
-Workflow publication is a separate integration from this reporter. It consumes the host [workflow observation contract](/extensions#workflow-activity-and-lifecycle-hooks) without importing workflow scheduler internals.
+Atomic sends status, generic attention messages, and the parent session's ID and local session path to the local Herdr server. It does not send prompt text, tool arguments, transcripts, or workflow output. Session reporting alone does not guarantee automatic session restoration in Herdr.

--- a/packages/coding-agent/src/core/retry-policy.ts
+++ b/packages/coding-agent/src/core/retry-policy.ts
@@ -9,7 +9,7 @@
  * handling, sleeping, and whether the chain may advance afterwards.
  */
 
-import { retryDelayMs } from "@earendil-works/pi-ai";
+import { retryDelayMs } from "@bastani/pi-ai";
 
 export interface RetryPolicySettings {
 	readonly enabled: boolean;

--- a/packages/coding-agent/src/core/settings-manager-basic-accessors.ts
+++ b/packages/coding-agent/src/core/settings-manager-basic-accessors.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { DEFAULT_MAX_AGENT_RETRY_DELAY_MS } from "@earendil-works/pi-ai";
+import { DEFAULT_MAX_AGENT_RETRY_DELAY_MS } from "@bastani/pi-ai";
 import { normalizePath } from "../utils/paths.ts";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-dispatcher.ts";
 import { SettingsManager } from "./settings-manager-core.ts";

--- a/packages/coding-agent/src/modes/interactive/components/chat-session-host.ts
+++ b/packages/coding-agent/src/modes/interactive/components/chat-session-host.ts
@@ -309,8 +309,9 @@ export class ChatSessionHost<TExtraEntry extends ChatTranscriptEntryLike = never
 		return handleChatSessionInput(this.state, data, this.editorCallbacks());
 	}
 
-	async interrupt(options?: { restoreQueuedMessages?: boolean }): Promise<void> {
-		await interruptChatSession(this.state, options);
+	interrupt(options?: { restoreQueuedMessages?: boolean }): Promise<void> {
+		// Keep the observed settlement: an async wrapper would orphan rejections from Escape callers.
+		return interruptChatSession(this.state, options);
 	}
 
 	async submit(mode: ChatSessionSubmitMode = "auto", submittedText?: string): Promise<void> {

--- a/packages/coding-agent/test/herdr-subagents.test.ts
+++ b/packages/coding-agent/test/herdr-subagents.test.ts
@@ -1,15 +1,25 @@
 import assert from "node:assert/strict";
 import { test, vi } from "vitest";
+import type { IntercomClient } from "../../intercom/broker/client.js";
+import { registerContactSupervisorTool } from "../../intercom/contact-supervisor-tool.js";
+import { createIncomingMessageSender, type IncomingMessageSender } from "../../intercom/incoming-message-delivery.js";
+import { registerIntercomTool } from "../../intercom/intercom-tool.js";
+import { routeIncomingReply } from "../../intercom/reply-routing.js";
+import { ReplyTracker } from "../../intercom/reply-tracker.js";
+import { ReplyWaiterRegistry } from "../../intercom/reply-waiter.js";
+import type { Message, SessionInfo } from "../../intercom/types.js";
 import { createEventBus } from "../src/core/event-bus.js";
 import { createExtensionRuntime, loadExtensionFromFactory } from "../src/core/extensions/loader.js";
 import { ExtensionRunner } from "../src/core/extensions/runner.js";
 import { noOpUIContext } from "../src/core/extensions/runner-ui.js";
+import type { ExtensionFactory } from "../src/core/extensions/types.js";
 import { SessionManager } from "../src/core/session-manager.js";
 import { AgentTaskHost } from "../src/core/tasks/agent-adapter.js";
 import type { TaskResult } from "../src/core/tasks/contracts.js";
 import { deriveSessionActivity } from "../src/extensions/herdr/activity.js";
 import { createHerdrExtension } from "../src/extensions/herdr/index.js";
 import { arg, fakeHerdr } from "./helpers/herdr.js";
+import { createHarnessWithExtensions } from "./test-harness.js";
 
 test("independent subagents keep Herdr working while the parent is settled or awaiting approval", () => {
 	for (const availability of ["ready", "recovering", "unavailable"] as const) {
@@ -103,3 +113,233 @@ test("Herdr observes overlapping owner tasks and reattaches without losing runni
 		await fake.dispose();
 	}
 });
+
+test.each(["need_decision", "interview_request"] as const)(
+	"supervisor-only contact_supervisor %s round trip emits no user approval prompt and retains Herdr working",
+	async (reason) => {
+		const fake = await fakeHerdr();
+		const waiters = new ReplyWaiterRegistry();
+		const replies = new ReplyTracker();
+		const delivered = Promise.withResolvers<void>();
+		const finish = Promise.withResolvers<TaskResult>();
+		const begin = Promise.withResolvers<void>();
+		const cancellation = new AbortController();
+		const prompts: string[] = [];
+		const observePrompts: ExtensionFactory = (pi) => {
+			pi.on("ui_prompt_start", () => {
+				prompts.push("start");
+			});
+			pi.on("ui_prompt_end", () => {
+				prompts.push("end");
+			});
+		};
+		const presence = {
+			cwd: fake.dir,
+			model: "test",
+			pid: process.pid,
+			startedAt: 1,
+			lastActivity: 1,
+			status: "thinking" as const,
+		};
+		const parent: SessionInfo = { ...presence, id: "parent", name: "supervisor" };
+		const child: SessionInfo = { ...presence, id: "child", name: "worker" };
+		let deliver!: IncomingMessageSender;
+		// Only the broker transport is in-memory. Tool formatting, custom-message
+		// admission, reply tracking/correlation, owner activity and reporting are real.
+		const childClient = {
+			sessionId: child.id,
+			supervisorSessionId: parent.id,
+			async sendToSupervisor(to: string, outgoing: Parameters<IntercomClient["sendToSupervisor"]>[1]) {
+				assert.equal(to, parent.id);
+				const message: Message = {
+					id: outgoing.messageId!,
+					timestamp: Date.now(),
+					expectsReply: outgoing.expectsReply,
+					content: { text: outgoing.text },
+				};
+				replies.recordIncomingMessage(child, message);
+				await deliver({ from: child, message, channel: "supervisor", bodyText: message.content.text }, "trigger");
+				delivered.resolve();
+				return { id: message.id, delivered: true };
+			},
+		} as IntercomClient;
+		const parentClient = {
+			sessionId: parent.id,
+			async send(to: string, outgoing: Parameters<IntercomClient["send"]>[1]) {
+				assert.equal(to, child.id);
+				const message: Message = {
+					id: outgoing.messageId!,
+					timestamp: Date.now(),
+					replyTo: outgoing.replyTo,
+					content: { text: outgoing.text },
+				};
+				return { id: message.id, delivered: routeIncomingReply(waiters.pending(), parent, message) };
+			},
+		} as IntercomClient;
+		const supervisor = await createHarnessWithExtensions({
+			responses: ["Considering the worker's question."],
+			extensionFactories: [
+				createHerdrExtension({ env: fake.env, enabled: () => true }),
+				observePrompts,
+				(pi) => {
+					pi.registerWorkflowActivityPublisher().publishSnapshot({ availability: "ready", roots: [] });
+					deliver = createIncomingMessageSender({
+						pi,
+						currentGeneration: () => 1,
+						canDeliver: () => true,
+						queueTurnContext: (context) => replies.queueTurnContext(context),
+					});
+					pi.on("agent_start", () => replies.beginTurn());
+					pi.on("agent_end", () => replies.endTurn());
+					registerIntercomTool(pi, {
+						ensureConnected: async () => parentClient,
+						syncPresenceIdentity() {},
+						homeGroup: () => "default",
+						setJoinedGroups() {},
+						clearJoinedGroups() {},
+						confirmSend: true,
+						replyTracker: replies,
+					});
+				},
+			],
+		});
+		const worker = await createHarnessWithExtensions({
+			extensionFactories: [
+				observePrompts,
+				(pi) =>
+					registerContactSupervisorTool(pi, {
+						childOrchestratorMetadata: {
+							orchestratorTarget: parent.id,
+							runId: "supervisor-only",
+							agent: "worker",
+							index: "0",
+						},
+						ensureConnected: async () => childClient,
+						syncPresenceIdentity() {},
+						resolveSessionTarget: async () => parent.id,
+						beginReplyWait: (from, replyTo, signal) => waiters.begin(from, replyTo, signal),
+					}),
+			],
+		});
+		let request: ReturnType<NonNullable<ReturnType<typeof worker.session.getToolDefinition>>["execute"]> | undefined;
+		try {
+			// Keep UI available: the absence of prompts must not rely on headless mode.
+			await supervisor.session.bindExtensions({ mode: "tui", uiContext: { ...noOpUIContext } });
+			await worker.session.bindExtensions({ mode: "tui", uiContext: { ...noOpUIContext } });
+			await fake.waitFor(1);
+			const host = supervisor.session.getAgentTaskHost();
+			const contact = worker.session.getToolDefinition("contact_supervisor")!;
+			const started = await host.startAgentTask(
+				{ kind: "agent", agent: "worker", task: "Ask the supervisor" },
+				"worker",
+				() => {
+					request = begin.promise.then(() =>
+						contact.execute(
+							"request",
+							{
+								reason,
+								message: "Which implementation should I use?",
+								...(reason === "interview_request"
+									? {
+											interview: {
+												questions: [{ id: "choice", type: "text", question: "Which implementation?" }],
+											},
+										}
+									: {}),
+							},
+							cancellation.signal,
+							undefined,
+							worker.session.extensionRunner.createContext(),
+						),
+					);
+					return { result: request.then(() => finish.promise), cleanup: Promise.resolve({ kind: "reaped" }) };
+				},
+			);
+			assert.ok(started.ok);
+			// Establish active owner work before beginning the coordination round trip.
+			await vi.waitFor(
+				async () => {
+					const calls = (await fake.calls()).filter((call) => call.phase === "end");
+					assert.equal(arg(calls.at(-1)!.args, "--state"), "working");
+				},
+				{ timeout: 5_000 },
+			);
+			begin.resolve();
+			await delivered.promise;
+			assert.ok(request);
+			assert.equal(waiters.pending().length, 1, "the child is waiting for its supervisor, not the user");
+			await vi.waitFor(() => assert.equal(supervisor.eventsOfType("agent_settled").length, 1));
+			const incoming = supervisor.session.messages.find(
+				(message) => message.role === "custom" && message.customType === "intercom_message",
+			);
+			assert.ok(incoming, "the supervisor actually receives the question in its conversation");
+			assert.match(String(incoming.content), /Which implementation/);
+			await supervisor.session.extensionRunner.flushUIPromptNotifications(1_000);
+			await worker.session.extensionRunner.flushUIPromptNotifications(1_000);
+			assert.deepEqual(prompts, []);
+			assert.equal(
+				arg((await fake.waitFor(2)).at(-1)!.args, "--state"),
+				"working",
+				JSON.stringify(await fake.calls()),
+			);
+
+			const structuredReply = { responses: [{ id: "choice", value: "Use the existing implementation." }] };
+			const answer =
+				reason === "interview_request" ? JSON.stringify(structuredReply) : "Use the existing implementation.";
+			const reply = supervisor.session.extensionRunner
+				.getAllRegisteredTools()
+				.find((tool) => tool.definition.name === "intercom")!.definition;
+			const sent = await reply.execute(
+				"reply",
+				{ action: "reply", message: answer },
+				undefined,
+				undefined,
+				supervisor.session.extensionRunner.createContext(),
+			);
+			assert.equal(sent.isError, false);
+			const result = await request;
+			assert.equal(result.isError, false);
+			assert.match(JSON.stringify(result.content), /Use the existing implementation/);
+			if (reason === "interview_request") assert.deepEqual(result.details, { structuredReply });
+			assert.equal(waiters.pending().length, 0);
+			assert.equal(replies.listPending().length, 0);
+			await supervisor.session.extensionRunner.flushUIPromptNotifications(1_000);
+			await worker.session.extensionRunner.flushUIPromptNotifications(1_000);
+			assert.deepEqual(prompts, [], "a supervisor answer must not open a user approval prompt either");
+			const watched = host.watchOwnerTasks();
+			assert.ok(watched.ok);
+			assert.equal(
+				watched.value.snapshot.tasks.find((task) => task.ref.taskId === started.value.taskId)?.execution.kind,
+				"running",
+				"the answered child retains its owner task",
+			);
+			watched.value.dispose();
+			assert.equal(arg((await fake.waitFor(2)).at(-1)!.args, "--state"), "working");
+			finish.resolve({ kind: "cancelled", cause: "user" });
+			await host.waitForTask(started.value.taskId);
+			await vi.waitFor(async () => {
+				const calls = (await fake.calls()).filter((call) => call.phase === "end");
+				assert.equal(arg(calls.at(-1)!.args, "--state"), "idle");
+			});
+			await supervisor.session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+			const reports = (await fake.calls()).filter((call) => call.phase === "end" && call.args[1] === "report-agent");
+			assert.ok(reports.length > 2);
+			assert.equal(arg(reports.at(-1)!.args, "--state"), "idle", "only owner task settlement makes Herdr idle");
+			assert.ok(
+				reports.slice(1, -1).every((call) => arg(call.args, "--state") === "working"),
+				JSON.stringify(reports),
+			);
+			assert.doesNotMatch(JSON.stringify(reports), /Waiting for approval/);
+		} finally {
+			cancellation.abort();
+			finish.resolve({ kind: "cancelled", cause: "shutdown" });
+			begin.resolve();
+			await request;
+			await supervisor.session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+			await supervisor.session.closeSessionTasks();
+			supervisor.cleanup();
+			worker.cleanup();
+			await fake.dispose();
+		}
+	},
+);

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -47,6 +47,7 @@ const project = (name: string, include: string[], exclude: string[]) => ({
 		name,
 		globals: true,
 		environment: "node" as const,
+		globalSetup: ["../../test/global-setup-herdr-isolation.ts"],
 		testTimeout: defaultTestTimeoutMs,
 		include,
 		exclude: ["**/node_modules/**", ...exclude],

--- a/test/global-setup-herdr-isolation.ts
+++ b/test/global-setup-herdr-isolation.ts
@@ -1,0 +1,10 @@
+/**
+ * Test TUIs and CLI fixtures must not claim/release the developer's live pane.
+ * Clear inherited Herdr credentials in the runner before workers and their
+ * subprocesses start. Dedicated reporter tests supply their own fake env.
+ */
+export default function setup(): void {
+	for (const key of Object.keys(process.env)) {
+		if (key.startsWith("HERDR_")) delete process.env[key];
+	}
+}

--- a/test/integration/installed-package-node-extensions.test.ts
+++ b/test/integration/installed-package-node-extensions.test.ts
@@ -106,11 +106,14 @@ function buildInstalledLayout(): string {
 		if (entry === ".bin" || entry === ".cache") continue;
 		const source = join(repoNodeModules, entry);
 		if (!fs.statSync(source).isDirectory()) continue;
-		if (entry === "@bastani") {
+		if (entry === "@bastani" || entry === "@earendil-works") {
 			const scopeDir = join(layoutNodeModules, entry);
 			fs.mkdirSync(scopeDir);
 			for (const scoped of fs.readdirSync(source)) {
-				if (scoped === "atomic") continue;
+				if (entry === "@bastani" && scoped === "atomic") continue;
+				// The local build alias is not a dependency of the published package.
+				// Exclude it on every platform so it cannot hide undeclared imports.
+				if (entry === "@earendil-works" && scoped === "pi-ai") continue;
 				linkDir(join(source, scoped), join(scopeDir, scoped));
 			}
 			continue;

--- a/test/unit/execution-routing-guidance.test.ts
+++ b/test/unit/execution-routing-guidance.test.ts
@@ -169,8 +169,10 @@ describe("workflow-first execution routing", () => {
 		for (const phrase of [
 			"measurement configuration used for that benchmark result",
 			"not a universal workflow default",
-			"| Security, identity, adversarial challenge, final approval | `max`",
-			"| Codebase mapping, lifecycle analysis, compatibility, planning, synthesis, triage, repair | `high`",
+			"`max` is usually overkill and is not preferred in practice.",
+			"| Coding, implementation, routine fixes | `low` or `medium` |",
+			"| Code review, test design, failure analysis, security, identity, adversarial challenge, final approval | `high` or `xhigh` |",
+			"| Codebase mapping, lifecycle analysis, compatibility, planning, synthesis, triage | `high` |",
 			"| User-impact review and final reporting | `medium`",
 			"| Deterministic checks | No model call",
 		]) {
@@ -199,9 +201,11 @@ describe("workflow-first execution routing", () => {
 		}
 
 		for (const phrase of [
-			"Reserve `max` for a high-cost-of-error role or an explicit user request",
-			"For each primary and fallback, choose a level for the same stage role independently",
-			"A fallback is not a reason to inherit `max` mechanically",
+			"`max` is an exception, not a role default.",
+			"Consider it only when task-specific evidence justifies the extra effort or the user explicitly requests it.",
+			"An explicit request wins over these defaults, but the requested level still must appear in the configured catalog; do not invent an unsupported suffix.",
+			"For each primary and fallback, choose a supported level for the same stage role independently.",
+			"If `xhigh` is unavailable, use `high` rather than automatically promoting to `max`; choose another catalog model or leave the stage unpinned if neither is supported.",
 		]) {
 			expect(modelSelection).toContain(phrase);
 		}

--- a/test/unit/runtime-config.test.ts
+++ b/test/unit/runtime-config.test.ts
@@ -182,7 +182,7 @@ describe("WorkflowRuntimeConfig — WORKFLOW_CONFIG_DEFAULTS alignment", () => {
 			resumeInFlight: WORKFLOW_CONFIG_DEFAULTS.resumeInFlight,
 		};
 		assert.equal(config.maxDepth, 4);
-		assert.equal(config.defaultConcurrency, 4);
+		assert.equal(config.defaultConcurrency, 3);
 		assert.equal(config.persistRuns, true);
 		assert.equal(config.statusFile, false);
 		assert.equal(config.resumeInFlight, "ask");

--- a/test/unit/test-herdr-environment-isolation.test.ts
+++ b/test/unit/test-herdr-environment-isolation.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { test } from "vitest";
+import { repositoryRoot } from "../../vitest.base.js";
+import {
+	bunExecutable,
+	makeDirectorySync,
+	makeTempDirectory,
+	removeTempDirectory,
+	spawnSyncCollect,
+	writeTextSync,
+} from "../helpers/runtime.js";
+
+// Structural: each scenario starts a real configured Vitest suite and Node/Bun descendants.
+const REAL_VITEST_ISOLATION_TIMEOUT_MS = 120_000;
+const REAL_VITEST_PROCESS_TIMEOUT_MS = 90_000;
+const DESCENDANT_PROCESS_TIMEOUT_MS = 10_000;
+
+for (const [label, root] of [
+	["repository projects", repositoryRoot],
+	["coding-agent projects", join(repositoryRoot, "packages/coding-agent")],
+]) {
+	test(
+		`${label} isolate inherited Herdr pane credentials before collection and subprocess creation`,
+		() => {
+			const directory = makeTempDirectory("atomic-herdr-test-isolation-");
+			const configPath = join(directory, "vitest.config.mjs");
+			const fixturePath = join(directory, "isolation.test.ts");
+			const configUrl = pathToFileURL(join(root, "vitest.config.ts")).href;
+			const vitestUrl = pathToFileURL(join(repositoryRoot, "node_modules/vitest/dist/index.js")).href;
+			const environmentUrl = pathToFileURL(
+				join(repositoryRoot, "packages/coding-agent/src/extensions/herdr/environment.ts"),
+			).href;
+			const snapshot = `({ keys: Object.keys(process.env).filter(key => key.startsWith("HERDR_")).sort(), eligible: captureHerdrEnvironment(process.env) !== undefined })`;
+			const childSource = `import { captureHerdrEnvironment } from ${JSON.stringify(environmentUrl)}; console.log(JSON.stringify(${snapshot}));`;
+			try {
+				// Retain the real projects' setup and runner settings; only substitute the collected file.
+				writeTextSync(
+					configPath,
+					`import config from ${JSON.stringify(configUrl)};
+export default {
+  ...config,
+  test: {
+    ...config.test,
+    projects: config.test.projects.map(project => ({
+      ...project,
+      test: {...project.test, root: ${JSON.stringify(root)}, include: [${JSON.stringify(fixturePath)}]},
+    })),
+  },
+};\n`,
+				);
+				writeTextSync(
+					fixturePath,
+					`import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from ${JSON.stringify(vitestUrl)};
+import { captureHerdrEnvironment } from ${JSON.stringify(environmentUrl)};
+const atCollection = ${snapshot};
+test("worker cannot activate inherited pane reporting at collection", () => {
+  assert.deepEqual(atCollection, {keys: [], eligible: false});
+});
+for (const runtime of ${JSON.stringify([process.execPath, bunExecutable()])}) {
+  test(runtime + " descendant cannot activate inherited pane reporting", () => {
+    const child = spawnSync(runtime, ["--input-type=module", "-e", ${JSON.stringify(childSource)}], {encoding: "utf8", timeout: ${DESCENDANT_PROCESS_TIMEOUT_MS}});
+    assert.equal(child.status, 0, child.stderr);
+    assert.deepEqual(JSON.parse(child.stdout), {keys: [], eligible: false});
+  });
+}\n`,
+				);
+				const artifacts = join(directory, "artifacts");
+				makeDirectorySync(artifacts);
+				const result = spawnSyncCollect(
+					[
+						process.execPath,
+						join(repositoryRoot, "node_modules/vitest/vitest.mjs"),
+						"--run",
+						"--config",
+						configPath,
+					],
+					{
+						cwd: root,
+						timeout: REAL_VITEST_PROCESS_TIMEOUT_MS,
+						env: {
+							...process.env,
+							ATOMIC_WORKFLOW_ARTIFACT_DIR: artifacts,
+							HERDR_ENV: "1",
+							// Never point a regression, including its RED run, at a real binary or pane.
+							HERDR_BIN_PATH: join(directory, "nonexistent-herdr"),
+							HERDR_PANE_ID: "test-pane",
+							HERDR_SOCKET_PATH: join(directory, "nonexistent.sock"),
+							HERDR_TAB_ID: "test-tab",
+							HERDR_WORKSPACE_ID: "test-workspace",
+						},
+					},
+				);
+				assert.equal(result.exitCode, 0, result.stdout.toString() + result.stderr.toString());
+			} finally {
+				removeTempDirectory(directory);
+			}
+		},
+		REAL_VITEST_ISOLATION_TIMEOUT_MS,
+	);
+}

--- a/test/unit/workflow-tool-parent-budget-resume.test.ts
+++ b/test/unit/workflow-tool-parent-budget-resume.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../packages/workflows/src/durable/tool-primitive.js";
 import { run } from "../../packages/workflows/src/engine/run.js";
 import { BUDGET_WRAP_UP_PROMPT } from "../../packages/workflows/src/engine/run-budget.js";
+import { WORKFLOW_CONFIG_DEFAULTS } from "../../packages/workflows/src/extension/config-loader.js";
 import { createExtensionRuntime } from "../../packages/workflows/src/extension/runtime.js";
 import { workflowResumeAction } from "../../packages/workflows/src/extension/workflow-tool-control.js";
 import { stageControlRegistry } from "../../packages/workflows/src/runs/foreground/stage-control-registry.js";
@@ -111,6 +112,14 @@ test("raised-budget continuation replays tool-parented parallel tasks", async ()
 		},
 	});
 	const runtime = createExtensionRuntime({
+		// Admit the whole fan-out before any task settles, keeping every task parented by the preflight tool.
+		config: {
+			maxDepth: WORKFLOW_CONFIG_DEFAULTS.maxDepth,
+			defaultConcurrency: taskNames.length,
+			persistRuns: WORKFLOW_CONFIG_DEFAULTS.persistRuns,
+			statusFile: WORKFLOW_CONFIG_DEFAULTS.statusFile,
+			resumeInFlight: WORKFLOW_CONFIG_DEFAULTS.resumeInFlight,
+		},
 		adapters: {
 			agentSession: {
 				async create(_options, meta: StageExecutionMeta) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,9 @@ const setupFiles = ["./test/setup-workflow-durability.ts"];
  * Global setups run once per project in the orchestrator process, before any
  * file is collected.
  *
+ * `global-setup-herdr-isolation` strips inherited pane credentials before any
+ * workers or CLI fixtures can report to the developer's live Herdr pane.
+ *
  * `global-setup-workflow-artifacts` creates the per-run workflow-artifact
  * directory that `setup-workflow-durability` points workers at, and removes it
  * in teardown. It runs for all three projects.
@@ -27,6 +30,7 @@ const setupFiles = ["./test/setup-workflow-durability.ts"];
  * single `existsSync`, so CI — which builds the binding in an explicit step
  * first — and any warm worktree pay nothing.
  */
+const herdrSetup = "./test/global-setup-herdr-isolation.ts";
 const artifactSetup = "./test/global-setup-workflow-artifacts.ts";
 const nativeSetup = "./test/global-setup-natives.ts";
 
@@ -40,7 +44,7 @@ const project = (name: string, directory: string) => ({
 		include: [`${directory}/**/*.test.ts`],
 		exclude: ["**/node_modules/**"],
 		setupFiles,
-		globalSetup: [artifactSetup, nativeSetup],
+		globalSetup: [herdrSetup, artifactSetup, nativeSetup],
 		testTimeout: TEST_TIMEOUT_MS,
 		hookTimeout: TEST_TIMEOUT_MS,
 	},


### PR DESCRIPTION
## Summary

Fix failures found while checking the latest five commits: `cbd9e12c67`, `6806f79952`, `8531b1e1fa`, `c7d8c66d09`, and `2346bebb54`. Also include the requested Herdr test isolation, supervisor-coordination regressions, and concise user guides.

## Changes

- Use the declared `@bastani/pi-ai` dependency for core retry imports. Exclude the checkout-only upstream alias from the installed Node smoke so Linux/macOS cannot hide the Windows startup failure.
- Return the original observed chat interruption promise instead of creating an unhandled async wrapper. Keep cancellation errors observable by callers and retain fault-injection coverage.
- Pin the intended concurrency default of three and explicitly request four slots in the four-task budget-replay fixture. Preserve its topology and replay assertions.
- Align reasoning-guidance assertions with the latest deliberate coding/review defaults while retaining explicit-user-request and catalog/fallback safeguards.
- Strip inherited `HERDR_*` variables in both Vitest configurations before workers start. Test-created reporters must not send idle/release reports to the developer's live pane. Real-runner regressions cover collection and Node/Bun subprocess inheritance; dedicated fake reporter tests still work.
- Add decision and structured-interview `contact_supervisor` round-trip tests with real tool registration, message admission, reply correlation, owner-task tracking, and a fake Herdr CLI. Assert no user-approval events and continued working status until the task settles. No speculative production reporter suppression was added.
- Reduce `development.md` to 89 lines and `herdr.md` to 53 lines. Add an `AGENTS.md` rule keeping shipped docs user-facing and internal details in repository docs, code/test comments, or PR descriptions.

## Validation

- Final full root unit suite: **799 files passed, 7,959 tests passed, 23 skipped**. The isolation regression was rerun after adding subprocess deadlines: 2 tests passed.
- Final full coding-agent suite: **536 files passed, 4,419 tests passed, 50 skipped**.
- Rebuilt installed Node smoke plus stage-chat integration: **27 tests passed**.
- Supervisor-coordination validation: **38 Herdr tests and 24 Intercom tests passed**, including repeated focused runs.
- `npm run check`, signed commit hooks, docs link validation, and scoped qlty checks passed.
- Original CI evidence: https://github.com/bastani-inc/atomic/actions/runs/34387897833

### Integration environment limitations

An earlier isolated full integration run passed **831 tests, 12 skipped**. The latest full run passed **830 tests** and failed only during npm installation for the packed-workflow SDK test, before its type assertions. This is an upstream AWS SDK publication race: the install first failed with ETARGET, then the newly listed `@aws-sdk/credential-provider-login@3.972.78` tarball returned HTTP 404 on a fresh-metadata retry. No dependency pins or test assertions were weakened to bypass it. The latest integration run is not claimed green.

Local runs also encountered a pre-existing shared PostgreSQL process launched from a deleted checkout, with missing timezone files. A private nonexistent Unix-socket `DBOS_SYSTEM_DATABASE_URL` safely prevents attachment/provisioning; the tests keep their existing in-memory backend. The shared process was not stopped or changed. This is not real PostgreSQL durability coverage.

### Herdr observation boundary

A safe fake-endpoint probe reproduced a test-created TUI reporter issuing `idle` and `release-agent` with inherited pane settings. The isolation regressions fail before the fix and pass afterward. This prevents that interference path, but the precise historical one-second UI transition was not captured. No test reports, releases, restarts, or manual state overrides were sent to the live pane.

No merge or release actions requested or performed.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary

- Improves Herdr environment isolation and supervisor coordination coverage.
- Simplifies coding-agent documentation, but the development guide still contains maintainer-only test, CI, smoke-test, and shrinkwrap procedures.

The documentation requirement must be satisfied before merging.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until the documentation requirement is satisfied.

The review contains one blocking repository-rule violation in the coding-agent documentation.

**Files Needing Attention:** packages/coding-agent/docs/development.md

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/coding-agent/docs/development.md:53-76
**Keep User Docs User-Facing**

This coding-agent documentation retains maintainer test commands, CI details, an installed-package smoke procedure, and shrinkwrap maintenance instructions. The repository requires this directory to contain concise user-facing usage, configuration, and troubleshooting guidance rather than test infrastructure or maintainer-only procedures. Move these details to repository-level documentation; this repository requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: isolate Herdr pane state and cover..."](https://github.com/bastani-inc/atomic/commit/c2caf01da2daea88f4a5d291bf3406fb6e93bcba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62251654)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))
- Knowledge Base — [Coding agent application](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/coding-agent.md)
- Knowledge Base — [Coding agent startup and sessions](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/coding-agent-startup-and-sessions.md)
- Knowledge Base — [Intercom delivery and replies](https://app.greptile.com/bastani-inc/-/custom-context/knowledge-base/bastani-inc/atomic/-/docs/intercom-delivery-and-replies.md)
</details>


<!-- /greptile_comment -->