### PR TITLE
fix(test): normalize Herdr fixture glob paths on Windows

### DIFF
--- a/test/unit/test-herdr-environment-isolation.test.ts
+++ b/test/unit/test-herdr-environment-isolation.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { convertPathToPattern } from "tinyglobby";
 import { test } from "vitest";
 import { repositoryRoot } from "../../vitest.base.js";
 import {
@@ -27,6 +28,8 @@ for (const [label, root] of [
 			const directory = makeTempDirectory("atomic-herdr-test-isolation-");
 			const configPath = join(directory, "vitest.config.mjs");
 			const fixturePath = join(directory, "isolation.test.ts");
+			// Vitest include entries are glob patterns, not native Windows paths.
+			const fixturePattern = convertPathToPattern(fixturePath);
 			const configUrl = pathToFileURL(join(root, "vitest.config.ts")).href;
 			const vitestUrl = pathToFileURL(join(repositoryRoot, "node_modules/vitest/dist/index.js")).href;
 			const environmentUrl = pathToFileURL(
@@ -45,7 +48,7 @@ export default {
     ...config.test,
     projects: config.test.projects.map(project => ({
       ...project,
-      test: {...project.test, root: ${JSON.stringify(root)}, include: [${JSON.stringify(fixturePath)}]},
+      test: {...project.test, root: ${JSON.stringify(root)}, include: [${JSON.stringify(fixturePattern)}]},
     })),
   },
 };\n`,


### PR DESCRIPTION
## Summary

Fix both Herdr environment-isolation regressions failing before collection on Windows in [CI job 102606661411](https://github.com/bastani-inc/atomic/actions/runs/34393285367/job/102606661411).

## Changes

Convert the native fixture path with the existing tinyglobby `convertPathToPattern` API before serializing the Vitest include pattern. Preserve all isolation assertions, real project settings, subprocess coverage, and timeouts. No shipped behavior changes.

## Validation

- Both focused isolation scenarios passed locally.
- `npm run check` and commit hooks passed.
- Independent debugger static review found no blocking issue.
- A subprocess probe of the library Windows conversion branch produced the expected forward-slash pattern. This is not actual Windows Vitest execution.

## Notes

The user explicitly requested immediate admin merge after local validation due to time constraints. Hosted CI is not claimed green. The separate Linux archive timeout change is not included; publication remains paused.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791574260&installation_model_id=10562&pr_number=2961&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2961&signature=4a637a149e27297f21161452e96fe1d2ba27c2918f28eab8c7e0130039c93990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes the temporary Herdr isolation fixture path safe for Vitest glob matching on Windows while retaining the existing generated configuration for both repository roots. The focused isolation test completes successfully for both scenarios.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the Windows path normalization behaves as intended and the affected isolation coverage passes.

No actionable issues were found. A representative Windows path was converted to a slash-separated glob pattern, and the focused test passed for both generated Vitest configurations.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that the Windows-path check converts a backslash-separated temporary fixture path into a slash-separated glob pattern.
- Executed the focused Herdr isolation test and confirmed it passes for both repository-root configurations.
- Authored and executed the Windows glob validation script and captured the pre-change Windows-native include entry and the post-change slash-separated pattern.
- Ran the focused Vitest execution under both configurations and observed a passing result for the isolation test.

<a href="https://app.greptile.com/trex/runs/23420198/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): normalize Herdr fixture glob ..."](https://github.com/bastani-inc/atomic/commit/119eff9d4db060a96aa2f244530438a4afc8f361) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62273001)</sub>

<!-- /greptile_comment -->