### PR TITLE
fix(workflows): run workspace tests through root Vitest suites

### DIFF
--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -58,10 +58,10 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "bun run test:unit",
-    "test:unit": "bun test ../../test/unit",
-    "test:integration": "bun test ../../test/integration",
-    "test:all": "bun run test:unit && bun run test:integration",
+    "test": "npm --prefix ../.. run test:unit --",
+    "test:unit": "npm --prefix ../.. run test:unit --",
+    "test:integration": "npm --prefix ../.. run test:integration --",
+    "test:all": "npm --prefix ../.. run test:all --",
     "typecheck": "tsc --noEmit -p ../../tsconfig.json",
     "lint": "tsc --noEmit -p ../../tsconfig.json"
   },

--- a/test/ci/ci-workflow-contracts.test.ts
+++ b/test/ci/ci-workflow-contracts.test.ts
@@ -76,6 +76,20 @@ test("every test suite entry point resolves to one shared per-test timeout", asy
 	assert.match(await readText(join(root, ".github/workflows/test.yml")), /run-flaky-test-suite\.ts/u);
 });
 
+test("workflows workspace test scripts delegate to the root Vitest suites", async () => {
+	const manifest = await readJson<{ scripts: Record<string, string> }>(join(root, "packages/workflows/package.json"));
+	// npm test visits workspace test scripts after running the root suites.
+	// Delegate to the same root entry points as CI, never back to root `test`.
+	for (const [entry, target] of Object.entries({
+		test: "test:unit",
+		"test:unit": "test:unit",
+		"test:integration": "test:integration",
+		"test:all": "test:all",
+	})) {
+		assert.equal(manifest.scripts[entry], `npm --prefix ../.. run ${target} --`, `${entry} bypasses root test setup`);
+	}
+});
+
 /**
  * Run 33833721342 reached `npm ci` with an exact-key cache hit, then emitted
  * nothing for the full six-minute static-checks job cap. npm's former default


### PR DESCRIPTION
## Summary

Make the workflows workspace use the same root Vitest entrypoints as CI. Its stale `bun test` commands otherwise run the migrated root suites under the wrong runner when the broad root `npm test` reaches workspace tests.

This is a separate change based directly on `main` (`c86bcfa9c`), with no commits from PR #2983.

## Changes

- Delegate `test`, `test:unit`, `test:integration`, and `test:all` to their root suite scripts using `npm --prefix ../..`.
- Preserve Vitest's root working directory, configuration, setup, project selection, and test-filter argument forwarding.
- Keep `test` mapped to unit tests and `test:all` mapped to unit plus integration. Never delegate to root `test`, which would recurse through workspaces.
- Add a CI contract covering all four entrypoints. It fails against the old scripts.

No test assertions are weakened, no CI jobs or timeout/concurrency settings change, and Bun's runtime/build/script roles remain intact. This is maintainer test infrastructure, so it does not add a user-facing package changelog entry.

## Validation

- Regression demonstrated red before changing scripts.
- `npm run test:ci-contracts`: 95 passed across 16 files.
- `npm test --workspace=@bastani/workflows -- test/unit/compaction-auth-ladder.test.ts -t '.*'`: 6 passed, correctly dispatched to root Vitest unit project.
- `npm run test:integration --workspace=@bastani/workflows -- test/integration/compaction-manual-honesty.test.ts -t '.*'`: 7 passed, correctly dispatched to root Vitest integration project.
- `npm run check`: passed.
- Read-only review found no actionable issues; no independent Windows execution is claimed.
- `npm run test:all --workspace=@bastani/workflows`: unfiltered unit suite 8,233 passed / 23 skipped across 807 files; integration suite 907 passed / 12 skipped across 72 files. Exit 0. Existing Vite dynamic-import and Node shell-argument warnings remain outside this diff.
- Commit hooks passed without bypass; commit `60e2b56e4` is SSH-signed.

The broad root `npm test` was not run end-to-end; it also invokes other workspace suites. The workflows workspace's actual unit/integration path was exercised unfiltered above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791701195&installation_model_id=10562&pr_number=2984&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2984&signature=ff9d232dac48dc2165ab95367618b7bbb48e54f8da59d1e1c63dde61229b9d8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62966981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The change is safe to merge, with one non-blocking test-command behavior concern that should be addressed for predictable targeted test runs.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Filters skip unit tests** <a href="https://github.com/bastani-inc/atomic/pull/2984#discussion_r3986672064">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/workflows/package.json:64
When `test:all` receives a file or test-name filter, this delegation reaches the root aggregate command, whose `&&` chain attaches those arguments only to `test:integration`. The unit suite runs without the requested filter, so a targeted workflows test command unexpectedly executes all unit tests and takes longer than intended. Forward the arguments to both suites independently, or require callers to invoke each filtered suite directly.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- ## Summary
- The workflows `test:all` entrypoint does not pass file and test-name filters to the unit suite. Targeted invocations therefore run the entire unit suite before applying the filter only to integration tests.
- ## Merge safety
- This concern is non-blocking: the change can merge, but filtered workflow test runs should be fixed to remain fast and predictable.

<sub>Reviews (1) · Last reviewed commit: ["fix(workflows): run workspace tests thro..."](https://github.com/bastani-inc/atomic/commit/60e2b56e423aa4a54cf1caf9bb222d1e19265f9d)</sub>

<!-- /greptile_comment -->