### PR TITLE
fix(intercom): route diagnostics through the owning session

### DIFF
--- a/packages/coding-agent/docs/intercom.md
+++ b/packages/coding-agent/docs/intercom.md
@@ -137,6 +137,12 @@ The session list and ALT+M picker show connected agent sessions, not every open 
 
 Name sessions with `/name` so they can target each other (for example `/name planner` and `/name worker`). If a session is unnamed, Intercom exposes a runtime-only fallback alias like `subagent-chat-1a2b3c4d-1111-4222-8333-123456789abc` so other sessions can still target it. That alias is not persisted as the session title, so resume pickers keep showing the transcript snippet instead of a generic name.
 
+### Troubleshooting initialization
+
+`Intercom heavy initialization failed; a later call will retry: …` means initialization can be attempted again on a later Intercom call. Interactive sessions show this as a yellow warning in the chat pane, without a console stack trace; non-interactive sessions retain console diagnostics. Terminal relay and cleanup failures appear as error notifications in interactive sessions.
+
+If initialization keeps failing, check the reported cause and `~/.atomic/agent/intercom/broker.log` (or the Intercom directory under `ATOMIC_CODING_AGENT_DIR`). Do not automatically resend an operation reported with an unknown delivery outcome; check with the recipient first.
+
 ## The intercom Tool
 
 | Parameter | Type | Description |

--- a/packages/coding-agent/docs/intercom.md
+++ b/packages/coding-agent/docs/intercom.md
@@ -139,7 +139,7 @@ Name sessions with `/name` so they can target each other (for example `/name pla
 
 ### Troubleshooting initialization
 
-`Intercom heavy initialization failed; a later call will retry: …` means initialization can be attempted again on a later Intercom call. Interactive sessions show this as a yellow warning in the chat pane, without a console stack trace; non-interactive sessions retain console diagnostics. Terminal relay and cleanup failures appear as error notifications in interactive sessions.
+`Intercom heavy initialization failed; a later call will retry: …` means initialization can be attempted again on a later Intercom call. Interactive sessions show this as a yellow warning in the chat pane, without a console stack trace; non-interactive sessions (print, JSON, and RPC) retain console diagnostics. Terminal relay and cleanup failures appear as error notifications in interactive sessions.
 
 If initialization keeps failing, check the reported cause and `~/.atomic/agent/intercom/broker.log` (or the Intercom directory under `ATOMIC_CODING_AGENT_DIR`). Do not automatically resend an operation reported with an unknown delivery outcome; check with the recipient first.
 

--- a/packages/coding-agent/src/core/extensions/runner-context.ts
+++ b/packages/coding-agent/src/core/extensions/runner-context.ts
@@ -108,7 +108,12 @@ export function copyScopedModels(scoped: readonly ScopedModel[]): readonly Scope
 	return Object.freeze(scoped.map((entry) => deepFrozenCopy(entry)));
 }
 
-const contextOwners = new WeakMap<ExtensionContext, object>();
+// Private host/builtin bridge, also read by intercom/context-owner.ts. Separate
+// bundles share identity without exposing guarded capabilities or retaining UI.
+const CONTEXT_OWNERS_KEY = Symbol.for("atomic-coding-agent/extension-context-owners@1");
+const contextOwnerBag = globalThis as typeof globalThis & { [CONTEXT_OWNERS_KEY]?: WeakMap<ExtensionContext, object> };
+contextOwnerBag[CONTEXT_OWNERS_KEY] ??= new WeakMap<ExtensionContext, object>();
+const contextOwners = contextOwnerBag[CONTEXT_OWNERS_KEY];
 
 /** Internal lifecycle identity; contexts themselves are recreated for every dispatch. */
 export function getExtensionContextOwner(context: ExtensionContext): object {
@@ -257,13 +262,16 @@ export function createExtensionContext(source: ExtensionContextSource, owner: ob
 	return context;
 }
 
-export function createExtensionCommandContext(source: ExtensionCommandContextSource): ExtensionCommandContext {
+export function createExtensionCommandContext(
+	source: ExtensionCommandContextSource,
+	owner: object = source,
+): ExtensionCommandContext {
 	// Use property descriptors instead of object spread so the guarded getters from
 	// createExtensionContext() stay lazy. A spread would eagerly read them once and
 	// freeze old values into the returned object, bypassing stale-instance checks.
 	const context = Object.defineProperties(
 		{},
-		Object.getOwnPropertyDescriptors(createExtensionContext(source)),
+		Object.getOwnPropertyDescriptors(createExtensionContext(source, owner)),
 	) as ExtensionCommandContext;
 	context.getSystemPromptOptions = () => {
 		source.assertActive();
@@ -293,5 +301,6 @@ export function createExtensionCommandContext(source: ExtensionCommandContextSou
 		source.assertActive();
 		return source.reload();
 	};
+	contextOwners.set(context, owner);
 	return context;
 }

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -522,7 +522,7 @@ export class ExtensionRunner {
 	}
 
 	createCommandContext(): ExtensionCommandContext {
-		return createExtensionCommandContext(this.createContextSource());
+		return createExtensionCommandContext(this.createContextSource(), this.contextOwner);
 	}
 
 	private createContextSource(): ExtensionCommandContextSource {

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Fixed
+
+- Route lazy initialization, event-relay, and rejected-candidate cleanup diagnostics through the owning interactive session's notifications instead of leaking console output and stacks. Retryable initialization uses warning color; non-interactive console diagnostics and retry behavior are unchanged.
+
 ## [0.9.19-alpha.3] - 2026-09-09
 
 ### Fixed

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ### Fixed
 
-- Route lazy initialization, event-relay, and rejected-candidate cleanup diagnostics through the owning interactive session's notifications instead of leaking console output and stacks. Retryable initialization uses warning color; non-interactive console diagnostics and retry behavior are unchanged.
+- Route lazy initialization, event-relay, and rejected-candidate cleanup diagnostics through the owning interactive session's notifications, including during shutdown, instead of leaking console output and stacks. Retryable initialization uses warning color; non-interactive console diagnostics (including RPC), original failures, acknowledgements, and retry behavior are preserved even when an error cannot be rendered.
 
 ## [0.9.19-alpha.3] - 2026-09-09
 

--- a/packages/intercom/context-owner.ts
+++ b/packages/intercom/context-owner.ts
@@ -1,0 +1,13 @@
+import type { ExtensionContext } from "@bastani/atomic";
+
+// Private bridge populated by the host's runner-context.ts. A builtin-local
+// reader works in the installed layout and across separately evaluated bundles.
+const CONTEXT_OWNERS_KEY = Symbol.for("atomic-coding-agent/extension-context-owners@1");
+
+export function getExtensionContextOwner(context: ExtensionContext): object {
+	const owners = (globalThis as typeof globalThis & { [CONTEXT_OWNERS_KEY]?: WeakMap<ExtensionContext, object> })[
+		CONTEXT_OWNERS_KEY
+	];
+	// Unknown/older hosts retain context identity; never touch guarded getters.
+	return owners?.get(context) ?? context;
+}

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -133,6 +133,27 @@ function renderHeavyToolResult(loadedHeavy: CapturedHeavy | null, name: string, 
 	if (renderer) return renderer(...args);
 	return renderIntercomToolResult(name, args);
 }
+
+/** Report against the captured owner, not whichever session is current after an await. */
+function reportDiagnostic(
+	ctx: ExtensionContext | undefined,
+	message: string,
+	error: unknown,
+	level: "warning" | "error",
+	consoleMessage = message,
+): void {
+	try {
+		if (ctx?.hasUI) {
+			ctx.ui.notify(message, level);
+			return;
+		}
+	} catch {
+		// A retired context or unavailable UI never authorizes console fallback.
+		return;
+	}
+	console.error(consoleMessage, error);
+}
+
 /**
  * Diagnostics for a background Intercom event relay.
  *
@@ -145,9 +166,11 @@ function renderHeavyToolResult(loadedHeavy: CapturedHeavy | null, name: string, 
  * reported. The caller-facing acknowledgement is emitted either way, so a
  * waiting relay never hangs on this decision.
  */
-function reportRelayFailure(eventName: string, error: unknown): void {
+function reportRelayFailure(ctx: ExtensionContext | undefined, eventName: string, error: unknown): void {
 	if (isRecoverableIntercomDisconnect(error)) return;
-	console.error(`Intercom event relay failed (${eventName}):`, error);
+	const prefix = `Intercom event relay failed (${eventName}):`;
+	const detail = error instanceof Error ? error.message : String(error);
+	reportDiagnostic(ctx, `${prefix} ${detail}`, error, "error", prefix);
 }
 
 /**
@@ -251,12 +274,12 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 			return handle;
 		}
 		let promise: Promise<IntercomHeavyHandle>;
+		let replayCtx: ExtensionContext | null = null;
 		promise = (async (): Promise<IntercomHeavyHandle> => {
 			const captured: CapturedHeavy = {
 				tools: new Map(), commands: new Map(), handlers: createForwardedHandlerMap(),
 				shortcuts: new Map(), eventHandlers: new Map(),
 			};
-			let replayCtx: ExtensionContext | null = null;
 			let cleaned = false;
 			const cleanupCandidate = async (): Promise<void> => {
 				const shutdown = lease.shutdown;
@@ -267,7 +290,9 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 				try {
 					await dispatchHandlers(captured, "session_shutdown", event, cleanupCtx);
 				} catch (cleanupError) {
-					console.error("Intercom failed to clean rejected lazy candidate:", cleanupError);
+					const prefix = "Intercom failed to clean rejected lazy candidate:";
+					const detail = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+					reportDiagnostic(cleanupCtx, `${prefix} ${detail}`, cleanupError, "error", prefix);
 				}
 			};
 			try {
@@ -295,7 +320,12 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 				if (heavyAttempt?.promise === promise) heavyAttempt = null;
 				if (!isRecoverableIntercomDisconnect(error)) {
 					const message = error instanceof Error ? error.message : String(error);
-					console.error(`Intercom heavy initialization failed; a later call will retry: ${message}`, error);
+					reportDiagnostic(
+						replayCtx ?? ctx,
+						`Intercom heavy initialization failed; a later call will retry: ${message}`,
+						error,
+						"warning",
+					);
 				}
 			},
 		);
@@ -581,7 +611,8 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 		if (!isPendingStageUndeliverableRelay(payload) || payload.handled === true) return;
 		payload.handled = true;
 		const forwarded = { ...payload, handled: false, completion: undefined };
-		payload.completion = loadHeavy(latestLifecycleContext())
+		const ctx = latestLifecycleContext();
+		payload.completion = loadHeavy(ctx)
 			.then(async (handle) => {
 				handle.assertCurrent();
 				await dispatchEventHandlers(handle.heavy, PENDING_STAGE_UNDELIVERABLE_EVENT, forwarded);
@@ -591,7 +622,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 					: false;
 			})
 			.catch((error) => {
-				reportRelayFailure(PENDING_STAGE_UNDELIVERABLE_EVENT, error);
+				reportRelayFailure(ctx, PENDING_STAGE_UNDELIVERABLE_EVENT, error);
 				return false;
 			});
 	});
@@ -601,7 +632,8 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 		PENDING_STAGE_ROUTE_EVENT,
 	] as const) {
 		pi.events.on(eventName, (payload) => {
-			const completion = loadHeavy(latestLifecycleContext()).then(async (handle) => {
+			const ctx = latestLifecycleContext();
+			const completion = loadHeavy(ctx).then(async (handle) => {
 				handle.assertCurrent();
 				await dispatchEventHandlers(handle.heavy, eventName, payload);
 				handle.assertCurrent();
@@ -615,7 +647,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 			}
 			void completion.catch((error) => {
 				rejectLazyResultRelay(pi, eventName, payload, error);
-				reportRelayFailure(eventName, error);
+				reportRelayFailure(ctx, eventName, error);
 			});
 		});
 	}

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -1,6 +1,7 @@
 import { APP_NAME, getEnvValue, type ExtensionAPI, type ExtensionContext, type SessionStartEvent, type ToolDefinition } from "@bastani/atomic";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { getExtensionContextOwner } from "./context-owner.js";
 import { renderIntercomToolResult } from "./result-renderers.js";
 import { executeHeavyTool, runHeavyCommand, type HeavyHandle } from "./lazy-tool-execution.js";
 import { assertCurrentLifecycleLease, createLifecycleLease, retainSettledLifecycleCleanup, retireLifecycleLease, SerializedLifecycleForwarder, type LifecycleLease } from "./lifecycle-lease.js";
@@ -284,6 +285,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 	}
 	async function loadHeavy(ctx?: ExtensionContext): Promise<IntercomHeavyHandle> {
 		let diagnosticRoute = captureDiagnosticRoute(ctx);
+		let diagnosticOwner = ctx && getExtensionContextOwner(ctx);
 		const lease = activeLease;
 		if (lease.retired) throw new Error("Intercom initialization unavailable: no active session");
 		await waitForPriorCleanup(lease);
@@ -329,9 +331,11 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 					sessionSnapshot = { event: createSyntheticSessionStartEvent(), ctx, generation: ++lifecycleGeneration, lease };
 				}
 				await ensureSessionStartReplayed(captured, lease, (replayContext) => {
-					// The same owner may already be stale; only a new owner needs a new route.
-					if (replayContext !== (replayCtx ?? ctx)) {
+					// Dispatch wrappers differ even for the same (possibly already stale) owner.
+					const owner = getExtensionContextOwner(replayContext);
+					if (owner !== diagnosticOwner) {
 						diagnosticRoute = captureDiagnosticRoute(replayContext);
+						diagnosticOwner = owner;
 					}
 					replayCtx = replayContext;
 				});

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -329,8 +329,11 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 					sessionSnapshot = { event: createSyntheticSessionStartEvent(), ctx, generation: ++lifecycleGeneration, lease };
 				}
 				await ensureSessionStartReplayed(captured, lease, (replayContext) => {
+					// The same owner may already be stale; only a new owner needs a new route.
+					if (replayContext !== (replayCtx ?? ctx)) {
+						diagnosticRoute = captureDiagnosticRoute(replayContext);
+					}
 					replayCtx = replayContext;
-					diagnosticRoute = captureDiagnosticRoute(replayContext);
 				});
 				assertLease(lease);
 				const handle = createHandle(captured, lease);

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -22,7 +22,7 @@ type LifecycleSnapshot<K extends keyof ForwardedEventMap> = {
 	event: ForwardedEventMap[K];
 	ctx: ExtensionContext;
 };
-type ShutdownSnapshot = LifecycleSnapshot<"session_shutdown"> & { generation: number };
+type ShutdownSnapshot = LifecycleSnapshot<"session_shutdown"> & { generation: number; diagnosticRoute: DiagnosticRoute };
 type IntercomLease = LifecycleLease<ShutdownSnapshot>;
 type SessionSnapshot = LifecycleSnapshot<"session_start"> & { generation: number; lease: IntercomLease };
 type IntercomHeavyHandle = HeavyHandle<CapturedHeavy>;
@@ -143,26 +143,37 @@ function diagnosticDetail(error: unknown): string {
 	}
 }
 
+type DiagnosticRoute = ExtensionContext | "console" | "silent";
+
+/** Snapshot routing before awaits can invalidate the owner's guarded getters. */
+function captureDiagnosticRoute(ctx: ExtensionContext | undefined): DiagnosticRoute {
+	try {
+		// RPC has UI too, but only a terminal owns pane diagnostics. Keep the
+		// context, not its raw UI: late TUI notifications must still be guarded.
+		return ctx?.hasUI && ctx.mode === "tui" ? ctx : "console";
+	} catch {
+		return "silent";
+	}
+}
+
 /** Report against the captured owner, not whichever session is current after an await. */
 function reportDiagnostic(
-	ctx: ExtensionContext | undefined,
+	route: DiagnosticRoute,
 	message: string,
 	error: unknown,
 	level: "warning" | "error",
 	consoleMessage = message,
 ): void {
-	try {
-		// RPC hosts also set hasUI; only the terminal's own mode owns pane
-		// diagnostics, so print, JSON, and RPC retain console output.
-		if (ctx?.hasUI && ctx.mode === "tui") {
-			ctx.ui.notify(message, level);
-			return;
-		}
-	} catch {
-		// A retired context or unavailable UI never authorizes console fallback.
+	if (route === "console") {
+		console.error(consoleMessage, error);
 		return;
 	}
-	console.error(consoleMessage, error);
+	if (route === "silent") return;
+	try {
+		route.ui.notify(message, level);
+	} catch {
+		// A retired TUI context or unavailable UI never authorizes console fallback.
+	}
 }
 
 /**
@@ -177,11 +188,11 @@ function reportDiagnostic(
  * reported. The caller-facing acknowledgement is emitted either way, so a
  * waiting relay never hangs on this decision.
  */
-function reportRelayFailure(ctx: ExtensionContext | undefined, eventName: string, error: unknown): void {
+function reportRelayFailure(route: DiagnosticRoute, eventName: string, error: unknown): void {
 	if (isRecoverableIntercomDisconnect(error)) return;
 	const prefix = `Intercom event relay failed (${eventName}):`;
 	const detail = diagnosticDetail(error);
-	reportDiagnostic(ctx, `${prefix} ${detail}`, error, "error", prefix);
+	reportDiagnostic(route, `${prefix} ${detail}`, error, "error", prefix);
 }
 
 /**
@@ -201,7 +212,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
   let loadedHeavy: IntercomHeavyHandle | null = null;
   let sessionSnapshot: SessionSnapshot | null = null;
 	// Event subscriptions outlive shutdown replay state; never use this owner to load heavy state.
-	let shutdownDiagnosticContext: ExtensionContext | undefined;
+	let shutdownDiagnosticRoute: DiagnosticRoute | undefined;
 	let lifecycleGeneration = 0;
 	let nextLeaseId = 1;
 	let activeLease = createLifecycleLease<ShutdownSnapshot>(nextLeaseId++);
@@ -272,6 +283,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 		await promise;
 	}
 	async function loadHeavy(ctx?: ExtensionContext): Promise<IntercomHeavyHandle> {
+		let diagnosticRoute = captureDiagnosticRoute(ctx);
 		const lease = activeLease;
 		if (lease.retired) throw new Error("Intercom initialization unavailable: no active session");
 		await waitForPriorCleanup(lease);
@@ -305,7 +317,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 				} catch (cleanupError) {
 					const prefix = "Intercom failed to clean rejected lazy candidate:";
 					const detail = diagnosticDetail(cleanupError);
-					reportDiagnostic(cleanupCtx, `${prefix} ${detail}`, cleanupError, "error", prefix);
+					reportDiagnostic(shutdown?.diagnosticRoute ?? diagnosticRoute, `${prefix} ${detail}`, cleanupError, "error", prefix);
 				}
 			};
 			try {
@@ -316,7 +328,10 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 				if (!sessionSnapshot && ctx) {
 					sessionSnapshot = { event: createSyntheticSessionStartEvent(), ctx, generation: ++lifecycleGeneration, lease };
 				}
-				await ensureSessionStartReplayed(captured, lease, (replayContext) => { replayCtx = replayContext; });
+				await ensureSessionStartReplayed(captured, lease, (replayContext) => {
+					replayCtx = replayContext;
+					diagnosticRoute = captureDiagnosticRoute(replayContext);
+				});
 				assertLease(lease);
 				const handle = createHandle(captured, lease);
 				loadedHeavy = handle;
@@ -334,7 +349,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 				if (!isRecoverableIntercomDisconnect(error)) {
 					const message = diagnosticDetail(error);
 					reportDiagnostic(
-						replayCtx ?? ctx,
+						diagnosticRoute,
 						`Intercom heavy initialization failed; a later call will retry: ${message}`,
 						error,
 						"warning",
@@ -476,7 +491,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
     }
     const generation = ++lifecycleGeneration;
     sessionSnapshot = { event, ctx, generation, lease };
-		shutdownDiagnosticContext = undefined;
+		shutdownDiagnosticRoute = undefined;
     cancelWarmUpRetry();
     if (ctx.orchestrationContext?.kind === "workflow-stage" && ctx.orchestrationContext.pendingStageDelivery !== undefined) {
       const pendingStageDelivery = ctx.orchestrationContext.pendingStageDelivery;
@@ -502,8 +517,9 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 	pi.on("session_shutdown", async (event, ctx) => {
 		const lease = activeLease;
 		const generation = ++lifecycleGeneration;
-		retireLifecycleLease(lease, { event, ctx, generation });
-		shutdownDiagnosticContext = ctx;
+		const diagnosticRoute = captureDiagnosticRoute(ctx);
+		retireLifecycleLease(lease, { event, ctx, generation, diagnosticRoute });
+		shutdownDiagnosticRoute = diagnosticRoute;
 		cancelWarmUpRetry();
 		const retiredHeavy = loadedHeavy?.heavy ?? null;
 		const retiredAttempt = heavyAttempt?.lease === lease ? heavyAttempt.promise : null;
@@ -627,7 +643,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 		payload.handled = true;
 		const forwarded = { ...payload, handled: false, completion: undefined };
 		const ctx = latestLifecycleContext();
-		const diagnosticCtx = ctx ?? shutdownDiagnosticContext;
+		const diagnosticRoute = ctx ? captureDiagnosticRoute(ctx) : shutdownDiagnosticRoute ?? "console";
 		payload.completion = loadHeavy(ctx)
 			.then(async (handle) => {
 				handle.assertCurrent();
@@ -638,7 +654,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 					: false;
 			})
 			.catch((error) => {
-				reportRelayFailure(diagnosticCtx, PENDING_STAGE_UNDELIVERABLE_EVENT, error);
+				reportRelayFailure(diagnosticRoute, PENDING_STAGE_UNDELIVERABLE_EVENT, error);
 				return false;
 			});
 	});
@@ -649,7 +665,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 	] as const) {
 		pi.events.on(eventName, (payload) => {
 			const ctx = latestLifecycleContext();
-			const diagnosticCtx = ctx ?? shutdownDiagnosticContext;
+			const diagnosticRoute = ctx ? captureDiagnosticRoute(ctx) : shutdownDiagnosticRoute ?? "console";
 			const completion = loadHeavy(ctx).then(async (handle) => {
 				handle.assertCurrent();
 				await dispatchEventHandlers(handle.heavy, eventName, payload);
@@ -664,7 +680,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 			}
 			void completion.catch((error) => {
 				rejectLazyResultRelay(pi, eventName, payload, error);
-				reportRelayFailure(diagnosticCtx, eventName, error);
+				reportRelayFailure(diagnosticRoute, eventName, error);
 			});
 		});
 	}

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -134,6 +134,15 @@ function renderHeavyToolResult(loadedHeavy: CapturedHeavy | null, name: string, 
 	return renderIntercomToolResult(name, args);
 }
 
+/** Formatting a diagnostic must never replace the failure or its acknowledgement. */
+function diagnosticDetail(error: unknown): string {
+	try {
+		return String(error instanceof Error ? error.message : error);
+	} catch {
+		return "Unprintable error";
+	}
+}
+
 /** Report against the captured owner, not whichever session is current after an await. */
 function reportDiagnostic(
 	ctx: ExtensionContext | undefined,
@@ -143,7 +152,9 @@ function reportDiagnostic(
 	consoleMessage = message,
 ): void {
 	try {
-		if (ctx?.hasUI) {
+		// RPC hosts also set hasUI; only the terminal's own mode owns pane
+		// diagnostics, so print, JSON, and RPC retain console output.
+		if (ctx?.hasUI && ctx.mode === "tui") {
 			ctx.ui.notify(message, level);
 			return;
 		}
@@ -169,7 +180,7 @@ function reportDiagnostic(
 function reportRelayFailure(ctx: ExtensionContext | undefined, eventName: string, error: unknown): void {
 	if (isRecoverableIntercomDisconnect(error)) return;
 	const prefix = `Intercom event relay failed (${eventName}):`;
-	const detail = error instanceof Error ? error.message : String(error);
+	const detail = diagnosticDetail(error);
 	reportDiagnostic(ctx, `${prefix} ${detail}`, error, "error", prefix);
 }
 
@@ -189,6 +200,8 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
   let heavyAttempt: HeavyAttempt | null = null;
   let loadedHeavy: IntercomHeavyHandle | null = null;
   let sessionSnapshot: SessionSnapshot | null = null;
+	// Event subscriptions outlive shutdown replay state; never use this owner to load heavy state.
+	let shutdownDiagnosticContext: ExtensionContext | undefined;
 	let lifecycleGeneration = 0;
 	let nextLeaseId = 1;
 	let activeLease = createLifecycleLease<ShutdownSnapshot>(nextLeaseId++);
@@ -291,7 +304,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 					await dispatchHandlers(captured, "session_shutdown", event, cleanupCtx);
 				} catch (cleanupError) {
 					const prefix = "Intercom failed to clean rejected lazy candidate:";
-					const detail = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+					const detail = diagnosticDetail(cleanupError);
 					reportDiagnostic(cleanupCtx, `${prefix} ${detail}`, cleanupError, "error", prefix);
 				}
 			};
@@ -319,7 +332,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 			(error: unknown) => {
 				if (heavyAttempt?.promise === promise) heavyAttempt = null;
 				if (!isRecoverableIntercomDisconnect(error)) {
-					const message = error instanceof Error ? error.message : String(error);
+					const message = diagnosticDetail(error);
 					reportDiagnostic(
 						replayCtx ?? ctx,
 						`Intercom heavy initialization failed; a later call will retry: ${message}`,
@@ -463,6 +476,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
     }
     const generation = ++lifecycleGeneration;
     sessionSnapshot = { event, ctx, generation, lease };
+		shutdownDiagnosticContext = undefined;
     cancelWarmUpRetry();
     if (ctx.orchestrationContext?.kind === "workflow-stage" && ctx.orchestrationContext.pendingStageDelivery !== undefined) {
       const pendingStageDelivery = ctx.orchestrationContext.pendingStageDelivery;
@@ -489,6 +503,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 		const lease = activeLease;
 		const generation = ++lifecycleGeneration;
 		retireLifecycleLease(lease, { event, ctx, generation });
+		shutdownDiagnosticContext = ctx;
 		cancelWarmUpRetry();
 		const retiredHeavy = loadedHeavy?.heavy ?? null;
 		const retiredAttempt = heavyAttempt?.lease === lease ? heavyAttempt.promise : null;
@@ -612,6 +627,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 		payload.handled = true;
 		const forwarded = { ...payload, handled: false, completion: undefined };
 		const ctx = latestLifecycleContext();
+		const diagnosticCtx = ctx ?? shutdownDiagnosticContext;
 		payload.completion = loadHeavy(ctx)
 			.then(async (handle) => {
 				handle.assertCurrent();
@@ -622,7 +638,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 					: false;
 			})
 			.catch((error) => {
-				reportRelayFailure(ctx, PENDING_STAGE_UNDELIVERABLE_EVENT, error);
+				reportRelayFailure(diagnosticCtx, PENDING_STAGE_UNDELIVERABLE_EVENT, error);
 				return false;
 			});
 	});
@@ -633,6 +649,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 	] as const) {
 		pi.events.on(eventName, (payload) => {
 			const ctx = latestLifecycleContext();
+			const diagnosticCtx = ctx ?? shutdownDiagnosticContext;
 			const completion = loadHeavy(ctx).then(async (handle) => {
 				handle.assertCurrent();
 				await dispatchEventHandlers(handle.heavy, eventName, payload);
@@ -647,7 +664,7 @@ export default function intercom(pi: ExtensionAPI, options: LightweightIntercomO
 			}
 			void completion.catch((error) => {
 				rejectLazyResultRelay(pi, eventName, payload, error);
-				reportRelayFailure(ctx, eventName, error);
+				reportRelayFailure(diagnosticCtx, eventName, error);
 			});
 		});
 	}

--- a/test/fixtures/intercom-owner-bundle-probe.mjs
+++ b/test/fixtures/intercom-owner-bundle-probe.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { setImmediate as tick } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+
+// Inputs are independently built host and builtin modules, not source imports.
+const { ExtensionRunner } = await import(pathToFileURL(process.argv[2]).href);
+const { default: intercom } = await import(pathToFileURL(process.argv[3]).href);
+const message = "Intercom heavy initialization failed; a later call will retry: Connection closen";
+const rows = [];
+function owner(mode, unowned = false) {
+	const notifications = [];
+	const runner = new ExtensionRunner(
+		[], { workflowActivityHub: { bindDispatcher() {} }, invalidate() {} }, ".", {}, {},
+	);
+	runner.setUIContext(
+		mode === "tui" || mode === "rpc" ? { notify: (message, level) => notifications.push({ message, level }) } : undefined,
+		mode,
+	);
+	// Plain compatibility contexts deliberately have no host registration. Lazy
+	// descriptors retain real guards, but must keep fallback object identity.
+	const plain = Object.defineProperties({}, Object.getOwnPropertyDescriptors(runner.createContext()));
+	return {
+		notifications,
+		context: (command = false) => unowned ? plain : command ? runner.createCommandContext() : runner.createContext(),
+		invalidate: () => runner.invalidate(),
+	};
+}
+for (const mode of ["print", "json", "rpc", "tui"]) {
+	for (const phase of ["import", "factory"]) {
+		for (const dispatch of ["tool", "command"]) {
+			for (const transition of ["same", "new-live", "new-stale", "unknown-same", "unknown-new-stale"]) {
+				const unowned = transition.startsWith("unknown");
+				const changesOwner = transition.includes("new");
+				const caller = owner(mode, unowned);
+				const targetMode = changesOwner ? mode === "tui" ? "print" : "tui" : mode;
+				const target = changesOwner ? owner(targetMode, unowned) : caller;
+				const startup = caller.context();
+				const invocation = caller.context(dispatch === "command");
+				if (!unowned) assert.notEqual(startup, invocation);
+				const replayContext = changesOwner ? target.context() : startup;
+				const gate = Promise.withResolvers();
+				const entered = Promise.withResolvers();
+				const failure = new Error("Connection closen");
+				const success = { content: [{ type: "text", text: "connected" }], details: {} };
+				const tools = new Map(), commands = new Map(), handlers = new Map();
+				let imports = 0, commandRetries = 0;
+				intercom({
+					on: (name, handler) => handlers.set(name, handler),
+					registerTool: (tool) => tools.set(tool.name, tool),
+					registerCommand: (name, command) => commands.set(name, command),
+					registerShortcut() {}, events: { on() {} },
+				}, { importHeavy: async () => {
+					if (++imports > 1) return { default(pi) {
+						pi.registerTool({ name: "intercom", execute: async () => success });
+						pi.registerCommand("intercom", { handler() { commandRetries++; } });
+					} };
+					entered.resolve(); await gate.promise;
+					return { default(pi) {
+						if (phase === "factory" && transition !== "new-live") queueMicrotask(target.invalidate);
+						pi.on("session_start", (_event, ctx) => {
+							assert.equal(ctx, replayContext);
+							if (transition !== "new-live") assert.throws(() => ctx.mode, /extension ctx is stale/);
+							throw failure;
+						});
+					} };
+				} });
+				const start = (ctx) => handlers.get("session_start")({ type: "session_start", reason: "startup" }, ctx);
+				const execute = (ctx) => dispatch === "command" ? commands.get("intercom").handler("", ctx)
+					: tools.get("intercom").execute("bundle", { action: "list" }, undefined, undefined, ctx);
+				const saved = { error: console.error, log: console.log, warn: console.warn };
+				const errors = [], otherWrites = [];
+				console.error = (...args) => errors.push(args);
+				console.log = console.warn = (...args) => otherWrites.push(args);
+				try {
+					await start(startup);
+					const rejected = assert.rejects(execute(invocation), (error) => error === failure);
+					await entered.promise;
+					if (changesOwner) await start(replayContext);
+					if (phase === "import" && transition !== "new-live") target.invalidate();
+					gate.resolve(); await rejected; await tick();
+					const consoleExpected = targetMode !== "tui" && !transition.includes("new-stale");
+					assert.deepEqual(errors, consoleExpected ? [[message, failure]] : []);
+					if (consoleExpected) assert.equal(errors[0][1], failure);
+					assert.deepEqual(otherWrites, []);
+					assert.deepEqual(target.notifications, transition === "new-live" && targetMode === "tui" ? [{ message, level: "warning" }] : []);
+					if (changesOwner) assert.deepEqual(caller.notifications, []);
+					const replacement = owner(mode);
+					await start(replacement.context());
+					const result = await execute(replacement.context(dispatch === "command"));
+					if (dispatch === "tool") assert.equal(result, success);
+					else assert.equal(commandRetries, 1);
+					assert.equal(imports, 2);
+					assert.deepEqual(replacement.notifications, []);
+					rows.push({ mode, phase, dispatch, transition });
+				} finally { Object.assign(console, saved); }
+			}
+		}
+	}
+}
+assert.equal(rows.length, 80);
+console.log(JSON.stringify({ passed: rows.length, runtime: typeof Bun === "undefined" ? "node" : "bun", rows }));

--- a/test/unit/intercom-context-owner-bundle.test.ts
+++ b/test/unit/intercom-context-owner-bundle.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { symlinkSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, test } from "vitest";
+import {
+	bunExecutable,
+	makeTempDirectory,
+	moduleDir,
+	removeTempDirectory,
+	spawnSyncCollect,
+} from "../helpers/runtime.js";
+
+const root = resolve(moduleDir(import.meta.url), "../..");
+let directory: string;
+const entries = {
+	host: "packages/coding-agent/src/core/extensions/runner.ts",
+	builtin: "packages/intercom/index.ts",
+};
+
+beforeAll(() => {
+	directory = makeTempDirectory("intercom-owner-bundles-");
+	// Only dependency resolution is linked; host and builtin local graphs are
+	// independently bundled, so a module-local identity WeakMap cannot pass.
+	symlinkSync(join(root, "node_modules"), join(directory, "node_modules"), "junction");
+	for (const [name, entry] of Object.entries(entries)) {
+		const result = spawnSyncCollect(
+			[
+				bunExecutable(),
+				"build",
+				entry,
+				"--target=node",
+				"--packages=external",
+				"--outfile",
+				join(directory, `${name}.mjs`),
+			],
+			{ cwd: root },
+		);
+		assert.equal(result.exitCode, 0, `${name} bundle failed:\n${result.stdout}\n${result.stderr}`);
+	}
+});
+
+afterAll(() => {
+	if (directory) removeTempDirectory(directory);
+});
+
+for (const runtime of ["node", "bun"] as const) {
+	test(`separate host and builtin bundles preserve diagnostic owner identity under ${runtime}`, () => {
+		const result = spawnSyncCollect(
+			[
+				runtime === "node" ? process.execPath : bunExecutable(),
+				join(root, "test/fixtures/intercom-owner-bundle-probe.mjs"),
+				join(directory, "host.mjs"),
+				join(directory, "builtin.mjs"),
+			],
+			{ cwd: directory },
+		);
+		assert.equal(result.exitCode, 0, `cross-bundle ${runtime} probe failed:\n${result.stdout}\n${result.stderr}`);
+		const receipt = JSON.parse(result.stdout.toString()) as { passed: number; runtime: string };
+		assert.equal(receipt.passed, 80);
+		assert.equal(receipt.runtime, runtime);
+	});
+}

--- a/test/unit/intercom-heavy-init-diagnostics.test.ts
+++ b/test/unit/intercom-heavy-init-diagnostics.test.ts
@@ -3,6 +3,10 @@ import { setImmediate as tick } from "node:timers/promises";
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@bastani/atomic";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
+import {
+	createExtensionContext,
+	type ExtensionContextSource,
+} from "../../packages/coding-agent/src/core/extensions/runner-context.js";
 import intercom from "../../packages/intercom/index.js";
 import { IntercomClientDisconnectedError } from "../../packages/intercom/recoverable-disconnect.js";
 
@@ -30,6 +34,7 @@ function fixture(importResults: ImportResult[], hasUI = false, mode: ExtensionCo
 	const handlers = new Map<string, LifecycleHandler>();
 	const eventHandlers = new Map<string, (payload: object) => void>();
 	let imports = 0;
+	const deliveries: Array<{ name: string; payload: unknown }> = [];
 	const pi = {
 		on(name: string, handler: LifecycleHandler) {
 			handlers.set(name, handler);
@@ -43,7 +48,9 @@ function fixture(importResults: ImportResult[], hasUI = false, mode: ExtensionCo
 			on(name: string, handler: (payload: object) => void) {
 				eventHandlers.set(name, handler);
 			},
-			emit() {},
+			emit(name: string, payload: unknown) {
+				deliveries.push({ name, payload });
+			},
 		},
 	};
 	intercom(pi as never, {
@@ -66,8 +73,9 @@ function fixture(importResults: ImportResult[], hasUI = false, mode: ExtensionCo
 	};
 	return {
 		notifications,
+		deliveries,
 		ctx,
-		async fire(name: string, context = ctx) {
+		async fire(name: string, context: ExtensionContext | typeof ctx = ctx) {
 			await handlers.get(name)?.({ type: name, reason: "startup" }, context as ExtensionContext);
 		},
 		emit(name: string, payload: object) {
@@ -76,7 +84,10 @@ function fixture(importResults: ImportResult[], hasUI = false, mode: ExtensionCo
 		get imports() {
 			return imports;
 		},
-		executeIntercom(context = ctx, params: { action: string; to?: string; message?: string } = { action: "list" }) {
+		executeIntercom(
+			context: ExtensionContext | typeof ctx = ctx,
+			params: { action: string; to?: string; message?: string } = { action: "list" },
+		) {
 			const tool = tools.get("intercom");
 			assert.ok(tool, "intercom tool should be registered");
 			return tool.execute("tool-call", params, new AbortController().signal, undefined, context as ExtensionContext);
@@ -96,6 +107,36 @@ function successfulHeavyModule(): HeavyModule {
 					return { content: [{ type: "text", text: "connected" }], details: {} };
 				},
 			});
+		},
+	};
+}
+
+/** Use the host's actual guarded getters, not a hasUI-only imitation. */
+function guardedContext(mode: ExtensionContext["mode"]) {
+	let active = true;
+	const notifications: Array<{ message: string; level?: string }> = [];
+	const ctx = createExtensionContext({
+		assertActive() {
+			if (!active) throw new Error("Extension context is stale");
+		},
+		getMode: () => mode,
+		hasUI: () => mode === "tui" || mode === "rpc",
+		getUIContext: () => ({
+			notify(message: string, level?: string) {
+				notifications.push({ message, level });
+			},
+		}),
+		getSubagentPolicy: () => undefined,
+		getOrchestrationContext: () => undefined,
+	} as ExtensionContextSource);
+	return {
+		ctx,
+		notifications,
+		invalidate() {
+			active = false;
+			for (const key of ["hasUI", "mode", "ui"] as const) {
+				assert.throws(() => ctx[key], /Extension context is stale/);
+			}
 		},
 	};
 }
@@ -297,13 +338,149 @@ describe("Intercom lazy heavy-initialization diagnostics", () => {
 		assert.deepEqual(consoleErrorCalls, []);
 	});
 
-	for (const eventName of ["atomic:workflow-pending-stage-route", "atomic:workflow-pending-stage-undeliverable"]) {
-		test(`does not redirect a stale ${eventName} callback to the replacement or console`, async () => {
-			const entered = Promise.withResolvers<void>();
-			const release = Promise.withResolvers<void>();
-			const failure = new Error("late relay failure");
-			const current = fixture(
-				[
+	for (const mode of ["print", "json", "rpc", "tui"] as const) {
+		for (const phase of ["initializing", "replaying"] as const) {
+			test(`retains the ${mode} ${phase} route when its guarded owner expires`, async () => {
+				const entered = Promise.withResolvers<void>();
+				const release = Promise.withResolvers<void>();
+				const failure = new Error("Connection closen");
+				const fail = async () => {
+					entered.resolve();
+					await release.promise;
+					throw failure;
+				};
+				const current = fixture([
+					{
+						module: {
+							async default(pi) {
+								if (phase === "initializing") await fail();
+								else pi.on("session_start", fail);
+							},
+						},
+					},
+				]);
+				const owner = guardedContext(mode);
+				const other = guardedContext(mode === "tui" ? "print" : "tui");
+				if (phase === "replaying") await current.fire("session_start", owner.ctx);
+				const rejected = assert.rejects(
+					current.executeIntercom(phase === "initializing" ? owner.ctx : other.ctx),
+					(error) => error === failure,
+				);
+				await entered.promise;
+				// Exercise the guarded boundary even if a host expires a pending owner.
+				owner.invalidate();
+				await current.fire("session_start", other.ctx);
+				release.resolve();
+				await rejected;
+				await tick();
+				const message = "Intercom heavy initialization failed; a later call will retry: Connection closen";
+				assert.deepEqual(consoleErrorCalls, mode === "tui" ? [] : [[message, failure]]);
+				if (mode !== "tui") assert.equal(consoleErrorCalls[0]?.[1], failure);
+				assert.deepEqual(owner.notifications, []);
+				assert.deepEqual(other.notifications, []);
+			});
+		}
+
+		test(`retains the ${mode} shutdown cleanup route independently of its expired replay owner`, async () => {
+			const replayEntered = Promise.withResolvers<void>();
+			const replayRelease = Promise.withResolvers<void>();
+			const cleanupEntered = Promise.withResolvers<void>();
+			const cleanupRelease = Promise.withResolvers<void>();
+			const failure = new Error("Connection closen");
+			const cleanupFailure = new Error("cleanup failed");
+			const owner = guardedContext(mode);
+			const replayOwner = guardedContext(mode === "tui" ? "print" : "tui");
+			const replacement = guardedContext("tui");
+			const current = fixture([
+				{
+					module: {
+						default(pi) {
+							pi.on("session_start", async () => {
+								replayEntered.resolve();
+								await replayRelease.promise;
+								throw failure;
+							});
+							pi.on("session_shutdown", async () => {
+								cleanupEntered.resolve();
+								await cleanupRelease.promise;
+								throw cleanupFailure;
+							});
+						},
+					},
+				},
+				{ module: successfulHeavyModule() },
+			]);
+			await current.fire("session_start", replayOwner.ctx);
+			const rejected = assert.rejects(current.executeIntercom(owner.ctx), (error) => error === failure);
+			await replayEntered.promise;
+			const shutdown = current.fire("session_shutdown", owner.ctx);
+			const replaced = current.fire("session_start", replacement.ctx);
+			replayRelease.resolve();
+			await cleanupEntered.promise;
+			owner.invalidate();
+			replayOwner.invalidate();
+			cleanupRelease.resolve();
+			await Promise.all([rejected, shutdown, replaced]);
+			const expected =
+				mode === "tui"
+					? [["Intercom heavy initialization failed; a later call will retry: Connection closen", failure]]
+					: [["Intercom failed to clean rejected lazy candidate:", cleanupFailure]];
+			assert.deepEqual(consoleErrorCalls, expected);
+			assert.equal(consoleErrorCalls[0]?.[1], mode === "tui" ? failure : cleanupFailure);
+			assert.deepEqual(owner.notifications, []);
+			assert.deepEqual(replayOwner.notifications, []);
+			assert.deepEqual(replacement.notifications, []);
+			await current.executeIntercom(replacement.ctx);
+			assert.equal(current.imports, 2);
+		});
+
+		test(`retains the ${mode} shutdown route for all relays arriving after runner invalidation`, async () => {
+			const current = fixture([]);
+			const owner = guardedContext(mode);
+			await current.fire("session_start", owner.ctx);
+			await current.fire("session_shutdown", owner.ctx);
+			owner.invalidate();
+			for (const eventName of [
+				"subagent:control-intercom",
+				"subagent:result-intercom",
+				"atomic:workflow-pending-stage-route",
+				"atomic:workflow-pending-stage-undeliverable",
+			]) {
+				const payload = {
+					completion: undefined as Promise<void> | Promise<boolean> | undefined,
+					runId: "run",
+					senderId: "sender",
+					messageId: "message",
+					notificationId: "notice",
+					reason: "not_started",
+				};
+				current.emit(eventName, payload);
+				if (eventName.endsWith("undeliverable")) assert.equal(await payload.completion, false);
+				else if (eventName.endsWith("stage-route")) await assert.rejects(payload.completion!, /no active session/);
+				await tick();
+				if (mode !== "tui") {
+					const args = consoleErrorCalls.shift();
+					assert.equal(args?.[0], `Intercom event relay failed (${eventName}):`);
+					assert.ok(args[1] instanceof Error);
+					assert.equal(args[1].message, "Intercom initialization unavailable: no active session");
+				}
+				assert.deepEqual(consoleErrorCalls, []);
+			}
+			assert.deepEqual(owner.notifications, []);
+			assert.equal(current.imports, 0, "a diagnostic route cannot reactivate the retired lease");
+		});
+
+		for (const eventName of [
+			"subagent:control-intercom",
+			"subagent:result-intercom",
+			"atomic:workflow-pending-stage-route",
+			"atomic:workflow-pending-stage-undeliverable",
+		]) {
+			test(`retains ${mode} late ${eventName} diagnostics after real context invalidation`, async () => {
+				const entered = Promise.withResolvers<void>();
+				const release = Promise.withResolvers<void>();
+				const failure = new Error("late relay failure");
+				const current = fixture([
 					{
 						module: {
 							default(pi) {
@@ -316,57 +493,64 @@ describe("Intercom lazy heavy-initialization diagnostics", () => {
 						},
 					},
 					{ module: successfulHeavyModule() },
-				],
-				true,
-			);
-			let retired = false;
-			const origin = {
-				...current.ctx,
-				get hasUI() {
-					if (retired) throw new Error("Extension context is stale");
-					return true;
-				},
-			};
-			await current.fire("session_start", origin);
-			const payload: {
-				completion?: Promise<void> | Promise<boolean>;
-				runId: string;
-				senderId: string;
-				messageId: string;
-				notificationId: string;
-				reason: string;
-			} = {
-				runId: "run",
-				senderId: "sender",
-				messageId: "message",
-				notificationId: "notice",
-				reason: "stage_never_started",
-			};
-			current.emit(eventName, payload);
-			assert.ok(payload.completion);
-			const settled = eventName.endsWith("undeliverable")
-				? payload.completion.then((value) => assert.equal(value, false))
-				: assert.rejects(payload.completion, (error) => error === failure);
-			await entered.promise;
-			await current.fire("session_shutdown", origin);
-			retired = true;
-			await current.fire("session_start", {
-				hasUI: false,
-				mode: "print",
-				ui: {
-					notify() {
-						assert.fail("wrong session");
-					},
-				},
+				]);
+				const origin = guardedContext(mode);
+				const replacement = guardedContext(mode === "tui" ? "print" : "tui");
+				const log = vi.spyOn(console, "log").mockImplementation(() => {});
+				const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+				try {
+					await current.fire("session_start", origin.ctx);
+					const payload = {
+						completion: undefined as Promise<void> | Promise<boolean> | undefined,
+						requestId: "request",
+						runId: "run",
+						senderId: "sender",
+						messageId: "message",
+						notificationId: "notice",
+						reason: "stage_never_started",
+					};
+					current.emit(eventName, payload);
+					const settled = eventName.endsWith("undeliverable")
+						? payload.completion!.then((value) => assert.equal(value, false))
+						: eventName.endsWith("stage-route")
+							? assert.rejects(payload.completion!, (error) => error === failure)
+							: Promise.resolve();
+					await entered.promise;
+					await current.fire("session_shutdown", origin.ctx);
+					origin.invalidate(); // Runner invalidates only after awaited shutdown.
+					await current.fire("session_start", replacement.ctx);
+					release.resolve();
+					await settled;
+					await tick();
+					assert.deepEqual(origin.notifications, []);
+					assert.deepEqual(replacement.notifications, []);
+					assert.deepEqual(
+						consoleErrorCalls,
+						mode === "tui" ? [] : [[`Intercom event relay failed (${eventName}):`, failure]],
+					);
+					if (mode !== "tui") assert.equal(consoleErrorCalls[0]?.[1], failure);
+					assert.equal(log.mock.calls.length, 0);
+					assert.equal(warn.mock.calls.length, 0);
+					assert.deepEqual(
+						current.deliveries,
+						eventName === "subagent:result-intercom"
+							? [
+									{
+										name: "subagent:result-intercom-delivery",
+										payload: { requestId: "request", delivered: false, error: failure.message },
+									},
+								]
+							: [],
+					);
+					await current.executeIntercom(replacement.ctx);
+					assert.equal(current.imports, 2, "the retired callback does not invalidate the replacement");
+				} finally {
+					release.resolve();
+					log.mockRestore();
+					warn.mockRestore();
+				}
 			});
-			release.resolve();
-			await settled;
-			await tick();
-			assert.deepEqual(current.notifications, []);
-			assert.deepEqual(consoleErrorCalls, []);
-			await current.executeIntercom();
-			assert.equal(current.imports, 2, "the retired callback does not invalidate the replacement");
-		});
+		}
 	}
 
 	for (const eventName of [

--- a/test/unit/intercom-heavy-init-diagnostics.test.ts
+++ b/test/unit/intercom-heavy-init-diagnostics.test.ts
@@ -1,13 +1,15 @@
 import assert from "node:assert/strict";
-import type { ExtensionAPI, ToolDefinition } from "@bastani/atomic";
+import { setImmediate as tick } from "node:timers/promises";
+import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@bastani/atomic";
 import { Type } from "typebox";
-import { afterEach, beforeEach, describe, test } from "vitest";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import intercom from "../../packages/intercom/index.js";
 import { IntercomClientDisconnectedError } from "../../packages/intercom/recoverable-disconnect.js";
 
 type HeavyModule = { default: (pi: ExtensionAPI) => void | Promise<void> };
 type ConsoleErrorCall = [message?: unknown, ...optionalParams: unknown[]];
 type ImportResult = { error: unknown } | { module: HeavyModule };
+type LifecycleHandler = (event: object, ctx: ExtensionContext) => void | Promise<void>;
 
 const originalConsoleError = console.error;
 let consoleErrorCalls: ConsoleErrorCall[] = [];
@@ -23,17 +25,26 @@ afterEach(() => {
 	console.error = originalConsoleError;
 });
 
-function fixture(importResults: ImportResult[]) {
+function fixture(importResults: ImportResult[], hasUI = false) {
 	const tools = new Map<string, ToolDefinition>();
+	const handlers = new Map<string, LifecycleHandler>();
+	const eventHandlers = new Map<string, (payload: object) => void>();
 	let imports = 0;
 	const pi = {
-		on() {},
+		on(name: string, handler: LifecycleHandler) {
+			handlers.set(name, handler);
+		},
 		registerTool(tool: ToolDefinition) {
 			tools.set(tool.name, tool);
 		},
 		registerCommand() {},
 		registerShortcut() {},
-		events: { on() {} },
+		events: {
+			on(name: string, handler: (payload: object) => void) {
+				eventHandlers.set(name, handler);
+			},
+			emit() {},
+		},
 	};
 	intercom(pi as never, {
 		async importHeavy() {
@@ -43,15 +54,37 @@ function fixture(importResults: ImportResult[]) {
 			return result.module;
 		},
 	});
-	const ctx = { hasUI: true };
+	const notifications: Array<{ message: string; level?: string }> = [];
+	const ctx = {
+		hasUI,
+		ui: {
+			notify(message: string, level?: string) {
+				notifications.push({ message, level });
+			},
+		},
+	};
 	return {
+		notifications,
+		ctx,
+		async fire(name: string, context = ctx) {
+			await handlers.get(name)?.({ type: name, reason: "startup" }, context as ExtensionContext);
+		},
+		emit(name: string, payload: object) {
+			eventHandlers.get(name)?.(payload);
+		},
 		get imports() {
 			return imports;
 		},
-		executeIntercom() {
+		executeIntercom(context = ctx) {
 			const tool = tools.get("intercom");
 			assert.ok(tool, "intercom tool should be registered");
-			return tool.execute("tool-call", { action: "list" }, new AbortController().signal, undefined, ctx as never);
+			return tool.execute(
+				"tool-call",
+				{ action: "list" },
+				new AbortController().signal,
+				undefined,
+				context as ExtensionContext,
+			);
 		},
 	};
 }
@@ -73,6 +106,386 @@ function successfulHeavyModule(): HeavyModule {
 }
 
 describe("Intercom lazy heavy-initialization diagnostics", () => {
+	test("shows the reported retryable initialization failure as a warning without console or stack output", async () => {
+		const failure = new Error("Connection closen");
+		failure.stack = "Error: Connection closen\n    at Socket.onClose (client.ts:42:7)";
+		const current = fixture([{ error: failure }, { module: successfulHeavyModule() }], true);
+		const log = vi.spyOn(console, "log");
+		const warn = vi.spyOn(console, "warn");
+		try {
+			await assert.rejects(current.executeIntercom(), (error) => error === failure);
+			assert.deepEqual(current.notifications, [
+				{
+					message: "Intercom heavy initialization failed; a later call will retry: Connection closen",
+					level: "warning",
+				},
+			]);
+			assert.deepEqual(consoleErrorCalls, []);
+			assert.equal(log.mock.calls.length, 0);
+			assert.equal(warn.mock.calls.length, 0);
+			assert.deepEqual(await current.executeIntercom(), {
+				content: [{ type: "text", text: "connected" }],
+				details: {},
+			});
+			assert.equal(current.imports, 2);
+		} finally {
+			log.mockRestore();
+			warn.mockRestore();
+		}
+	});
+
+	test("keeps rejected initialization and shutdown cleanup with their owners while replacement waits", async () => {
+		const entered = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const failure = new Error("Connection closen");
+		const cleanupFailure = new Error("cleanup failed during shutdown");
+		const current = fixture(
+			[
+				{
+					module: {
+						default(pi) {
+							pi.on("session_start", async () => {
+								entered.resolve();
+								await release.promise;
+								throw failure;
+							});
+							pi.on("session_shutdown", () => {
+								throw cleanupFailure;
+							});
+						},
+					},
+				},
+				{ module: successfulHeavyModule() },
+			],
+			true,
+		);
+		const rejected = assert.rejects(current.executeIntercom(), (error) => error === failure);
+		await entered.promise;
+		const cleanupNotifications: string[] = [];
+		const shutdown = current.fire("session_shutdown", {
+			hasUI: true,
+			ui: {
+				notify(message: string) {
+					cleanupNotifications.push(message);
+				},
+			},
+		});
+		const replacement = current.fire("session_start", {
+			hasUI: false,
+			ui: {
+				notify() {
+					assert.fail("replacement received an old diagnostic");
+				},
+			},
+		});
+		release.resolve();
+		await Promise.all([rejected, shutdown, replacement]);
+		assert.deepEqual(cleanupNotifications, [
+			"Intercom failed to clean rejected lazy candidate: cleanup failed during shutdown",
+		]);
+		assert.deepEqual(current.notifications, [
+			{
+				message: "Intercom heavy initialization failed; a later call will retry: Connection closen",
+				level: "warning",
+			},
+		]);
+		assert.deepEqual(consoleErrorCalls, []);
+		await current.executeIntercom();
+		assert.equal(current.imports, 2);
+	});
+
+	test("retains noninteractive diagnostic text and error identity across shared failure and later retry", async () => {
+		const failure = new Error("Connection closen");
+		const current = fixture([{ error: failure }, { module: successfulHeavyModule() }]);
+		await Promise.all([1, 2].map(() => assert.rejects(current.executeIntercom(), (error) => error === failure)));
+		assert.deepEqual(consoleErrorCalls, [
+			["Intercom heavy initialization failed; a later call will retry: Connection closen", failure],
+		]);
+		assert.equal(consoleErrorCalls[0]?.[1], failure);
+		assert.deepEqual(current.notifications, []);
+		assert.equal(current.imports, 1);
+		await current.executeIntercom();
+		assert.equal(current.imports, 2);
+	});
+
+	test("keeps background initialization diagnostics bound to the initiating context before replay", async () => {
+		const entered = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const failure = new Error("Connection closen");
+		const current = fixture(
+			[
+				{
+					module: {
+						async default() {
+							entered.resolve();
+							await release.promise;
+							throw failure;
+						},
+					},
+				},
+			],
+			true,
+		);
+		await current.fire("turn_start");
+		const payload: { completion?: Promise<void> } = {};
+		current.emit("atomic:workflow-pending-stage-route", payload);
+		assert.ok(payload.completion);
+		const rejected = assert.rejects(payload.completion, (error) => error === failure);
+		await entered.promise;
+		const replacement = {
+			hasUI: false,
+			ui: {
+				notify() {
+					assert.fail("wrong session");
+				},
+			},
+		};
+		await current.fire("session_start", replacement);
+		release.resolve();
+		await rejected;
+		await tick();
+		assert.deepEqual(current.notifications, [
+			{
+				message: "Intercom heavy initialization failed; a later call will retry: Connection closen",
+				level: "warning",
+			},
+			{
+				message: "Intercom event relay failed (atomic:workflow-pending-stage-route): Connection closen",
+				level: "error",
+			},
+		]);
+		assert.deepEqual(consoleErrorCalls, []);
+	});
+
+	for (const eventName of ["atomic:workflow-pending-stage-route", "atomic:workflow-pending-stage-undeliverable"]) {
+		test(`does not redirect a stale ${eventName} callback to the replacement or console`, async () => {
+			const entered = Promise.withResolvers<void>();
+			const release = Promise.withResolvers<void>();
+			const failure = new Error("late relay failure");
+			const current = fixture(
+				[
+					{
+						module: {
+							default(pi) {
+								pi.events.on(eventName, async () => {
+									entered.resolve();
+									await release.promise;
+									throw failure;
+								});
+							},
+						},
+					},
+					{ module: successfulHeavyModule() },
+				],
+				true,
+			);
+			let retired = false;
+			const origin = {
+				...current.ctx,
+				get hasUI() {
+					if (retired) throw new Error("Extension context is stale");
+					return true;
+				},
+			};
+			await current.fire("session_start", origin);
+			const payload: {
+				completion?: Promise<void> | Promise<boolean>;
+				runId: string;
+				senderId: string;
+				messageId: string;
+				notificationId: string;
+				reason: string;
+			} = {
+				runId: "run",
+				senderId: "sender",
+				messageId: "message",
+				notificationId: "notice",
+				reason: "stage_never_started",
+			};
+			current.emit(eventName, payload);
+			assert.ok(payload.completion);
+			const settled = eventName.endsWith("undeliverable")
+				? payload.completion.then((value) => assert.equal(value, false))
+				: assert.rejects(payload.completion, (error) => error === failure);
+			await entered.promise;
+			await current.fire("session_shutdown", origin);
+			retired = true;
+			await current.fire("session_start", {
+				hasUI: false,
+				ui: {
+					notify() {
+						assert.fail("wrong session");
+					},
+				},
+			});
+			release.resolve();
+			await settled;
+			await tick();
+			assert.deepEqual(current.notifications, []);
+			assert.deepEqual(consoleErrorCalls, []);
+			await current.executeIntercom();
+			assert.equal(current.imports, 2, "the retired callback does not invalidate the replacement");
+		});
+	}
+
+	test("a throwing UI sink never logs or replaces the initialization error and remains retryable", async () => {
+		const failure = new Error("Connection closen");
+		const current = fixture([{ error: failure }, { module: successfulHeavyModule() }], true);
+		current.ctx.ui.notify = () => {
+			throw new Error("UI closed");
+		};
+		await assert.rejects(current.executeIntercom(), (error) => error === failure);
+		await current.executeIntercom();
+		assert.equal(current.imports, 2);
+		assert.deepEqual(consoleErrorCalls, []);
+	});
+
+	test("attributes a failed startup replay to its lifecycle context rather than the tool caller", async () => {
+		const failure = new Error("Connection closen");
+		const current = fixture(
+			[
+				{
+					module: {
+						default(pi) {
+							pi.on("session_start", () => {
+								throw failure;
+							});
+						},
+					},
+				},
+			],
+			true,
+		);
+		await current.fire("session_start");
+		const callerNotifications: string[] = [];
+		const caller = {
+			hasUI: false,
+			ui: {
+				notify(message: string) {
+					callerNotifications.push(message);
+				},
+			},
+		};
+		await assert.rejects(current.executeIntercom(caller), (error) => error === failure);
+		assert.deepEqual(current.notifications, [
+			{
+				message: "Intercom heavy initialization failed; a later call will retry: Connection closen",
+				level: "warning",
+			},
+		]);
+		assert.deepEqual(callerNotifications, []);
+		assert.deepEqual(consoleErrorCalls, []);
+	});
+
+	for (const hasUI of [true, false]) {
+		test(`routes rejected-candidate cleanup with hasUI=${hasUI} and preserves the initialization error and retry`, async () => {
+			const failure = new Error("Connection closen");
+			const cleanupFailure = new Error("cleanup failed");
+			let cleanups = 0;
+			const current = fixture(
+				[
+					{
+						module: {
+							default(pi) {
+								pi.on("session_start", () => {
+									throw failure;
+								});
+								pi.on("session_shutdown", () => {
+									cleanups++;
+									throw cleanupFailure;
+								});
+							},
+						},
+					},
+					{ module: successfulHeavyModule() },
+				],
+				hasUI,
+			);
+			await assert.rejects(current.executeIntercom(), (error) => error === failure);
+			const prefix = "Intercom failed to clean rejected lazy candidate:";
+			const initMessage = "Intercom heavy initialization failed; a later call will retry: Connection closen";
+			assert.deepEqual(
+				current.notifications,
+				hasUI
+					? [
+							{ message: `${prefix} cleanup failed`, level: "error" },
+							{ message: initMessage, level: "warning" },
+						]
+					: [],
+			);
+			assert.deepEqual(
+				consoleErrorCalls,
+				hasUI
+					? []
+					: [
+							[prefix, cleanupFailure],
+							[initMessage, failure],
+						],
+			);
+			assert.equal(cleanups, 1);
+			await current.executeIntercom();
+			assert.equal(current.imports, 2);
+		});
+
+		for (const eventName of [
+			"subagent:control-intercom",
+			"subagent:result-intercom",
+			"atomic:workflow-pending-stage-route",
+			"atomic:workflow-pending-stage-undeliverable",
+		]) {
+			test(`routes ${eventName} failure with hasUI=${hasUI} without changing its acknowledgement`, async () => {
+				const failure = new Error("Intercom protocol error: bad frame");
+				const current = fixture(
+					[
+						{
+							module: {
+								default(pi) {
+									pi.events.on(eventName, () => {
+										throw failure;
+									});
+								},
+							},
+						},
+					],
+					hasUI,
+				);
+				// Background relays also run in hosts without session_start.
+				await current.fire("turn_start");
+				const payload: {
+					completion?: Promise<void> | Promise<boolean>;
+					handled?: boolean;
+					runId: string;
+					senderId: string;
+					messageId: string;
+					notificationId: string;
+					reason: string;
+				} = {
+					runId: "run",
+					senderId: "sender",
+					messageId: "message",
+					notificationId: "notice",
+					reason: "stage_never_started",
+				};
+				current.emit(eventName, payload);
+				if (eventName === "atomic:workflow-pending-stage-route") {
+					assert.ok(payload.completion);
+					await assert.rejects(payload.completion, (error) => error === failure);
+				} else if (eventName === "atomic:workflow-pending-stage-undeliverable") {
+					assert.equal(payload.handled, true);
+					assert.ok(payload.completion);
+					assert.equal(await payload.completion, false);
+				}
+				await tick();
+				const prefix = `Intercom event relay failed (${eventName}):`;
+				assert.deepEqual(
+					current.notifications,
+					hasUI ? [{ message: `${prefix} ${failure.message}`, level: "error" }] : [],
+				);
+				assert.deepEqual(consoleErrorCalls, hasUI ? [] : [[prefix, failure]]);
+			});
+		}
+	}
+
 	test("keeps a recoverable client disconnect out of console output while rejecting the caller", async () => {
 		const disconnectError = new IntercomClientDisconnectedError();
 		const current = fixture([{ error: disconnectError }]);

--- a/test/unit/intercom-heavy-init-diagnostics.test.ts
+++ b/test/unit/intercom-heavy-init-diagnostics.test.ts
@@ -12,7 +12,7 @@ import { IntercomClientDisconnectedError } from "../../packages/intercom/recover
 
 type HeavyModule = { default: (pi: ExtensionAPI) => void | Promise<void> };
 type ConsoleErrorCall = [message?: unknown, ...optionalParams: unknown[]];
-type ImportResult = { error: unknown } | { module: HeavyModule };
+type ImportResult = { error: unknown } | { module: HeavyModule | Promise<HeavyModule> };
 type LifecycleHandler = (event: object, ctx: ExtensionContext) => void | Promise<void>;
 
 const originalConsoleError = console.error;
@@ -339,6 +339,141 @@ describe("Intercom lazy heavy-initialization diagnostics", () => {
 	});
 
 	for (const mode of ["print", "json", "rpc", "tui"] as const) {
+		for (const phase of ["during import", "after factory"] as const) {
+			test(`retains the ${mode} route when the same owner expires ${phase} before first replay`, async () => {
+				const imported = Promise.withResolvers<HeavyModule>();
+				const owner = guardedContext(mode);
+				const failure = new Error("Connection closen");
+				const current = fixture([{ module: imported.promise }, { module: successfulHeavyModule() }]);
+				const log = vi.spyOn(console, "log").mockImplementation(() => {});
+				const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+				try {
+					await current.fire("session_start", owner.ctx);
+					const rejected = assert.rejects(current.executeIntercom(owner.ctx), (error) => error === failure);
+					await tick();
+					assert.equal(current.imports, 1, "the successful import is still pending");
+					if (phase === "during import") owner.invalidate();
+					imported.resolve({
+						default(pi) {
+							if (phase === "after factory") {
+								assert.equal(owner.ctx.mode, mode, "the factory starts with a live owner");
+								queueMicrotask(() => owner.invalidate());
+							}
+							pi.on("session_start", (_event, ctx) => {
+								assert.equal(ctx, owner.ctx);
+								assert.throws(() => ctx.mode, /Extension context is stale/);
+								throw failure;
+							});
+						},
+					});
+					await rejected;
+					await tick();
+					const message = "Intercom heavy initialization failed; a later call will retry: Connection closen";
+					assert.deepEqual(consoleErrorCalls, mode === "tui" ? [] : [[message, failure]]);
+					if (mode !== "tui") assert.equal(consoleErrorCalls[0]?.[1], failure);
+					assert.deepEqual(owner.notifications, []);
+					assert.equal(log.mock.calls.length, 0);
+					assert.equal(warn.mock.calls.length, 0);
+					const replacement = guardedContext(mode);
+					await current.fire("session_start", replacement.ctx);
+					assert.deepEqual(await current.executeIntercom(replacement.ctx), {
+						content: [{ type: "text", text: "connected" }],
+						details: {},
+					});
+					assert.equal(current.imports, 2);
+					assert.deepEqual(replacement.notifications, []);
+				} finally {
+					log.mockRestore();
+					warn.mockRestore();
+				}
+			});
+		}
+
+		for (const phase of ["first replay", "later replay"] as const) {
+			for (const state of ["live", "expired"] as const) {
+				test(`routes ${phase} failure and cleanup to a new ${state} ${mode} owner only`, async () => {
+					const imported = Promise.withResolvers<HeavyModule>();
+					const replayEntered = Promise.withResolvers<void>();
+					const replayRelease = Promise.withResolvers<void>();
+					const owner = guardedContext(mode);
+					const other = guardedContext(mode === "tui" ? "print" : "tui");
+					const failure = new Error("Connection closen");
+					const cleanupFailure = new Error("cleanup failed");
+					const module: HeavyModule = {
+						default(pi) {
+							pi.on("session_start", async (_event, ctx) => {
+								if (ctx === other.ctx) {
+									replayEntered.resolve();
+									await replayRelease.promise;
+									return;
+								}
+								assert.equal(ctx, owner.ctx);
+								if (state === "expired") assert.throws(() => ctx.mode, /Extension context is stale/);
+								else assert.equal(ctx.mode, mode);
+								throw failure;
+							});
+							pi.on("session_shutdown", (_event, ctx) => {
+								assert.equal(ctx, owner.ctx, "cleanup follows the failed replay owner");
+								throw cleanupFailure;
+							});
+						},
+					};
+					const current = fixture([{ module: imported.promise }, { module: successfulHeavyModule() }]);
+					await current.fire("session_start", other.ctx);
+					// Later replay returns to the initiating context after another owner has replayed.
+					const rejected = assert.rejects(
+						current.executeIntercom(phase === "first replay" ? other.ctx : owner.ctx),
+						(error) => error === failure,
+					);
+					if (phase === "later replay") {
+						imported.resolve(module);
+						await replayEntered.promise;
+					} else {
+						await tick();
+						assert.equal(current.imports, 1);
+					}
+					await current.fire("session_start", owner.ctx);
+					if (state === "expired") owner.invalidate();
+					imported.resolve(module);
+					replayRelease.resolve();
+					await rejected;
+					await tick();
+					const message = "Intercom heavy initialization failed; a later call will retry: Connection closen";
+					assert.deepEqual(
+						consoleErrorCalls,
+						state === "expired" || mode === "tui"
+							? []
+							: [
+									["Intercom failed to clean rejected lazy candidate:", cleanupFailure],
+									[message, failure],
+								],
+					);
+					if (state === "live" && mode !== "tui") {
+						assert.equal(consoleErrorCalls[0]?.[1], cleanupFailure);
+						assert.equal(consoleErrorCalls[1]?.[1], failure);
+					}
+					assert.deepEqual(
+						owner.notifications,
+						state === "live" && mode === "tui"
+							? [
+									{
+										message: "Intercom failed to clean rejected lazy candidate: cleanup failed",
+										level: "error",
+									},
+									{ message, level: "warning" },
+								]
+							: [],
+					);
+					assert.deepEqual(other.notifications, []);
+					const replacement = guardedContext(mode);
+					await current.fire("session_start", replacement.ctx);
+					await current.executeIntercom(replacement.ctx);
+					assert.equal(current.imports, 2);
+					assert.deepEqual(replacement.notifications, []);
+				});
+			}
+		}
+
 		for (const phase of ["initializing", "replaying"] as const) {
 			test(`retains the ${mode} ${phase} route when its guarded owner expires`, async () => {
 				const entered = Promise.withResolvers<void>();

--- a/test/unit/intercom-heavy-init-diagnostics.test.ts
+++ b/test/unit/intercom-heavy-init-diagnostics.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import { setImmediate as tick } from "node:timers/promises";
-import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@bastani/atomic";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext, ToolDefinition } from "@bastani/atomic";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
+import { ExtensionRunner } from "../../packages/coding-agent/src/core/extensions/runner.js";
 import {
 	createExtensionContext,
 	type ExtensionContextSource,
@@ -31,6 +32,7 @@ afterEach(() => {
 
 function fixture(importResults: ImportResult[], hasUI = false, mode: ExtensionContext["mode"] = "tui") {
 	const tools = new Map<string, ToolDefinition>();
+	const commands = new Map<string, Parameters<ExtensionAPI["registerCommand"]>[1]>();
 	const handlers = new Map<string, LifecycleHandler>();
 	const eventHandlers = new Map<string, (payload: object) => void>();
 	let imports = 0;
@@ -42,7 +44,9 @@ function fixture(importResults: ImportResult[], hasUI = false, mode: ExtensionCo
 		registerTool(tool: ToolDefinition) {
 			tools.set(tool.name, tool);
 		},
-		registerCommand() {},
+		registerCommand(name: string, command: Parameters<ExtensionAPI["registerCommand"]>[1]) {
+			commands.set(name, command);
+		},
 		registerShortcut() {},
 		events: {
 			on(name: string, handler: (payload: object) => void) {
@@ -83,6 +87,11 @@ function fixture(importResults: ImportResult[], hasUI = false, mode: ExtensionCo
 		},
 		get imports() {
 			return imports;
+		},
+		async executeCommand(context: ExtensionCommandContext) {
+			const command = commands.get("intercom");
+			assert.ok(command, "intercom command should be registered");
+			await command.handler("", context);
 		},
 		executeIntercom(
 			context: ExtensionContext | typeof ctx = ctx,
@@ -139,6 +148,24 @@ function guardedContext(mode: ExtensionContext["mode"]) {
 			}
 		},
 	};
+}
+
+function runnerOwner(mode: ExtensionContext["mode"]) {
+	const notifications: Array<{ message: string; level?: string }> = [];
+	const runner = new ExtensionRunner(
+		[],
+		{ workflowActivityHub: { bindDispatcher() {} }, invalidate() {} } as never,
+		"/tmp",
+		{} as never,
+		{} as never,
+	);
+	runner.setUIContext(
+		mode === "tui" || mode === "rpc"
+			? ({ notify: (message: string, level?: string) => notifications.push({ message, level }) } as never)
+			: undefined,
+		mode,
+	);
+	return { runner, notifications };
 }
 
 const unprintableFailures = [
@@ -340,6 +367,63 @@ describe("Intercom lazy heavy-initialization diagnostics", () => {
 
 	for (const mode of ["print", "json", "rpc", "tui"] as const) {
 		for (const phase of ["during import", "after factory"] as const) {
+			for (const dispatch of ["tool", "command"] as const) {
+				test(`retains the ${mode} route across distinct runner dispatches (${dispatch}) expiring ${phase}`, async () => {
+					const imported = Promise.withResolvers<HeavyModule>();
+					const { runner, notifications } = runnerOwner(mode);
+					const startup = runner.createContext();
+					const invocation = dispatch === "command" ? runner.createCommandContext() : runner.createContext();
+					assert.notEqual(startup, invocation, "normal dispatch creates separate wrappers");
+					const failure = new Error("Connection closen");
+					const current = fixture([{ module: imported.promise }, { module: successfulHeavyModule() }]);
+					const log = vi.spyOn(console, "log").mockImplementation(() => {});
+					const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+					try {
+						await current.fire("session_start", startup);
+						const pending =
+							dispatch === "command"
+								? current.executeCommand(invocation as ExtensionCommandContext)
+								: current.executeIntercom(invocation);
+						const rejected = assert.rejects(pending, (error) => error === failure);
+						await tick();
+						assert.equal(current.imports, 1);
+						if (phase === "during import") runner.invalidate();
+						imported.resolve({
+							default(pi) {
+								if (phase === "after factory") {
+									assert.equal(invocation.mode, mode);
+									queueMicrotask(() => runner.invalidate());
+								}
+								pi.on("session_start", (_event, ctx) => {
+									assert.equal(ctx, startup);
+									assert.throws(() => ctx.mode, /extension ctx is stale/);
+									throw failure;
+								});
+							},
+						});
+						await rejected;
+						await tick();
+						const message = "Intercom heavy initialization failed; a later call will retry: Connection closen";
+						assert.deepEqual(consoleErrorCalls, mode === "tui" ? [] : [[message, failure]]);
+						if (mode !== "tui") assert.equal(consoleErrorCalls[0]?.[1], failure);
+						assert.deepEqual(notifications, []);
+						assert.equal(log.mock.calls.length, 0);
+						assert.equal(warn.mock.calls.length, 0);
+						const replacement = runnerOwner(mode);
+						await current.fire("session_start", replacement.runner.createContext());
+						assert.deepEqual(await current.executeIntercom(replacement.runner.createContext()), {
+							content: [{ type: "text", text: "connected" }],
+							details: {},
+						});
+						assert.equal(current.imports, 2);
+						assert.deepEqual(replacement.notifications, []);
+					} finally {
+						log.mockRestore();
+						warn.mockRestore();
+					}
+				});
+			}
+
 			test(`retains the ${mode} route when the same owner expires ${phase} before first replay`, async () => {
 				const imported = Promise.withResolvers<HeavyModule>();
 				const owner = guardedContext(mode);

--- a/test/unit/intercom-heavy-init-diagnostics.test.ts
+++ b/test/unit/intercom-heavy-init-diagnostics.test.ts
@@ -25,7 +25,7 @@ afterEach(() => {
 	console.error = originalConsoleError;
 });
 
-function fixture(importResults: ImportResult[], hasUI = false) {
+function fixture(importResults: ImportResult[], hasUI = false, mode: ExtensionContext["mode"] = "tui") {
 	const tools = new Map<string, ToolDefinition>();
 	const handlers = new Map<string, LifecycleHandler>();
 	const eventHandlers = new Map<string, (payload: object) => void>();
@@ -57,6 +57,7 @@ function fixture(importResults: ImportResult[], hasUI = false) {
 	const notifications: Array<{ message: string; level?: string }> = [];
 	const ctx = {
 		hasUI,
+		mode,
 		ui: {
 			notify(message: string, level?: string) {
 				notifications.push({ message, level });
@@ -75,16 +76,10 @@ function fixture(importResults: ImportResult[], hasUI = false) {
 		get imports() {
 			return imports;
 		},
-		executeIntercom(context = ctx) {
+		executeIntercom(context = ctx, params: { action: string; to?: string; message?: string } = { action: "list" }) {
 			const tool = tools.get("intercom");
 			assert.ok(tool, "intercom tool should be registered");
-			return tool.execute(
-				"tool-call",
-				{ action: "list" },
-				new AbortController().signal,
-				undefined,
-				context as ExtensionContext,
-			);
+			return tool.execute("tool-call", params, new AbortController().signal, undefined, context as ExtensionContext);
 		},
 	};
 }
@@ -104,6 +99,26 @@ function successfulHeavyModule(): HeavyModule {
 		},
 	};
 }
+
+const unprintableFailures = [
+	{ name: "null-prototype", create: () => Object.assign(Object.create(null) as object, { reason: "broken frame" }) },
+	{
+		name: "throwing toString",
+		create: () => ({
+			toString() {
+				throw new Error("conversion failed");
+			},
+		}),
+	},
+	{
+		name: "throwing toPrimitive",
+		create: () => ({
+			[Symbol.toPrimitive]() {
+				throw new Error("conversion failed");
+			},
+		}),
+	},
+];
 
 describe("Intercom lazy heavy-initialization diagnostics", () => {
 	test("shows the reported retryable initialization failure as a warning without console or stack output", async () => {
@@ -164,6 +179,7 @@ describe("Intercom lazy heavy-initialization diagnostics", () => {
 		const cleanupNotifications: string[] = [];
 		const shutdown = current.fire("session_shutdown", {
 			hasUI: true,
+			mode: "tui",
 			ui: {
 				notify(message: string) {
 					cleanupNotifications.push(message);
@@ -172,6 +188,7 @@ describe("Intercom lazy heavy-initialization diagnostics", () => {
 		});
 		const replacement = current.fire("session_start", {
 			hasUI: false,
+			mode: "print",
 			ui: {
 				notify() {
 					assert.fail("replacement received an old diagnostic");
@@ -208,6 +225,28 @@ describe("Intercom lazy heavy-initialization diagnostics", () => {
 		assert.equal(current.imports, 2);
 	});
 
+	for (const mode of ["tui", "rpc", "print", "json"] as const) {
+		test(`routes ${mode} initialization diagnostics without changing shared failure or retry`, async () => {
+			const failure = new Error("Connection closen");
+			const current = fixture(
+				[{ error: failure }, { module: successfulHeavyModule() }],
+				mode === "tui" || mode === "rpc",
+				mode,
+			);
+			await Promise.all([1, 2].map(() => assert.rejects(current.executeIntercom(), (error) => error === failure)));
+			const message = "Intercom heavy initialization failed; a later call will retry: Connection closen";
+			assert.deepEqual(current.notifications, mode === "tui" ? [{ message, level: "warning" }] : []);
+			assert.deepEqual(consoleErrorCalls, mode === "tui" ? [] : [[message, failure]]);
+			if (mode !== "tui") assert.equal(consoleErrorCalls[0]?.[1], failure);
+			assert.equal(current.imports, 1);
+			assert.deepEqual(await current.executeIntercom(), {
+				content: [{ type: "text", text: "connected" }],
+				details: {},
+			});
+			assert.equal(current.imports, 2);
+		});
+	}
+
 	test("keeps background initialization diagnostics bound to the initiating context before replay", async () => {
 		const entered = Promise.withResolvers<void>();
 		const release = Promise.withResolvers<void>();
@@ -234,6 +273,7 @@ describe("Intercom lazy heavy-initialization diagnostics", () => {
 		await entered.promise;
 		const replacement = {
 			hasUI: false,
+			mode: "print" as const,
 			ui: {
 				notify() {
 					assert.fail("wrong session");
@@ -312,6 +352,7 @@ describe("Intercom lazy heavy-initialization diagnostics", () => {
 			retired = true;
 			await current.fire("session_start", {
 				hasUI: false,
+				mode: "print",
 				ui: {
 					notify() {
 						assert.fail("wrong session");
@@ -325,6 +366,101 @@ describe("Intercom lazy heavy-initialization diagnostics", () => {
 			assert.deepEqual(consoleErrorCalls, []);
 			await current.executeIntercom();
 			assert.equal(current.imports, 2, "the retired callback does not invalidate the replacement");
+		});
+	}
+
+	for (const eventName of [
+		"subagent:control-intercom",
+		"subagent:result-intercom",
+		"atomic:workflow-pending-stage-route",
+		"atomic:workflow-pending-stage-undeliverable",
+	]) {
+		test(`keeps ${eventName} diagnostics with the shutdown owner while cleanup drains`, async () => {
+			const entered = Promise.withResolvers<void>();
+			const drain = Promise.withResolvers<void>();
+			let cleanups = 0;
+			let relays = 0;
+			const current = fixture(
+				[
+					{
+						module: {
+							default(pi) {
+								successfulHeavyModule().default(pi);
+								pi.events.on(eventName, () => {
+									relays++;
+								});
+								pi.on("session_shutdown", async () => {
+									cleanups++;
+									entered.resolve();
+									await drain.promise;
+								});
+							},
+						},
+					},
+					{ module: successfulHeavyModule() },
+				],
+				true,
+				"tui",
+			);
+			await current.fire("session_start");
+			await current.executeIntercom();
+			const shutdown = current.fire("session_shutdown");
+			await entered.promise;
+			const payload: {
+				completion?: Promise<boolean>;
+				runId: string;
+				senderId: string;
+				messageId: string;
+				notificationId: string;
+				reason: string;
+			} = {
+				runId: "run",
+				senderId: "sender",
+				messageId: "message",
+				notificationId: "notice",
+				reason: "not_started",
+			};
+			current.emit(eventName, payload);
+			let replaced = false;
+			const replacement = current
+				.fire("session_start", {
+					hasUI: true,
+					mode: "tui",
+					ui: {
+						notify() {
+							assert.fail("replacement received the shutdown diagnostic");
+						},
+					},
+				})
+				.then(() => {
+					replaced = true;
+				});
+			try {
+				if (eventName.endsWith("undeliverable")) {
+					assert.ok(payload.completion);
+					assert.equal(await payload.completion, false);
+				} else if (eventName.endsWith("stage-route")) {
+					assert.ok(payload.completion);
+					await assert.rejects(payload.completion, /no active session/);
+				}
+				await tick();
+				assert.equal(replaced, false, "replacement still awaits retired cleanup");
+				assert.equal(current.imports, 1, "relay cannot activate a retired lease");
+				assert.equal(relays, 0);
+				assert.deepEqual(consoleErrorCalls, []);
+				assert.deepEqual(current.notifications, [
+					{
+						message: `Intercom event relay failed (${eventName}): Intercom initialization unavailable: no active session`,
+						level: "error",
+					},
+				]);
+			} finally {
+				drain.resolve();
+				await Promise.all([shutdown, replacement]);
+			}
+			assert.equal(cleanups, 1);
+			await current.executeIntercom();
+			assert.equal(current.imports, 2);
 		});
 	}
 
@@ -360,6 +496,7 @@ describe("Intercom lazy heavy-initialization diagnostics", () => {
 		const callerNotifications: string[] = [];
 		const caller = {
 			hasUI: false,
+			mode: "print" as const,
 			ui: {
 				notify(message: string) {
 					callerNotifications.push(message);
@@ -483,6 +620,163 @@ describe("Intercom lazy heavy-initialization diagnostics", () => {
 				);
 				assert.deepEqual(consoleErrorCalls, hasUI ? [] : [[prefix, failure]]);
 			});
+		}
+	}
+
+	test("retains console diagnostics for a relay with no lifecycle context", async () => {
+		const failure = new Error("relay before lifecycle");
+		const eventName = "atomic:workflow-pending-stage-undeliverable";
+		const current = fixture([
+			{
+				module: {
+					default(pi) {
+						pi.events.on(eventName, () => {
+							throw failure;
+						});
+					},
+				},
+			},
+		]);
+		const payload = {
+			runId: "run",
+			senderId: "sender",
+			messageId: "message",
+			notificationId: "notice",
+			reason: "not_started",
+			completion: undefined as Promise<boolean> | undefined,
+		};
+		current.emit(eventName, payload);
+		assert.ok(payload.completion);
+		assert.equal(await payload.completion, false);
+		assert.deepEqual(current.notifications, []);
+		assert.deepEqual(consoleErrorCalls, [[`Intercom event relay failed (${eventName}):`, failure]]);
+		assert.equal(consoleErrorCalls[0]?.[1], failure);
+	});
+
+	for (const mode of ["tui", "rpc", "print", "json"] as const) {
+		for (const cause of unprintableFailures) {
+			test(`preserves false relay acknowledgement and ${mode} diagnostics for ${cause.name}`, async () => {
+				const failure = cause.create();
+				const eventName = "atomic:workflow-pending-stage-undeliverable";
+				const current = fixture(
+					[
+						{
+							module: {
+								default(pi) {
+									pi.events.on(eventName, () => {
+										throw failure;
+									});
+								},
+							},
+						},
+					],
+					mode === "tui" || mode === "rpc",
+					mode,
+				);
+				await current.fire("session_start");
+				const payload = {
+					runId: "run",
+					senderId: "sender",
+					messageId: "message",
+					notificationId: "notice",
+					reason: "not_started",
+					completion: undefined as Promise<boolean> | undefined,
+				};
+				current.emit(eventName, payload);
+				assert.ok(payload.completion);
+				assert.equal(await payload.completion, false);
+				const prefix = `Intercom event relay failed (${eventName}):`;
+				assert.deepEqual(
+					current.notifications,
+					mode === "tui" ? [{ message: `${prefix} Unprintable error`, level: "error" }] : [],
+				);
+				assert.deepEqual(consoleErrorCalls, mode === "tui" ? [] : [[prefix, failure]]);
+				if (mode !== "tui") assert.equal(consoleErrorCalls[0]?.[1], failure);
+			});
+
+			test(`retains original ${cause.name} initialization rejection and retry in ${mode}`, async () => {
+				const failure = cause.create();
+				const current = fixture(
+					[{ error: failure }, { module: successfulHeavyModule() }],
+					mode === "tui" || mode === "rpc",
+					mode,
+				);
+				await assert.rejects(current.executeIntercom(), (error) => error === failure);
+				await tick();
+				const message = "Intercom heavy initialization failed; a later call will retry: Unprintable error";
+				assert.deepEqual(current.notifications, mode === "tui" ? [{ message, level: "warning" }] : []);
+				assert.deepEqual(consoleErrorCalls, mode === "tui" ? [] : [[message, failure]]);
+				if (mode !== "tui") assert.equal(consoleErrorCalls[0]?.[1], failure);
+				await current.executeIntercom();
+				assert.equal(current.imports, 2);
+			});
+
+			for (const recoverable of [false, true]) {
+				test(`preserves ${recoverable ? "typed-disconnect send retry" : "original initialization failure"} after ${cause.name} cleanup in ${mode}`, async () => {
+					const failure = recoverable ? new IntercomClientDisconnectedError() : new Error("Connection closen");
+					const cleanupFailure = cause.create();
+					const params = { action: "send", to: "peer", message: "  verbatim\nmessage  " };
+					let cleanups = 0;
+					let executions = 0;
+					const current = fixture(
+						[
+							{
+								module: {
+									default(pi) {
+										pi.on("session_start", () => {
+											throw failure;
+										});
+										pi.on("session_shutdown", () => {
+											cleanups++;
+											throw cleanupFailure;
+										});
+									},
+								},
+							},
+							{
+								module: {
+									default(pi) {
+										pi.registerTool({
+											name: "intercom",
+											label: "Intercom",
+											description: "recovered send",
+											parameters: Type.Object({}),
+											async execute(_id, actual) {
+												executions++;
+												assert.deepEqual(actual, params);
+												return { content: [{ type: "text", text: "sent" }], details: {} };
+											},
+										});
+									},
+								},
+							},
+						],
+						mode === "tui" || mode === "rpc",
+						mode,
+					);
+					if (!recoverable) {
+						await assert.rejects(current.executeIntercom(current.ctx, params), (error) => error === failure);
+						assert.equal(current.imports, 1);
+						assert.equal(executions, 0);
+					}
+					assert.deepEqual(await current.executeIntercom(current.ctx, params), {
+						content: [{ type: "text", text: "sent" }],
+						details: {},
+					});
+					assert.equal(current.imports, 2);
+					assert.equal(executions, 1);
+					assert.equal(cleanups, 1);
+					const prefix = "Intercom failed to clean rejected lazy candidate:";
+					const initMessage = "Intercom heavy initialization failed; a later call will retry: Connection closen";
+					const expectedNotices = [{ message: `${prefix} Unprintable error`, level: "error" }];
+					if (!recoverable) expectedNotices.push({ message: initMessage, level: "warning" });
+					assert.deepEqual(current.notifications, mode === "tui" ? expectedNotices : []);
+					const expectedConsole: ConsoleErrorCall[] = [[prefix, cleanupFailure]];
+					if (!recoverable) expectedConsole.push([initMessage, failure]);
+					assert.deepEqual(consoleErrorCalls, mode === "tui" ? [] : expectedConsole);
+					if (mode !== "tui") assert.equal(consoleErrorCalls[0]?.[1], cleanupFailure);
+				});
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Route Intercom diagnostics to the owning interactive session instead of writing warning text and `Socket.onClose` stacks over the TUI. Retryable initialization failures appear as yellow warnings in the chat pane; print, JSON and RPC retain console diagnostics.

## Changes

- Route lazy initialization, event-relay and rejected-candidate cleanup diagnostics by session ownership, including late failures and shutdown. Retired TUI contexts never fall back to the console or a replacement session.
- Preserve the captured headless route when the same owner expires during import or after the factory, before startup replay. Distinct startup, tool and command wrappers share the existing host owner identity through a private cross-bundle registry. Genuine ownership changes still recapture routing.
- Preserve original failures and console error arguments, acknowledgements, raw inputs, retry and recovery behavior, including failures that cannot be rendered.
- Add real-runner timing regressions and independent Node/Bun host-and-builtin bundle scenarios. Update Intercom troubleshooting and its Unreleased fix notes.

No public exports, schemas or configuration change. No migration is required.

## Verification

Accepted commit: `ffd9ced01a633c31f12aedb1563829bd447f7d33`, based on `cb13229bebe30ea7cb65689569569494b4bc651c`.

The completed implementation receipt and three independent reviews record the following results at that candidate. These checks were not rerun during PR publication:

- `npm run check` and the coding-agent package build passed.
- Seven focused unit files passed, 190 tests total. Reconnect integration passed 8 tests; relevant host context tests passed 42.
- Both supplied recapture reproducers passed, including `RECAPTURE_PHASE=after-factory`. Distinct real-runner and context-wrapper probes passed at both invalidation boundaries.
- Independent host/builtin bundles and actual emitted package-layout probes passed 80 scenarios per Node/Bun runtime, covering same, changed and unknown owners, tool/command dispatch, original rejection identity and successful retry.
- Actual TUI captures showed the exact `Intercom heavy initialization failed; a later call will retry: Connection closen` warning in yellow, with no console or stack leakage. Actual print/JSON/RPC scenarios retained the diagnostic and stack on stderr and completed a subsequent successful attempt.
- Public API/schema comparisons, strict consumer compilation, commit hooks and scoped Qlty built-in checks passed. Qlty plugin/security coverage is not claimed.

PR preparation reviewed the full cumulative diff, confirmed a clean worktree and matching working/index diffs, and passed `git diff origin/main...HEAD --check`. Full repository suite, Windows, standalone binary and real npm-install execution were not run. Terminal evidence remains local; no media upload is claimed.

## Review and scope

Goal `112c9add-4a0f-47bd-ae75-3b99d47c2434` is complete. The final ledger records three independent approvals, no blocking findings and reducer acceptance. Earlier review exposed the difference between context-wrapper identity and actual owner identity; the final repair and durable regressions address that case.

This cumulative PR includes all five task commits since `cb13229be`, not only the final repair:

- `850c85e69` route diagnostics through the owning UI
- `c2fe2b13f` keep diagnostics owned, mode-routed and non-destructive
- `d5d92781f` retain diagnostics after context invalidation
- `58752a370` preserve same-owner routing through first replay
- `ffd9ced01` retain diagnostics across same-owner dispatches

The PR diff contains nine files, 1,404 additions and 27 deletions. During publication, fetching `main` advanced the target to `fb5d6777a`; its new changes do not overlap these nine paths. The reviewed head and all commit SHAs were preserved without rebase or merge. Validation above applies to the accepted head, not a new merge result against the advanced target. No merge or release is requested.

## Contract amendments received

- "create a PR once done, use gh api user --jq .login."
- "Since this issue is retryable it's just warning text color."

`gh api user --jq .login` confirmed `lavaman131`. Publication follows acceptance and includes every task commit. Do not merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791664289&installation_model_id=10562&pr_number=2976&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2976&signature=d4fe2af0460f024bdf15ab1f4c96de46dffea9b5cab6cf6ec18921286760a42e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62783682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Not merge-safe until the root-test runtime-helper requirement is satisfied.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Use runtime helper** <a href="https://github.com/bastani-inc/atomic/pull/2976#discussion_r3983268850">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
test/unit/intercom-context-owner-bundle.test.ts:2
This root test imports and calls `symlinkSync` directly from `node:fs` instead of using `test/helpers/runtime.ts`. Add an appropriate shared helper and use it here so filesystem behavior stays centralized across supported runtimes. This repository requirement must be satisfied before merging.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Adds diagnostic-owner routing coverage for independently bundled Intercom host and builtin modules.
- One repository requirement remains: root tests must use the shared runtime compatibility layer before merging.

<sub>Reviews (1) · Last reviewed commit: ["fix(intercom): retain diagnostics across..."](https://github.com/bastani-inc/atomic/commit/ffd9ced01a633c31f12aedb1563829bd447f7d33)</sub>

<!-- /greptile_comment -->