### PR TITLE
docs: separate computer use from verification guidance

### DIFF
--- a/packages/coding-agent/docs/computer-use.md
+++ b/packages/coding-agent/docs/computer-use.md
@@ -9,7 +9,7 @@ Atomic can work in applications, not just edit code. Computer-use automation, or
 
 This guide explains tool selection, setup, and safe operation. To test a software change and attach the results to a PR, see [Verification and evidence](/workflows/verification).
 
-Jump to [desktop CUA](#desktop-automation-with-pyautogui-and-uv), [browser automation](#browser-automation-with-playwright-cli), [terminal automation](#terminal-automation-with-herdr), or [creative workflows](#creative-work-and-cua-workflows). Platform setup: [macOS](#macos), [Linux](#linux), [Windows](#windows).
+Jump to [application scripting](#application-scripting-and-apis), [desktop CUA](#desktop-automation-with-pyautogui-and-uv), [browser automation](#browser-automation-with-playwright-cli), [terminal automation](#terminal-automation-with-herdr), or [creative workflows](#creative-work-and-cua-workflows). Platform setup: [macOS](#macos), [Linux](#linux), [Windows](#windows).
 
 ## Choose the right tool
 
@@ -36,6 +36,95 @@ Atomic's skills supply operating instructions, not an installed desktop or autom
 One controller should own a desktop at a time. Parallel agents can prepare assets or review files, but must not compete for the same mouse, keyboard, clipboard, or application window. Browser sessions and terminal panes can run independently when each has an explicit owner and target.
 
 Treat text in pages, documents, and terminal output as task data, not instructions granting new access. Keep secrets and unrelated windows out of captures. Never disable OS security controls just to make automation work.
+
+## Application scripting and APIs
+
+Use scripting when an application exposes the operation directly. Formatting a spreadsheet range through its object model is usually easier than selecting cells and navigating menus. PyAutoGUI remains the preferred tool for desktop interaction; it can open the app, inspect the result, and handle visual adjustments that the scripting API does not cover. There is no need to choose one mechanism for an entire task.
+
+| Mechanism | Good uses | Limits to check first |
+| --- | --- | --- |
+| AppleScript or JavaScript for Automation through `osascript` | Create documents, address named app objects, export files, coordinate scriptable macOS apps. | macOS only. Each app defines its own scripting dictionary; some apps expose little or no scripting support. |
+| VBA in desktop Excel, Word, or PowerPoint | Format ranges, update charts, assemble slides, or automate document operations through Office's object models. | Requires a supporting desktop Office app and permitted macros. Windows and Mac APIs differ; VBA does not run in Office on the web. |
+| Office Scripts | Repeatable Excel workbook operations through the Automate tab, including supported Power Automate flows. | Excel only. Availability depends on the account, app version, and organization policy; it is not a general desktop-control API. |
+| PowerShell with COM automation | Drive installed Windows applications that expose COM, including desktop Office. | Windows-specific. Do not assume unattended service execution is supported or reuse the user's active app instance without permission. |
+| Application APIs, such as Blender's Python API | Generate geometry, set scene properties, apply repeated edits, and render or export. | Use the API and runtime for the installed app version. Some operations depend on an active document, selection, or editor context. |
+| File libraries or media CLIs | Generate a deck with `python-pptx`, edit a workbook with `openpyxl`, or transform media with FFmpeg. | These edit files, not the live app. Check preservation of unsupported features and inspect the result in the target application. |
+
+Before writing a script, identify the target app/version, input document, object names, and output path. Read the application's API reference or scripting dictionary rather than guessing methods. Start with a read-only query or a disposable copy, and keep a record of which operations changed the document.
+
+### macOS recipe: create a draft with osascript
+
+Open Script Editor and choose File > Open Dictionary to inspect an application's supported commands, objects, and properties. Apple's [scripting terminology guide](https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/AboutScriptingTerminology.html) explains how to read the dictionary. App scripting addresses document objects directly; `System Events` UI scripting instead drives accessible interface controls and needs Accessibility permission.
+
+Save this as `create-note.applescript`:
+
+```applescript
+on run argv
+    if (count of argv) is not 1 then error "Pass the draft text as one argument."
+    set draftText to item 1 of argv
+    tell application "TextEdit"
+        set draft to make new document with properties {text:draftText}
+        activate
+        return (text of draft) as text
+    end tell
+end run
+```
+
+Run it from a macOS shell:
+
+```sh
+osascript create-note.applescript "Draft outline for the presentation"
+```
+
+This creates a new, unsaved TextEdit document and returns its text to the shell. It does not overwrite a file. Check the returned text and inspect the document, then save to an agreed destination if required. macOS may ask permission for the launching app to control TextEdit; let the user grant it.
+
+Pass content as arguments rather than interpolating it into executable script text. For longer content, have the script read an explicit input file. JavaScript for Automation is another macOS option, invoked with `osascript -l JavaScript script.js`; it uses Apple's automation objects, not a browser DOM or Node.js APIs. Use whichever language fits the app's documentation and existing scripts.
+
+### Office recipe: format an Excel report with VBA
+
+For a desktop workbook, use [VBA](https://learn.microsoft.com/en-us/office/vba/library-reference/concepts/getting-started-with-vba-in-office) to change specific ranges instead of sending a long sequence of clicks. Try this on a trusted copy of a workbook with a worksheet named `Summary` and a report in `A1:D20`:
+
+1. Save the copy as an Excel Macro-Enabled Workbook, `.xlsm`, if you want to retain the macro.
+2. Open Developer > Visual Basic. In the copied workbook's project, choose Insert > Module and paste the macro below. If Developer is hidden, enable that tab through Excel's ribbon settings.
+3. Review the code and run `FormatSummary` through Developer > Macros, subject to your organization's macro policy.
+4. Inspect the header, number formatting, and column widths. Save only the reviewed copy.
+
+```vb
+Option Explicit
+
+Sub FormatSummary()
+    Dim report As Worksheet
+    Set report = ThisWorkbook.Worksheets("Summary")
+
+    report.Range("A1:D1").Font.Bold = True
+    report.Range("B2:D20").NumberFormat = "#,##0.00"
+    report.Range("A1:D20").Columns.AutoFit
+End Sub
+```
+
+`ThisWorkbook` is the workbook containing the macro, not whichever workbook happens to be active. Put the macro in the copied report's project, not a personal macro workbook. The example changes formatting only and does not save automatically. Its operations are documented in the [Excel VBA reference](https://learn.microsoft.com/en-us/office/vba/api/overview/excel).
+
+For other jobs, address workbook, worksheet, slide, shape, or document objects explicitly. A recorded macro can help discover operations, but replace dependence on `Selection`, `ActiveSheet`, or `ActivePresentation` with references to the intended objects before reusing it. For presentations, use PowerPoint's object model rather than treating Excel VBA as a universal Office API.
+
+Never enable all macros, weaken Trust Center settings, or enable programmatic access to the VBA project just to inject code. If policy blocks the macro, use an approved mechanism or report the restriction. VBA in a document can access more than that document, so inspect unfamiliar macros before opening or running them. If a script changes application-wide settings such as events or alerts, restore their previous values on success and error; do not suppress prompts to force a save.
+
+VBA support in desktop Excel, Word, and PowerPoint includes macOS, but Windows COM, ActiveX, and Win32-dependent code is not portable. Consult Microsoft's [Office for Mac guidance](https://learn.microsoft.com/en-us/office/vba/api/overview/office-mac) for sandbox and file-access differences. Saving as `.xlsx` cannot retain VBA; choose the output format deliberately.
+
+### Office Scripts, app runtimes, and file tools
+
+For Excel on the web or a supported desktop installation with the Automate tab, consider Office Scripts. Record a small action or create a script there, then use the `ExcelScript` workbook API for repeatable edits. These TypeScript scripts are not VBA and do not run as ordinary Node.js scripts. Check [Office Scripts versus VBA](https://learn.microsoft.com/en-us/office/dev/scripts/resources/vba-differences) for platform, licensing, and API differences. Creating a Power Automate flow can introduce scheduled runs and cloud access; do so only when that automation is part of the request.
+
+Use an application's own scripting runtime when it supplies the API. For example, Blender scripts normally run through Blender's Python Console, Text Editor, or command line. A plain uv Python environment does not automatically have the running application's `bpy` module or scene. With Blender on PATH, an existing `input.blend`, and a reviewed `scene-script.py`, a batch invocation is:
+
+```sh
+blender --background input.blend --python-exit-code 1 --python scene-script.py
+```
+
+Argument order matters. This loads the scene before running the script, and `--python-exit-code 1` makes a script exception produce a nonzero process exit. The script must explicitly save or export any intended output to a new path; exiting successfully does not imply a saved scene. See the [Blender Python quickstart](https://docs.blender.org/api/current/info_quickstart.html) and [command-line reference](https://docs.blender.org/manual/en/latest/advanced/command_line/arguments.html). Use uv for external orchestration or file-processing scripts, and Blender's runtime for Blender operations.
+
+For file-only work, a library can avoid opening the application at all. Know what it preserves: [openpyxl does not calculate Excel formulas](https://openpyxl.readthedocs.io/en/stable/simple_formulae.html), and a deck created with [python-pptx](https://python-pptx.readthedocs.io/en/latest/) still needs a layout check for clipping, fonts, and missing media. For video, FFmpeg can handle batch transforms while an editor's own scripting API can retain timeline structure. Check installed API/version or edition limits before assuming an editor exposes scripting.
+
+Combine these approaches when useful: generate the content with a script, open the result with CUA, adjust the visual details, export, and reopen the export. A successful API call proves neither visual quality nor that the GUI path works. If the task is specifically to verify a menu, dialog, or user flow, exercise that interface too.
 
 ## Desktop automation with PyAutoGUI and uv
 
@@ -191,7 +280,7 @@ For modified-key setup in Atomic, see [tmux setup](/tmux). For behavioral checks
 - PyAutoGUI depends on native Python bindings on macOS. If import or capture fails, check the installed release's [installation requirements](https://pyautogui.readthedocs.io/en/latest/install.html) before adding dependencies to the uv environment.
 - Check Retina scaling and keep the target on the primary display. A black or incomplete capture usually needs permission or display troubleshooting, not more clicks.
 
-Use `osascript` for AppleScript or JavaScript for Automation when an app's scripting dictionary exposes the operation you need. For example, `osascript -e 'tell application "TextEdit" to activate'` can bring a known app forward before PyAutoGUI works in it. Inspect the resulting window before typing. `System Events` UI scripting and native accessibility APIs can address menus and controls more reliably than coordinates. Consult Apple's [UI scripting guide](https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/AutomatetheUserInterface.html).
+Use `osascript` for AppleScript or JavaScript for Automation when an app's scripting dictionary exposes the operation you need. See [application scripting and recipes](#application-scripting-and-apis) for a runnable example and Office automation choices. `System Events` UI scripting and native accessibility APIs can address menus and controls more reliably than coordinates; consult Apple's [UI scripting guide](https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/AutomatetheUserInterface.html).
 
 `screencapture` is useful for native screenshots; Screenshot or QuickTime Player can record the screen or a selected area. Check permissions and the selected recording region before capture.
 
@@ -231,7 +320,7 @@ Herdr is preferred when eligible; tmux is a practical fallback on local or remot
 - Use a consistent display scale and primary monitor. Check coordinates again after moving a window between displays with different DPI settings.
 - Standard-user automation cannot reliably drive elevated apps or the UAC secure desktop. Stop for the user or choose an authorized non-elevated path rather than escalating just to force input through.
 
-[Windows UI Automation](https://learn.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-overview) exposes controls by name and automation ID. Tools such as [pywinauto](https://pywinauto.readthedocs.io/en/latest/) can be easier than pixel matching for accessible Windows apps. PowerShell, COM automation, or an application's own API can handle structured document operations. Use PyAutoGUI for the remaining visual interactions.
+[Windows UI Automation](https://learn.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-overview) exposes controls by name and automation ID. Tools such as [pywinauto](https://pywinauto.readthedocs.io/en/latest/) can be easier than pixel matching for accessible Windows apps. For structured document operations, see [VBA, PowerShell/COM, and app scripting](#application-scripting-and-apis). Use PyAutoGUI for the remaining visual interactions.
 
 Snipping Tool or OBS can capture desktop evidence. Check the selected window and saved recording before sharing it.
 

--- a/packages/coding-agent/docs/computer-use.md
+++ b/packages/coding-agent/docs/computer-use.md
@@ -1,0 +1,283 @@
+---
+title: "Computer use"
+description: "Use desktop apps, browsers, and terminals with Atomic on macOS, Linux, and Windows."
+---
+
+# Computer use
+
+Atomic can work in applications, not just edit code. Computer-use automation, or CUA, can create a Blender scene, build a presentation, edit a video, operate a desktop app, or move work between applications. Browser and terminal automation cover related tasks with more direct controls.
+
+This guide explains tool selection, setup, and safe operation. To test a software change and attach the results to a PR, see [Verification and evidence](/workflows/verification).
+
+Jump to [desktop CUA](#desktop-automation-with-pyautogui-and-uv), [browser automation](#browser-automation-with-playwright-cli), [terminal automation](#terminal-automation-with-herdr), or [creative workflows](#creative-work-and-cua-workflows). Platform setup: [macOS](#macos), [Linux](#linux), [Windows](#windows).
+
+## Choose the right tool
+
+| Where the work happens | Preferred tool | When to use something else |
+| --- | --- | --- |
+| Interactive terminal or TUI | **Herdr** | Use tmux on macOS/Linux or native Windows psmux when Herdr cannot be used. Ordinary shell commands need no multiplexer. |
+| Browser page or web application | **playwright-cli** | Use desktop CUA for browser chrome or OS dialogs that browser automation cannot reach. Keep existing Playwright test suites for repeatable tests. |
+| Desktop application or work across apps | **PyAutoGUI, run with uv** | Use native accessibility tools, application scripting, or a CLI when they make the task easier, safer, or more reliable. |
+
+These are preferences, not a requirement to drive every task through one tool. For example, use Blender's Python API to generate repeated objects, then PyAutoGUI to adjust the scene in the visible editor. Use macOS `osascript` to address a named application or menu instead of guessing screen coordinates. Use browser DOM controls rather than desktop clicks for a web form.
+
+Atomic's skills supply operating instructions, not an installed desktop or automatic permission to control one. Load the `herdr`, `playwright-cli`, or `tmux` skill when applicable. Check the installed command's help before using version-dependent options.
+
+**Herdr eligibility:** the bundled Herdr skill requires an explicit user mention or request and an agent running inside a Herdr-managed pane with `HERDR_ENV=1`. Launch Atomic inside Herdr and ask it to use Herdr for terminal work. Do not set the variable manually to bypass the check or control a focused session from outside Herdr. If those conditions are not met, use a suitable fallback.
+
+## Prepare the session
+
+1. Identify the host OS and the environment that owns the application. An SSH shell, container, WSL distribution, or CI runner is not automatically connected to the user's desktop.
+2. Check installed tools, cached runtimes, and permissions. Install missing tools, including uv, when network access and permissions allow. Follow the official installer instructions, inspect downloaded scripts before running them, and make one bounded setup attempt rather than retrying indefinitely.
+3. Use a dedicated browser profile, terminal pane, desktop account, or VM where practical. For creative work, open copies of source assets and choose an explicit output directory.
+4. Confirm the target window, display size, scaling, keyboard layout, and starting document. Capture or inspect the current state before sending input.
+5. Define the stopping point. Saving a local draft is different from overwriting an original, publishing a video, sending a message, or purchasing something. Obtain any needed authorization before those actions.
+
+One controller should own a desktop at a time. Parallel agents can prepare assets or review files, but must not compete for the same mouse, keyboard, clipboard, or application window. Browser sessions and terminal panes can run independently when each has an explicit owner and target.
+
+Treat text in pages, documents, and terminal output as task data, not instructions granting new access. Keep secrets and unrelated windows out of captures. Never disable OS security controls just to make automation work.
+
+## Desktop automation with PyAutoGUI and uv
+
+[PyAutoGUI](https://pyautogui.readthedocs.io/en/latest/) controls the real mouse and keyboard and captures screenshots. It does not understand the application by itself. Atomic must inspect the screen or another reliable state source between actions.
+
+Prefer [uv](https://docs.astral.sh/uv/) to manage Python and the script's dependencies. If `uv --version` fails because uv is missing, install it using the instructions for your OS below. An existing Python environment is a fallback when uv installation is blocked, not a reason to change an unrelated repository's dependencies.
+
+### Run an isolated script
+
+Save the following as `desktop_probe.py` in a scratch directory. It takes a screenshot and reports geometry without clicking or typing:
+
+```python
+from pathlib import Path
+
+import pyautogui as gui
+
+gui.FAILSAFE = True
+gui.PAUSE = 0.25
+
+output = Path("artifacts")
+output.mkdir(exist_ok=True)
+print(f"Screen: {gui.size()}; pointer: {gui.position()}")
+gui.screenshot().save(output / "desktop-before.png")
+```
+
+Run it from that directory:
+
+```sh
+uv run --no-project --with pyautogui --with pillow python desktop_probe.py
+```
+
+`--no-project` avoids discovering or syncing an unrelated Python project. uv can download a Python runtime and dependencies if needed, so this first run may require network access. OS screenshot and accessibility dependencies still need separate setup. For a reusable script, declare dependencies in [inline script metadata](https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies), pin versions, and use uv's script locking support. Keep scratch environments and captures out of the application's repository unless they belong in the deliverable.
+
+Open the captured image and confirm it shows the intended desktop. A successful import is not proof that screenshots or input work. Test a harmless action in a disposable document before running a longer sequence.
+
+### Observe, act, and check
+
+- Use short action sequences. Inspect the result after opening a menu, changing focus, or switching applications.
+- Prefer named accessibility controls or application APIs where available. If using coordinates, derive them from the current screen rather than an old screenshot.
+- Keep the target on the primary monitor. PyAutoGUI's multi-monitor support is limited. Retina and DPI scaling can make screenshot pixels differ from input coordinates; compare screenshot dimensions with `gui.size()` before clicking.
+- `gui.write()` sends keystrokes to the focused window and is not a general Unicode text-insertion API. For non-ASCII content, prefer app scripting or a controlled clipboard paste. Clipboard contents may be sensitive, so preserve and restore them when appropriate.
+- For image matching, crop to the relevant region and use fixtures from the same theme and scaling. Handle a missing image as a failed observation, not a reason to click a default location. PyAutoGUI's `confidence` option requires OpenCV in the Python environment.
+- Wait for an observable result with a deadline. A fixed sleep alone does not prove a render, export, or save has finished.
+
+See PyAutoGUI's [keyboard controls](https://pyautogui.readthedocs.io/en/latest/keyboard.html), [mouse controls](https://pyautogui.readthedocs.io/en/latest/mouse.html), and [screenshot functions](https://pyautogui.readthedocs.io/en/latest/screenshot.html) for API details.
+
+### Stop and recover safely
+
+Keep `FAILSAFE` enabled and leave a pause between calls. Moving the pointer to a corner of the primary monitor causes a subsequent PyAutoGUI call to raise `FailSafeException`. Keep a separate way to interrupt the automation process available too.
+
+Prefer complete actions such as `press`, `hotkey`, and `click` over holding input across several steps. If a script must hold a key or mouse button, track what it holds and release it in cleanup. An interrupt or failsafe can itself prevent PyAutoGUI cleanup calls. Stop the script, check for held input, and release it manually or through a safe native mechanism before resuming. Do not disable the failsafe in order to keep clicking.
+
+After a timeout or interruption, inspect the current document and any output files. A save or export may have completed even if its acknowledgement was lost. Do not repeat destructive actions blindly.
+
+## Browser automation with playwright-cli
+
+Prefer [playwright-cli](https://github.com/microsoft/playwright-cli) for websites and web apps on all three desktop platforms. Its snapshots expose page structure and element references, so a workflow can use actual controls rather than screen coordinates.
+
+### Setup and first session
+
+Load the `playwright-cli` skill and check `playwright-cli --help`. If the command is unavailable, check whether the project's installed Playwright exposes `npx --no-install playwright cli --help`. Otherwise install the CLI when permitted:
+
+```sh
+npm install -g @playwright/cli@latest
+playwright-cli --help
+```
+
+Use the installed CLI's browser setup guidance if a browser is missing. Do not add browser automation dependencies to an unrelated project just to run a one-off task.
+
+Create a uniquely named session, replacing `desktop-demo` if that name is already in use:
+
+```sh
+playwright-cli -s=desktop-demo open https://example.com --headed
+playwright-cli -s=desktop-demo snapshot
+playwright-cli -s=desktop-demo screenshot --filename=browser-before.png
+playwright-cli -s=desktop-demo close
+```
+
+For a real task, act between the snapshot and final capture. Read element references from the current snapshot, then use `click`, `fill`, `select`, or `press`. Do not reuse an example reference such as `e5` without discovering what it points to. Refresh the snapshot after navigation or substantial UI changes.
+
+### Best practices
+
+- Keep the same session name on every command. Close only sessions you created, not every browser on the machine.
+- Prefer a fresh profile. Attach to an existing personal browser only when authorized; stored sessions can expose private tabs and credentials.
+- Use headed mode for visual work. Headless mode can verify DOM behavior, but does not establish that desktop integration or native dialogs work.
+- Inspect visible results and relevant console/network output. Use semantic locators and assertions in a maintained Playwright test for repeatable regression coverage.
+- Use `upload` for supported file inputs rather than driving an OS file picker. Switch to CUA or native tooling only for UI outside the page, and then recheck focus before returning to browser control.
+- Treat cookies, saved authentication state, traces, and network logs as sensitive. Do not commit or attach a browser profile as evidence.
+- Browser mobile emulation tests a web viewport, not a native Android or iOS application.
+
+For verification captures and recordings, see [browser evidence](/workflows/verification#browser-changes).
+
+## Terminal automation with Herdr
+
+Prefer Herdr for interactive terminal work on macOS, Linux, and Windows, subject to the [eligibility requirements](#choose-the-right-tool). Use ordinary shell execution for builds, scripts, or commands that do not need interactive input. A long-running command alone is not a reason to add a multiplexer.
+
+### Setup and a dedicated pane
+
+Check `herdr --version` and `herdr --help`. Install missing Herdr using its [official installation guide](https://github.com/herdrdev/herdr/tree/v0.9.0#install) when permitted. macOS supports `brew install herdr`; macOS/Linux and Windows also have official shell and PowerShell installers. Inspect downloaded scripts before executing them.
+
+Once inside an eligible managed pane, check `herdr status` for client/server compatibility. Do not stop or replace an active server just to obtain a new feature. Atomic's automatic status reporting is documented separately in [Herdr integration](/herdr).
+
+Use the Herdr skill to discover the current pane and create a dedicated sibling without changing the user's focus. For example, in a POSIX shell inside Herdr:
+
+```sh
+herdr pane split --current --direction right --cwd "$PWD" --no-focus
+```
+
+Choose the split direction to suit the available space. Read the new pane ID from the creation response. In the commands below, replace `<pane-id>` with that returned ID and `<command>` with the intended command:
+
+```text
+herdr pane run <pane-id> "<command>"
+herdr pane wait-output <pane-id> --match "<expected output>" --timeout 10000
+herdr pane read <pane-id> --source visible
+```
+
+`pane run` sends text and Enter. `pane send-text` alone does not submit. `wait-output` can match text already on the screen, so use a fresh pane or a run-specific marker and inspect the result. The appearance of a marker is not a substitute for checking the command's exit status or the application's final state.
+
+For ordinary logs, `--source recent-unwrapped --lines 120` avoids soft-wrapped lines. For layout, inspect `visible` at the intended terminal dimensions. Alternate-screen content that has scrolled away may not be recoverable from host scrollback. Capture important states as they occur.
+
+### tmux and psmux fallbacks
+
+When Herdr is unavailable, cannot be installed, or has no eligible managed session, use tmux on macOS/Linux or [psmux](https://github.com/psmux/psmux) for native Windows terminals. Record the reason when it affects the requested coverage. Do not take over an unrelated pane to satisfy the preference.
+
+Load the tmux skill and check the installed help. tmux and psmux share familiar commands, but supported flags and behavior can differ. Herdr has a different CLI entirely.
+
+For tmux, create a dedicated session with a unique name, then discover its actual pane ID:
+
+```sh
+tmux new-session -d -s atomic-demo
+tmux list-panes -t atomic-demo -F '#{pane_id}'
+```
+
+Substitute the returned ID for `<pane-id>`:
+
+```text
+tmux send-keys -t <pane-id> -l -- "<command>"
+tmux send-keys -t <pane-id> Enter
+tmux capture-pane -p -t <pane-id>
+```
+
+Use literal text and a separate Enter to avoid interpreting arbitrary text as key names. On psmux, inspect `psmux list-panes` and use `psmux capture-pane -p -t <pane-id>` as documented in its [scripting guide](https://github.com/psmux/psmux/blob/master/docs/scripting.md). Discover IDs rather than assuming `%0` is your pane. Clean up only the session or pane created for the task. Never use a global server-kill command as routine cleanup.
+
+For modified-key setup in Atomic, see [tmux setup](/tmux). For behavioral checks and recordings, see [terminal evidence](/workflows/verification#terminal-changes).
+
+## macOS
+
+### Desktop and native tools
+
+- Install missing uv with `brew install uv` when Homebrew is available, or use the reviewed macOS installer from [uv installation](https://docs.astral.sh/uv/getting-started/installation/). Confirm `uv --version` in the launching shell.
+- Allow the application launching automation, such as Terminal or your IDE, in System Settings > Privacy & Security > Accessibility. Screenshot capture also needs Screen Recording permission, which may be labelled Screen & System Audio Recording on newer macOS versions. Relaunch the affected app if macOS requests it.
+- AppleScript automation may also prompt for Automation permission to control another app. Let the user grant permissions; do not script around consent dialogs.
+- PyAutoGUI depends on native Python bindings on macOS. If import or capture fails, check the installed release's [installation requirements](https://pyautogui.readthedocs.io/en/latest/install.html) before adding dependencies to the uv environment.
+- Check Retina scaling and keep the target on the primary display. A black or incomplete capture usually needs permission or display troubleshooting, not more clicks.
+
+Use `osascript` for AppleScript or JavaScript for Automation when an app's scripting dictionary exposes the operation you need. For example, `osascript -e 'tell application "TextEdit" to activate'` can bring a known app forward before PyAutoGUI works in it. Inspect the resulting window before typing. `System Events` UI scripting and native accessibility APIs can address menus and controls more reliably than coordinates. Consult Apple's [UI scripting guide](https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/AutomatetheUserInterface.html).
+
+`screencapture` is useful for native screenshots; Screenshot or QuickTime Player can record the screen or a selected area. Check permissions and the selected recording region before capture.
+
+### Browser and terminal
+
+playwright-cli uses its own browser session. WebKit coverage is not proof of every Safari-specific desktop behavior. Use an actual target browser when that distinction matters.
+
+Herdr is the first choice for interactive terminals when eligible. Homebrew provides Herdr and tmux. Preserve the shell, terminal dimensions, and keyboard behavior relevant to the task rather than silently changing them to make a scenario pass.
+
+## Linux
+
+### Desktop and native tools
+
+- Install missing uv through the [official Linux installer](https://docs.astral.sh/uv/getting-started/installation/) or an available distribution package. Review the installer before executing it, then confirm `uv --version`.
+- PyAutoGUI's Linux input backend uses X11. Run in an accessible graphical X11 session with the correct `DISPLAY` and authorization. Installing Python packages does not create a desktop session.
+- Check the distribution's screenshot and Python support packages. PyAutoGUI documents `scrot` and Python Tk/development packages for Linux; the required capture backend varies with the installed Pillow/PyScreeze versions. Use the distribution package manager with permission, not guessed cross-distribution commands.
+- A Wayland session is not equivalent to X11. XWayland does not grant access to every native Wayland app. Prefer compositor-supported capture/input tools, desktop portals, or native accessibility APIs when they support the operation. Do not weaken session security or claim PyAutoGUI has full Wayland support.
+- For unattended X11 work, a dedicated virtual display such as Xvfb can be useful. It does not prove behavior on a real Wayland desktop, GPU configuration, or physical display. Creative applications may require working graphics acceleration.
+
+[AT-SPI](https://gnome.pages.gitlab.gnome.org/at-spi2-core/) can expose named controls in accessible applications. `xdotool` and `wmctrl` can help with focus and window placement on X11; they are not general Wayland replacements. On Wayland, choose tools for the actual compositor and inspect their permission requirements. Use app APIs where custom canvases do not expose useful accessibility controls.
+
+For recordings, use a supported desktop recorder or OBS with the appropriate display or portal source. Confirm the saved file contains the intended window, not a blank capture.
+
+### Browser and terminal
+
+playwright-cli may need browser binaries and system libraries on a minimal Linux install. A headed browser needs a display. Headless browsing remains useful on SSH or CI hosts but does not grant desktop access.
+
+Herdr is preferred when eligible; tmux is a practical fallback on local or remote POSIX shells. An SSH terminal can run terminal scenarios without access to the remote desktop. Record which host owns the pane and application.
+
+## Windows
+
+### Desktop and native tools
+
+- Install missing uv with `winget install --id=astral-sh.uv -e` or use the reviewed PowerShell installer from [uv installation](https://docs.astral.sh/uv/getting-started/installation/). Open a new shell if PATH changed, then run `uv --version`.
+- Run PyAutoGUI and uv in the Windows graphical session that owns the app. Running them inside WSL does not automatically control native Windows windows.
+- Keep the session unlocked and available during automation. A disconnected or minimized Remote Desktop session can change rendering or input behavior; verify the actual remote-session setup before relying on it.
+- Use a consistent display scale and primary monitor. Check coordinates again after moving a window between displays with different DPI settings.
+- Standard-user automation cannot reliably drive elevated apps or the UAC secure desktop. Stop for the user or choose an authorized non-elevated path rather than escalating just to force input through.
+
+[Windows UI Automation](https://learn.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-overview) exposes controls by name and automation ID. Tools such as [pywinauto](https://pywinauto.readthedocs.io/en/latest/) can be easier than pixel matching for accessible Windows apps. PowerShell, COM automation, or an application's own API can handle structured document operations. Use PyAutoGUI for the remaining visual interactions.
+
+Snipping Tool or OBS can capture desktop evidence. Check the selected window and saved recording before sharing it.
+
+### Browser and terminal
+
+Use native Windows playwright-cli when the task depends on Windows browsers, downloads, or desktop dialogs. Quote paths and URLs for the shell actually in use; do not paste POSIX shell syntax into PowerShell.
+
+Prefer native Herdr when eligible. In PowerShell, check `$env:HERDR_ENV -eq '1'`, use `(Get-Location).Path` for the working directory, and read pane IDs from CLI responses. If Herdr cannot be used, install psmux through its documented Windows installation options and inspect its help. WSL tmux is useful for Linux programs, but is not native Windows ConPTY coverage.
+
+See [Windows setup](/windows) for Atomic's shell requirements.
+
+## Creative work and CUA workflows
+
+CUA can produce an artifact rather than a test report. Choose the deliverable first, then combine visual interaction with the application's strongest automation interface.
+
+| Task | Practical approach | Useful deliverables |
+| --- | --- | --- |
+| Blender 3D modeling | Use Blender Python for repeatable geometry or scene setup; use PyAutoGUI for visible editor operations and visual inspection. | Editable `.blend` file, exported model if requested, preview render. |
+| Presentations | Use an app API or document library for structured content; use CUA to refine layout, inspect slides, and run the slideshow. | Editable deck plus PDF or slide previews. |
+| Video editing | Use the editor's scripting API or media CLI for repetitive operations; use CUA to adjust the timeline, inspect transitions, and review playback. | Editable project, required source references, final export. |
+| Work across applications | Use native scripting for named windows and file operations; use PyAutoGUI where the task needs visual interaction. | Saved documents and a concise record of completed steps. |
+
+Do not substitute a screenshot for the editable project or final export the user requested. Reopen saved files, check missing assets and fonts, and inspect the actual export. For video, check audio and timing as well as a still frame. Keep originals intact and use explicit save paths. Rendering, uploading, or exporting through a paid service may need separate authorization.
+
+When the user wants a CUA workflow, include PyAutoGUI in the stage that operates the desktop. A useful sequence is:
+
+1. Prepare assets and confirm the intended application, output formats, and permissions.
+2. Open the dedicated desktop and inspect its starting state.
+3. Create or edit with PyAutoGUI and suitable native/app APIs, saving checkpoints.
+4. Reopen and inspect the deliverables, then make bounded corrections if needed.
+5. Hand off local files. Publish or upload only to an authorized target.
+
+Pass scripts, project files, and artifact paths between stages rather than long click transcripts. Give one stage exclusive desktop ownership and use finite deadlines for renders and exports. Stop on unexpected dialogs, lost focus, missing permissions, or failed observations. On resume, inspect the app and files before repeating an action.
+
+See [workflow authoring](/workflows/authoring) for stages and human-input gates. Use durable `ctx.tool` calls for workflow-owned external operations, with finite timeouts and cancellation; model stages can use the appropriate automation tools to operate the app. If the user asks to work inline, keep the same safety and deliverable checks without creating a workflow.
+
+## Troubleshooting
+
+| Symptom | What to check |
+| --- | --- |
+| uv or another command is missing | Install it when permitted, refresh PATH, and check its version in the same shell that will launch automation. |
+| Black screenshot or no desktop | Check screen permissions, display/session ownership, X11 versus Wayland, and remote-session state. |
+| Input reaches the wrong app | Stop. Confirm focus, window identity, scaling, and that no other controller shares the desktop. |
+| Browser element reference no longer works | Take a fresh snapshot and locate the current control. |
+| Herdr binary exists but control is unavailable | Check explicit request, managed-pane context, and client/server compatibility. Use a fallback rather than replacing the server. |
+| Save/export timed out | Inspect the file and app state before retrying. Preserve partial output for diagnosis. |
+| Install or graphical access is blocked | Continue work that can be done safely with available APIs or shell tools, and state what remains unverified or unfinished. |
+
+A tool being unavailable is a reason to choose another supported mechanism or report a limitation, not to invent a successful interaction.

--- a/packages/coding-agent/docs/docs.json
+++ b/packages/coding-agent/docs/docs.json
@@ -17,6 +17,7 @@
           "index",
           "quickstart",
           "usage",
+          "computer-use",
           "providers",
           "environment-variables",
           "llama-cpp",

--- a/packages/coding-agent/docs/herdr.md
+++ b/packages/coding-agent/docs/herdr.md
@@ -2,6 +2,8 @@
 
 Atomic reports its status to [Herdr](https://herdr.dev) automatically when you launch it in a Herdr pane. No extra extension is required. The pane identifies the agent as `atomic`.
 
+For interactive terminal automation, pane isolation, and tool fallbacks, see [Computer use](/computer-use#terminal-automation-with-herdr). This page covers Atomic's automatic status integration.
+
 ## Setup
 
 Use Herdr 0.8.2 or newer and launch Atomic inside it. Herdr supplies the pane connection settings automatically; you do not need to configure them yourself.

--- a/packages/coding-agent/docs/index.md
+++ b/packages/coding-agent/docs/index.md
@@ -59,6 +59,7 @@ For the full first-run flow, see [Quickstart](/quickstart).
 
 - [Quickstart](/quickstart) - install, authenticate, and run a first session.
 - [Using Atomic](/usage) - interactive mode, slash commands, context files, and CLI reference.
+- [Computer use](/computer-use) - work in desktop apps, browsers, and terminals across macOS, Linux, and Windows.
 - [Providers](/providers) - subscription and API-key setup for built-in providers.
 - [Environment variables](/environment-variables) - Atomic/Pi aliases, provider credentials, and bash session metadata.
 - [Security](/security) - project trust, sandbox boundaries, and vulnerability reporting.

--- a/packages/coding-agent/docs/tmux.md
+++ b/packages/coding-agent/docs/tmux.md
@@ -2,6 +2,8 @@
 
 Atomic works inside tmux, but tmux strips modifier information from certain keys by default. Without configuration, `SHIFT+Enter` and `CTRL+Enter` are usually indistinguishable from plain `Enter`.
 
+For terminal automation, prefer Herdr when eligible, with tmux or native Windows psmux as fallbacks. See [Computer use](/computer-use#terminal-automation-with-herdr) for tool selection and safe session control. This page covers Atomic's keyboard setup inside tmux.
+
 ## Recommended Configuration
 
 Add to `~/.tmux.conf`:

--- a/packages/coding-agent/docs/workflows.md
+++ b/packages/coding-agent/docs/workflows.md
@@ -40,6 +40,8 @@ Prefer composing builtin definitions with `ctx.workflow(...)` over copying or re
 4. [Operations](/workflows/operations) — run, inspect, steer, pause, resume, and configure workflows.
 5. [API reference](/workflows/api-reference) — look up definitions, contexts, options, results, and programmatic APIs.
 
+For checking changes and sharing results in PRs, see [Verification and evidence](/workflows/verification). For general desktop, browser, and terminal work, including creative workflows, see [Computer use](/computer-use).
+
 ## When to Use Workflows
 
 Unless the user explicitly chooses inline execution, workflows are the default for non-trivial requests or structured work with a verifiable objective. Requests such as `quickly`, `inline`, `do this directly`, and `don't use a workflow` override that default for the specified task, even when complex. Treat "quickly" as an inline execution choice, not a request for a faster workflow. Do not launch a hidden/nested replacement or ask the user to reapprove the choice. Preserve testing, review, evidence, safety and authorization inline. Quoted examples, questions about inline code, and descriptions of software that should run quickly are not mode instructions. For an active switch, safely hold/stop the affected run and reconcile completed work and in-flight effects before continuing without duplicates; completed work is not undone. See [Verification and evidence](/workflows/verification).

--- a/packages/coding-agent/docs/workflows/verification.md
+++ b/packages/coding-agent/docs/workflows/verification.md
@@ -1,79 +1,138 @@
 # Verification and evidence
 
-Use executable verification appropriate to the changed behavior. Workflow authors should put the same evidence contract in worker, reviewer and final handoff prompts. Goal and Ralph share this guidance. Reviewers inspect actual artifacts and results, not claims or filenames.
+Verify the behavior that changed, then give the reviewer enough evidence to understand the result. A small fix may need a focused test and a short explanation. An interactive change usually needs a real user scenario as well. A video is useful when it shows something a test log or screenshot cannot; it is not required for every PR.
 
-## Execution mode
+For tool installation, automation techniques, platform permissions, and general work in applications, read [Computer use](/computer-use). That guide covers Herdr for terminals, playwright-cli for browsers, and PyAutoGUI with uv for desktop CUA on macOS, Linux, and Windows. It also covers native accessibility and application tools when they are easier or more reliable.
 
-An explicit request to work `quickly`, `inline`, `do this directly`, `don't use a workflow`, or equivalent overrides workflow-first defaults for that task, including complex implementation and review loops. Treat "quickly" as an inline execution choice, not a request for a faster workflow. Do not create or launch a hidden or nested replacement workflow, or ask the user to reapprove the choice. Keep appropriate testing, review and evidence inline. Safety and authorization requirements do not change.
+## Choose checks that answer the question
 
-Apply the preference only to its stated task. Quoted examples and questions about inline code are not execution-mode instructions; neither are descriptions of software that should run quickly. Without an opt-out, normal workflow fit defaults apply.
+Start with the project's existing tests, build, typecheck, and lint commands. Add an interactive scenario when the change affects what a user sees or does. Do not replace required checks with a recording, or create a UI solely to demonstrate a non-UI change.
 
-If the user switches during an active workflow, safely hold or stop the affected run using its available lifecycle controls. Reconcile completed work and in-flight side effects before continuing inline so commands and external writes are not duplicated. Stages notify the controlling session rather than launching a replacement. Already-completed work remains completed; do not claim it was undone.
+| Changed behavior | Preferred mechanism | What to check |
+| --- | --- | --- |
+| Interactive terminal or TUI | **Herdr**, under its explicit-request and managed-pane requirements; tmux or native Windows psmux as fallbacks | Actual input, rendered output, navigation, resizing, and exit behavior relevant to the change. |
+| Browser/frontend | **playwright-cli** | The user flow and its visible result, with DOM or network assertions where useful. |
+| Desktop app, simulator, or emulator | **PyAutoGUI with uv**, supplemented by native/app APIs | The visible app scenario and its saved or exported result. |
+| API, library, script, or other non-UI behavior | Existing test runner and shell commands | Inputs, outputs, error handling, and relevant build/type contracts. |
+| Documentation | Documentation checks and example review | Links, navigation, command accuracy, and whether a reader can follow the instructions. |
 
-## Select the verification environment
+See [tool selection](/computer-use#choose-the-right-tool) before operating a session. Herdr is the terminal priority, but the preference does not authorize control from outside a Herdr-managed pane. Install missing tools when permitted; otherwise use the available fallback and describe any coverage gap.
 
-The same routing applies when a user asks for automation outside a verification workflow. Use PyAutoGUI for desktop computer use, also called CUA, and the playwright-cli skill for browser automation. Prefer herdr for terminal automation/testing on macOS, Linux and Windows. Install it if missing when network access and permissions permit; fall back to tmux or native Windows psmux when installation or use is not possible. Load the matching skill before acting. The pinned upstream herdr skill still requires an explicit user mention or request and `HERDR_ENV=1`; preference does not authorize control from outside a Herdr-managed pane. Keep desktop failsafes enabled and release held keys/buttons after interruption.
+## Define a reproducible scenario
 
-Inspect installed tools, cached runtimes, existing sessions and safe test configuration first. Install missing tools/plugins when online access and permissions permit. Known offline or restricted installation is enough reason not to attempt a prohibited download. Otherwise make a reasonable capability check or one bounded setup attempt, not an endless installation retry loop.
+Before running it, write down:
 
-When a mechanism cannot run, continue available authoritative repository checks, retain useful local evidence, and record the constraint, attempted commands and observed output, narrower validation and missing coverage. Do not require production credentials or take unsafe actions to satisfy a generic verification suggestion. An unavailable optional mechanism is not failed implementation, but it does not waive a required project check.
+- The behavior being verified and the expected result.
+- The commit or artifact under test, plus any uncommitted changes.
+- The environment that matters, such as OS, app/browser version, terminal dimensions, display scaling, and test fixtures.
+- The actions and assertions, including a relevant failure or edge case.
 
-| Changed behavior | Verification and evidence |
-| --- | --- |
-| Browser/frontend, including API-dependent flows | Use the playwright-cli skill. Exercise the real user flow and assert its result. Retain current screenshots, video, DOM snapshots or network evidence as appropriate. |
-| TUI/terminal | Prefer the herdr skill on macOS, Linux and Windows under its explicit-request and managed-pane requirements. Install if missing when permitted; fall back to the tmux skill or native Windows psmux if unavailable or unusable. Exercise actual interactive input and inspect pane output or a terminal recording. These tools do not have interchangeable CLIs. |
-| Desktop/simulator/emulator | Use PyAutoGUI for desktop CUA, with native platform tools where they provide safer input or better assertions. Capture screenshots/video from a real visible app scenario, not a browser recording labeled as desktop or iOS proof. |
-| Non-UI | Run relevant unit, integration, build, type or command-line scenarios. Do not manufacture a UI or video requirement. |
+Use dedicated sessions and non-production data. Wait for observable completion with a deadline instead of assuming that a submitted command or a fixed delay means success. Preserve useful failure output before cleanup.
 
-### Terminal contracts
+After a repair, rerun the affected checks on the new candidate. Label before/after evidence and keep it clear which commit produced each result. Do not present an earlier passing run as verification of later edits.
 
-Herdr supports macOS, Linux and Windows. Check `herdr --version` and, inside a managed pane, `herdr status` before installing or relying on server features. If missing, use the [official installation instructions](https://github.com/herdrdev/herdr/tree/v0.9.0#install): `brew install herdr` on macOS, the reviewed `https://herdr.dev/install.sh` installer on macOS/Linux, or `https://herdr.dev/install.ps1` on Windows. Inspect downloaded installer code before executing it, follow host permissions and use a bounded setup attempt. Do not stop or replace a running server to make a test work. If installation is blocked or no eligible Herdr session is available, record the constraint and use tmux/psmux rather than taking over the focused session.
+## Capture evidence appropriate to the change
 
-[psmux](https://github.com/psmux/psmux) is a native Windows ConPTY multiplexer using tmux-style commands. Its [scripting guide](https://github.com/psmux/psmux/blob/master/docs/scripting.md) documents `psmux capture-pane -p -t %0` for stdout capture. Verify installed help and use the actual pane identifier rather than assuming `%0` belongs to the test.
+### Browser changes
 
-[herdr's CLI](https://herdr.dev/docs/cli-reference/) talks to a running server. Discover your isolated test pane with `herdr pane list`. `herdr pane run <pane_id> <command>` submits a command with Enter; `herdr pane send-text` alone does not submit. `herdr pane read <pane_id> --source visible` returns the screen text. For bounded waits use `herdr pane wait-output <pane_id> --match <text> --timeout 10000`. Do not confuse pane output with an agent lifecycle status or infer success from `idle`. Check installed version/help and host support before use. Do not take over unrelated panes.
+Use playwright-cli to exercise the actual flow. A screenshot can show layout; a DOM snapshot can show control state; console and network output can help establish why a flow failed. Pair captures with assertions about the result, such as a saved record appearing after reload.
 
-### Reproduce stage skill terminal evidence
-
-From an Atomic source checkout, install dependencies with `npm ci --ignore-scripts` and run `npm run build`. With Node, Bun, tmux and a POSIX shell on PATH, run the committed driver:
-
-```sh
-node test/fixtures/stage-chat-skill-driver.mjs --evidence-dir /tmp/stage-skills-80 --columns 80 --rows 24
-node test/fixtures/stage-chat-skill-driver.mjs --evidence-dir /tmp/stage-skills-48 --columns 48 --rows 16
-```
-
-Use a fresh evidence directory for each run; existing directories are refused. The driver executes `test/fixtures/stage-chat-skill-terminal.ts` directly with Bun, not `bun build`. No provider credentials are needed. It waits for the real editor to clear and the notice to render after each `/tasks` command before typing the next command, then verifies stage-local skill selection and invocation. Captures, assertions, render barriers and session events stay in the requested directory. Failures retain diagnostics and clean up the dedicated tmux session.
-
-The small driver contract tests run in the normal unit suite. The actual tmux scenario is an explicit local verification command, not an automatic CI terminal test. This POSIX driver does not establish Windows coverage.
-
-### Desktop safety
-
-The [OpenAI CUA sample](https://github.com/openai/openai-cua-sample-app#first-run) distinguishes JavaScript Playwright browser control from Python PyAutoGUI desktop input. It is an optional sample requiring API/model access, not a prerequisite for every GUI test. Follow its [Python quickstart and interruption guidance](https://github.com/openai/openai-cua-sample-app/blob/main/python-app/README.md).
-
-Use a dedicated desktop/session with controlled fixtures. macOS needs Accessibility and Screen Recording permissions for the launching app; Linux PyAutoGUI needs an appropriate X11 desktop and dependencies; Windows needs a graphical session. Screenshots may include other windows and PyAutoGUI controls real mouse and keyboard input. Keep failsafes enabled, inspect privacy before saving/sharing, release held keys/buttons after interruption, and check for leftover processes before restarting. Do not install the sample's pnpm dependencies into an npm repository.
-
-A visible simulator/emulator or suitable native automation/mirroring setup is required for mobile UI. PyAutoGUI does not directly control an arbitrary physical iPhone. Use native platform tooling where it provides better assertions or safer input.
-
-## qlty setup and fallback
-
-Use the qlty skill to choose reliable, low-noise checks and useful metrics based on user priorities and repository evidence. Preserve existing `.qlty/qlty.toml`, the project's chosen tools such as Biome, and authoritative package/CI checks. Do not add competing formatters or run wholesale formatting by habit. Record command/output, scope and a relevant baseline; numbers without a decision are not useful verification.
-
-During authorized coding, absent config permits `qlty init --no` or a hand-authored `.qlty/qlty.toml`; inspect generated suggestions. Missing config alone is not a blocker. For offline/restricted installation or a missing binary, use the skill's bundled manual-configuration reference to prepare TOML without network when configuration edits are in scope. Use source-backed options, omit unknown optional plugin versions rather than inventing them, and validate syntax/schema with available tools. Read-only tasks stay read-only or use isolated scratch config.
-
-Installed built-in metrics/smells may work offline. Cached plugins may work too, but uncached source/plugin/runtime resolution can require downloads. Report configuration prepared separately from lint/security/metrics actually run. TOML parsing is not proof of plugin availability or a passing quality check. Continue available repository checks without making optional qlty installation a universal blocker.
-
-## Native GitHub media
-
-Only publish to an authorized target. Detect the provider first and inspect/redact artifacts for secrets, personal information and unrelated windows. Name the verified commit and scenario in the accompanying evidence. Collection alone is not upload authorization.
-
-[GitHub CLI >=2.99.0](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/) supports repeatable `--attach` on `gh issue create`, `edit`, `comment` and `gh pr create`, `edit`, `comment`. Check `gh --version` and the specific command's `--help` before using it. For an authorized PR comment:
+For a named browser session you own, the CLI supports captures such as:
 
 ```sh
-gh pr comment 123 --repo owner/repo --body-file evidence.md --attach proof.mp4
+playwright-cli -s=pr-check snapshot --filename=after.yaml
+playwright-cli -s=pr-check screenshot --filename=after.png
 ```
 
-Use actual target and file values. Attach each file once. A body-local path reference is rewritten to the hosted URL; other attachments append in flag order. Images can use `--attach 'screen.png#Image alt text'`; videos do not support alt text. A standalone `![](proof.mp4)` paragraph is rewritten to an embedded player. See [official attachment documentation](https://docs.github.com/en/github-cli/github-cli/attaching-files-with-github-cli).
+For behavior best shown in motion, check the installed CLI's help, start recording before the relevant actions, and stop afterward:
 
-Supported media include PNG, JPEG, GIF, WebP, SVG, MP4, MOV and WebM. Images/GIFs have a 10 MB limit; video limits are 10 MB on Free and 100 MB on paid plans. Repository write access and supported OAuth/classic PAT authentication are required; this release does not support GitHub Enterprise Server. Recheck current limits for the chosen host/account.
+```sh
+playwright-cli -s=pr-check video-start flow.webm
+# Exercise the scenario here.
+playwright-cli -s=pr-check video-stop
+```
 
-Read back the created or edited issue/PR/comment and confirm usable GitHub-hosted links before reporting success. Unsupported versions, hosts, providers, auth or sizes require a truthful fallback: retain the local artifact and explain authorized manual attachment or supported provider tooling. Do not claim a `file://` reference is uploaded evidence or send artifacts to unrelated third-party hosts.
+Open the saved artifact and confirm it includes the final state. Keep recordings short and focused. Inspect traces, authentication state, and network output for secrets before sharing. See [browser setup and best practices](/computer-use#browser-automation-with-playwright-cli).
+
+### Terminal changes
+
+Use Herdr to send real interactive input and inspect the resulting pane, or use tmux/psmux when Herdr cannot be used. Keep the terminal dimensions and shell relevant to the change. Test narrow layouts or modified keys when those are affected.
+
+Retain screen captures or transcripts that show the input and result. For cursor movement, redraws, colors, or timing, a terminal recording or video may explain more than plain text. Capture important states during the run; alternate-screen content may not remain in scrollback. Check exit status or explicit assertions rather than treating an agent's `idle` indicator as a passing result.
+
+See [terminal setup and capture commands](/computer-use#terminal-automation-with-herdr). A browser rendering of terminal text is not proof that the real TUI accepted input. WSL tmux does not establish native Windows terminal coverage.
+
+### Desktop, simulator, and emulator changes
+
+Run PyAutoGUI through uv in a dedicated graphical session, using [the desktop guide](/computer-use#desktop-automation-with-pyautogui-and-uv). Native accessibility tools or application APIs can give more reliable assertions than pixel matching. For example, check a saved document through the app API after exercising the visible Save flow.
+
+Capture the actual application or simulator. A browser recording is not desktop or iOS evidence. PyAutoGUI can interact with a visible simulator/emulator window, but does not directly control an arbitrary physical phone. Use supported native tooling where needed, and name the device or emulator actually exercised.
+
+Keep failsafes enabled and release held keys/buttons after interruption. Inspect saved files and exports rather than assuming a completed click means a completed operation. Screenshots show appearance, not necessarily persistence or correctness.
+
+## Use evidence in a workflow
+
+Give workers, reviewers, and the final handoff the same scenario and success criteria. A verification stage should produce commands, observed results, and artifact paths. The reviewer should inspect those results, not just accept the worker's summary or a filename.
+
+For workflow-owned checks, use durable `ctx.tool` calls with finite timeouts and cancellation. Pass scripts and larger evidence through files. After a failed check, send the actual failure to a bounded repair step and rerun the affected checks. Keep implementation acceptance separate from later PR creation, upload, or publication. See [workflow authoring](/workflows/authoring) and [reliable design](/workflows/reliable-design).
+
+### Execution mode
+
+The same verification standard applies inline. A task-scoped request such as `quickly`, `inline`, or `don't use a workflow` means no workflow creation or launch, including hidden replacements. If switching an active run to inline, stop or hold it safely and reconcile completed work and in-flight effects before continuing. See [when to use workflows](/workflows#when-to-use-workflows).
+
+## When a tool or environment is unavailable
+
+Inspect installed tools and cached runtimes first. Install missing tools or plugins when network access and permissions allow. If installation is restricted, or no suitable graphical session is available, continue the checks that can run and record:
+
+- What was unavailable and the observed error or known restriction.
+- Any setup attempt and the narrower checks that actually ran.
+- What still needs verification, including missing platform coverage.
+
+Do not require production credentials or bypass permissions to satisfy a generic verification suggestion. An optional tool being unavailable is not an implementation failure, but a required project check remains required. Do not label skipped, mocked, or simulated coverage as a real platform run.
+
+### qlty setup and fallback
+
+Use the qlty skill when it adds useful lint, security, or complexity checks. Preserve the repository's existing tools and `.qlty/qlty.toml`; do not introduce a competing formatter or wholesale formatting changes.
+
+When configuration changes are in scope, missing config can be initialized with `qlty init --no` or prepared manually using the skill's bundled configuration reference. Review generated suggestions. Read-only tasks should remain read-only or use isolated scratch configuration.
+
+Cached plugins and built-in metrics may work offline; uncached plugins or runtimes may need downloads. Report prepared configuration separately from checks actually executed. Valid TOML is not proof that a plugin ran. Optional qlty setup should not block available repository checks.
+
+## Include evidence in a PR
+
+Give the reviewer a short summary before linking logs or media. For example, replace the placeholders in this template with observed results:
+
+```markdown
+## Verification
+
+- Candidate: <commit SHA; note any uncommitted changes>
+- Environment: <OS, app/tool versions, relevant dimensions>
+- Checks: <command and result>
+- Scenario: <starting state, actions, expected and observed result>
+- Evidence: <hosted links or attached artifacts>
+- Limits: <checks/platforms not exercised>
+```
+
+Attach a screenshot for a visual state, a short recording for an interaction, or logs for command behavior. Include reproduction steps even when media is available. Label local-only paths as local; reviewers cannot open a file on your machine. CI artifact links are useful when readers have access, but note retention limits where relevant.
+
+Only upload to an authorized repository or destination. Inspect and redact secrets, personal information, private source content, and unrelated windows before attaching files. Permission to collect local evidence is not permission to publish it.
+
+### Native GitHub media
+
+[GitHub CLI 2.99.0 and newer](https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/) supports repeatable `--attach` on issue and PR `create`, `edit`, and `comment` commands. Check `gh --version`, the specific command's `--help`, and the host's [attachment support and limits](https://docs.github.com/en/github-cli/github-cli/attaching-files-with-github-cli).
+
+For an authorized PR comment, replace the target and file paths:
+
+```sh
+gh pr comment 123 --repo owner/repo --body-file evidence.md \
+  --attach 'after.png#Settings panel after saving' \
+  --attach flow.webm
+```
+
+The backslashes above are POSIX shell continuations. In PowerShell, use a single line or PowerShell continuation syntax.
+
+Attach each file once. The CLI rewrites body-local attachment references to hosted URLs; otherwise it appends attachments in flag order. Images support `#Image alt text`; videos do not support alt text. A standalone `![](flow.webm)` paragraph in the body becomes an embedded player. These are CLI attachment features, not support for arbitrary local paths in GitHub Markdown.
+
+Supported media include PNG, JPEG, GIF, WebP, SVG, MP4, MOV, and WebM. Uploads require repository push access and supported authentication. Recheck current size limits and authentication support for the target account and host. The 2.99.0 release does not support GitHub Enterprise Server.
+
+Read back the created or edited PR/comment and confirm usable hosted links before reporting an upload as successful. If the CLI, provider, authentication, or file size is unsupported, retain the local artifact and explain the manual attachment path or supported provider tooling. Do not upload to an unrelated host to work around a limitation.


### PR DESCRIPTION
## Summary

Separate general computer use from software verification so readers can find the right tool and platform setup without working through a testing guide. CUA now explicitly includes creative application work, such as Blender modeling, presentations, and video editing.

## Changes

- Add `computer-use.md` with clear preferences: Herdr for interactive terminals, playwright-cli for browsers, and PyAutoGUI run with uv for desktop automation. Document installing missing uv and tools when permitted.
- Provide macOS, Linux, and Windows sections covering permissions, display/session ownership, native accessibility and application APIs, and practical fallbacks such as `osascript`, AT-SPI, Windows UI Automation, tmux, and psmux.
- Add practical AppleScript/osascript and Excel VBA recipes, guidance for Office Scripts and PowerShell/COM, and a Blender batch invocation with meaningful error exit status. Explain macro security, document targeting, app runtimes versus uv, and when scripting should be combined with visual inspection.
- Explain desktop safety, browser/pane isolation, recovery after interruption, creative deliverables, and how to include CUA in workflows without requiring a workflow for inline tasks.
- Rewrite `workflows/verification.md` around choosing proportionate checks, exercising real scenarios, inspecting artifacts, reporting limitations, and attaching evidence to PRs. Keep setup details in the computer-use guide rather than duplicating them.
- Add documentation navigation and cross-links from the overview, workflow, Herdr, and tmux pages. Remove the maintainer-specific stage-skill fixture walkthrough from the user-facing verification guide; the fixture and its usage instructions are unchanged.

Herdr's explicit-request and managed-pane requirements remain intact. Tool preferences allow native or application-specific mechanisms when they are easier or more reliable. No runtime, prompt, skill, dependency, or changelog changes.

## Validation

- `npm run check` passed: Biome, root/package typechecks, public typetests, and shrinkwrap validation.
- `npm run docs:check --workspace=@bastani/atomic` passed for all 48 pages.
- A focused local check validated 23 fragment links across the affected guides and parsed the Python example without executing desktop input.
- Checked browser example options against playwright-cli 0.1.19 help, uv options against uv 0.12.12 help, and GitHub attachments against gh 2.100.0 help and official documentation.
- `npm run test:unit -- test/unit/workflow-docs-host-portability.test.ts` passed, 4 tests.
- Commit hooks passed without bypass.
- Read-only specialist review checked source-backed tool/platform claims and navigation. Both findings are addressed: GitHub upload push-access requirements and portable macOS recording wording.

This is a docs-only change. No cross-platform GUI scenarios, creative-app workflows, media uploads, or full test-suite pass are claimed.

### Scripting follow-up

Commit `afe980f6e` adds the scripting recipes. Docs validation passed for all 48 pages; 11 same-page anchors and seven shell snippets passed focused anchor/syntax checks. Commit hooks, including `npm run check`, passed again. VBA operations, Office platform limits, Blender flags, and file-library limitations were checked against the linked official references. AppleScript, VBA, and Blender examples were not executed against native applications on this Linux host.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791660067&installation_model_id=10562&pr_number=2975&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2975&signature=912c89cea8bee3e25ce990d42f64f0bb2b6cf5206176d06d64a8518fa3364eb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62750747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

<h3>Summary</h3>

- Adds computer-use documentation, refines software-verification guidance, and improves navigation and cross-links across the coding-agent documentation.

<sub>Reviews (2) · Last reviewed commit: ["docs: add practical application scriptin..."](https://github.com/bastani-inc/atomic/commit/afe980f6e120451e36de8fc7c490dabe583df4e3)</sub>

<!-- /greptile_comment -->