### PR TITLE
test(build): fail when emitted JavaScript calls the result of a new expression

### DIFF
--- a/test/unit/dist-emit-integrity.test.ts
+++ b/test/unit/dist-emit-integrity.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { extname, join, relative } from "node:path";
+import { parse } from "acorn";
+import { simple } from "acorn-walk";
+import { test } from "vitest";
+import { fileExistsSync, moduleDir } from "../helpers/runtime.js";
+
+const root = join(moduleDir(import.meta.url), "../..");
+const distRoot = join(root, "packages", "coding-agent", "dist");
+const supervisorPath = join(distRoot, "core", "tasks", "supervisor.js");
+const buildCommand = "npm --workspace=@bastani/atomic run build";
+
+/** Copied verbatim by `copy-assets`: browser fragments, not emitted modules, and not standalone programs. */
+const copiedAssetDirectories = ["core/export-html/template-js", "core/export-html/vendor"];
+
+function listEmittedJavaScript(directory: string): string[] {
+	return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+		const path = join(directory, entry.name);
+		if (entry.isDirectory()) return entry.name === "node_modules" ? [] : listEmittedJavaScript(path);
+		return [".js", ".mjs", ".cjs"].includes(extname(entry.name)) ? [path] : [];
+	});
+}
+
+/**
+ * `new f(a)(b)` in emitted output means the compiler moved construction onto the
+ * wrong callee. It is what shipped in 0.9.19-alpha.2: erasing `as typeof native`
+ * dropped the parentheses in
+ * `new (require(...) as typeof native).TaskSupervisor()`, so the native class ran
+ * as a plain function and every task supervisor held an inert object. Nothing
+ * else in the built tree uses this shape, so any hit is a miscompile.
+ */
+test("emitted JavaScript never calls the result of a new expression", () => {
+	assert.ok(
+		fileExistsSync(supervisorPath),
+		`Missing built artifact ${supervisorPath}. Run \`${buildCommand}\` before this test.`,
+	);
+	const offenders: string[] = [];
+
+	for (const path of listEmittedJavaScript(distRoot)) {
+		const relativePath = relative(distRoot, path).replaceAll("\\", "/");
+		if (copiedAssetDirectories.some((directory) => relativePath.startsWith(`${directory}/`))) continue;
+		const source = readFileSync(path, "utf8");
+		const program = parse(source, { ecmaVersion: "latest", sourceType: "module", locations: true });
+		simple(program, {
+			CallExpression: (node) => {
+				if (node.callee.type !== "NewExpression" || node.callee.arguments.length === 0) return;
+				offenders.push(`${relativePath}:${node.loc?.start.line}: ${source.slice(node.start, node.end)}`);
+			},
+		});
+	}
+
+	assert.deepEqual(offenders, []);
+});


### PR DESCRIPTION
Closes #2966.

## Problem

`@bastani/atomic` 0.9.19-alpha.2 shipped `dist/core/tasks/supervisor.js:518` as

```js
#native = new createModuleRequire(import.meta.url)("@bastani/atomic-natives").TaskSupervisor();
```

compiled from

```ts
#native = new (createModuleRequire(import.meta.url)("@bastani/atomic-natives") as typeof native).TaskSupervisor();
```

The parentheses existed only to wrap `as typeof native`; erasing the assertion dropped them, and `new f(a)(b).C()` parses as `((new f(a))(b)).C()`. The napi class ran as a plain function, every `TaskSupervisor` held an inert object, and every command and subagent tool died in the published build. Nothing in the repository inspects emitted JavaScript, so the divergence shipped.

## What this adds

`test/unit/dist-emit-integrity.test.ts`: parse every emitted `.js`/`.mjs`/`.cjs` under `packages/coding-agent/dist` with acorn and fail on any `CallExpression` whose callee is a `NewExpression` with arguments. The two verbatim-copied browser fragment directories (`core/export-html/template-js/`, `core/export-html/vendor/`) are excluded because `copy-assets` copies them as fragments, not standalone programs; every other file must parse, and a parse failure fails the test.

One AST rule suffices: on the pre-fix tree it produces exactly one hit, and on the fixed tree zero across 815 emitted files. It is artifact-level, so it catches the defect whatever source shape produces it, unlike a lint rule against `new (x as T).y()`.

`test/unit` matches `builtin-copy-import-closure.test.ts` (built artifact required, build command named in the failure message), and `.github/workflows/test.yml:111-113` builds `packages/coding-agent` before `npm run test:unit`.

## Verification

Guard against the stale pre-fix `dist` (the artifact that shipped), before rebuilding:

```
$ npx vitest --run --project unit test/unit/dist-emit-integrity.test.ts
 FAIL  |unit| test/unit/dist-emit-integrity.test.ts > emitted JavaScript never calls the result of a new expression
AssertionError: Expected values to be strictly deep-equal:
+ actual - expected

+ [
+   'core/tasks/supervisor.js:518: new createModuleRequire(import.meta.url)("@bastani/atomic-natives")'
+ ]
- []
```

After `npm --workspace=@bastani/atomic-natives run build && npm --workspace=@bastani/atomic run build`:

```
$ npx vitest --run --project unit test/unit/dist-emit-integrity.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  5.42s (tests 4.01s)
```

and the rebuilt artifact reads

```js
function createNativeSupervisor() {
    const binding = createModuleRequire(import.meta.url)("@bastani/atomic-natives");
    return new binding.TaskSupervisor();
}
export class TaskSupervisor {
    #native = createNativeSupervisor();
```

with no `new createModuleRequire` in the file. Constructing from that artifact and calling `bindHostSession` prints `BIND-OK host`.

`npm run check` passes. `npm run test:unit`: this test passes; 46 tests in 16 unrelated files fail locally on Windows (interactive engine, workflow/subagent session, install-powershell, herdr isolation suites), overwhelmingly as timeouts on a loaded machine. This branch differs from `origin/main` by exactly one added file that nothing imports, so those failures are independent of the change.

No explicit vitest timeout: the scan takes ~4 s (17 s cold cache on Windows) against the shared 30 s budget.

## Scope

The source fix is already on `main` in `d7c80a898`, so this PR carries no product change and no changelog entry — `AGENTS.md` restricts `packages/*/CHANGELOG.md` to shipped user-facing behaviour, and this is test infrastructure. It also does not duplicate the behavioural probe `d7c80a898` added to `test/integration/installed-package-node-extensions.test.ts`; that constructs one class from an installed layout, while this detects the emit defect class across the whole artifact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791584542&installation_model_id=10562&pr_number=2967&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2967&signature=578b591d93d66bad96203f4f64ff5bbaa6f915a206be3533d59e01c19f359759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary

- Adds a regression test that parses emitted coding-agent JavaScript and rejects calls on constructed expressions.
- The test must use the repository’s shared runtime helpers before merging.

<h3>Confidence Score: 4/5</h3>

Not merge-safe until the shared-runtime-helper repository requirement is satisfied.

The final findings contain one confirmed, blocking repository-rule violation and no higher-impact findings.

**Files Needing Attention:** test/unit/dist-emit-integrity.test.ts

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/unit/dist-emit-integrity.test.ts:2
**Use Shared Runtime Helpers**

This root test imports `readdirSync` and `readFileSync` directly from `node:fs` instead of using `test/helpers/runtime.ts`. Use the existing `readDirectorySync` and `readTextSync` helpers, adding a shared helper there only if needed. This violates the repository directive and must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(build): fail when emitted JavaScrip..."](https://github.com/bastani-inc/atomic/commit/4de605dfbbe5c83a062dac63fa92de1eafb89247) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62347280)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/bastani-inc/atomic/blob/main/AGENTS.md))

<!-- /greptile_comment -->