### PR TITLE
docs(release): prepare 0.9.19-alpha.4 changelogs

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,8 @@ This package is a Bastani fork of `@earendil-works/pi-ai`. Upstream history at t
 
 ## [Unreleased]
 
+## [0.9.19-alpha.4] - 2026-09-10
+
 ### Added
 
 - Enabled native deferred tool loading for Fireworks Messages models. Use `ToolSearch` or `tool_search` as the loader name for prompt-prefix deferral ([#9323](https://github.com/earendil-works/pi/issues/9323)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.4] - 2026-09-10
+
 ### Breaking Changes
 
 - Workflow controls, completion, help, and status hints use `/workflow pause`, `/workflow quit`, and `/workflow resume`. The workflow tool supports run, stage, and individual durable-tool pause targets; `/workflow pause [run-id|--all]` controls runs. Workflow lifecycle control events report `action: "pause"` for pause requests.

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.19-alpha.4] - 2026-09-10
+
 ### Fixed
 
 - Route lazy initialization, event-relay, and rejected-candidate cleanup diagnostics through the owning interactive session's notifications, including during shutdown, instead of leaking console output and stacks. Retryable initialization uses warning color; non-interactive console diagnostics (including RPC), original failures, acknowledgements, and retry behavior are preserved even when an error cannot be rendered.

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.4] - 2026-09-10
+
 ### Fixed
 
 - The retained embedded Postgres process now starts on Windows administrative accounts with the same restricted access token `pg_ctl` applies: the Administrators and Power Users SIDs become deny-only, every privilege except the ones PostgreSQL keeps is deleted, and the current user is re-added to the token's default DACL so the postmaster's own child processes remain creatable. The exact process handle from `CreateProcessAsUserW` stays the retained lease, preserving exact-handle fast shutdown, retry-after-timeout ownership, and release-without-kill semantics. Non-administrative Windows accounts keep the previous spawn path unchanged, and Unix privilege handling is untouched.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.4] - 2026-09-10
+
 ### Breaking Changes
 
 - Renamed the terminal subagent control action from `interrupt` to `kill`. Replace `subagent({ action: "interrupt", id })` with `subagent({ action: "kill", id })`, including calls using `runId`. The old action is rejected, not aliased. Killed children cannot be resumed; launch a fresh child with explicit context for follow-up work. Command results and status report killed, while parent cancellation and lower-level host/native interruption retain their existing semantics.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.19-alpha.4] - 2026-09-10
+
 ### Breaking Changes
 
 - Workflow run control uses `pause` across slash commands, tool actions, runtime APIs, and lifecycle control events. Run-level pause preserves resumable work, including nested task-result checkpoint tails and executor-only waits; targeted stage pause retains queued messages, and targeted `ctx.tool` pause cancels only that call. Use `resume` to continue eligible work.


### PR DESCRIPTION
## Summary

Prepare prerelease 0.9.19-alpha.4 by moving the existing Unreleased notes into dated release sections in the ai, coding-agent, intercom, natives, subagents, and workflows changelogs. Existing notes and previously released history are unchanged.

## Validation

- Confirmed one changelog-only commit touching exactly the six prepared files, with only a release heading and blank line added to each.
- All eight workspace package manifests, workspace lock entries, first-party pins, Cargo workspace and lock versions, and generated native version checks remain at 0.0.0. No manifests, lockfiles, Cargo files, or generated version files changed.
- `bun run test:unit -- test/unit/changelog.test.ts test/unit/build-release-notes.test.ts`: 19 tests passed.
- `bun run scripts/build-release-notes.ts 0.9.19-alpha.4`: combined release notes generated successfully.
- `bun run check`: passed, including typechecks and shrinkwrap verification. Two existing informational Biome diagnostics were left unchanged.
- Commit hooks and `git diff --check`: passed. Post-commit validation confirmed a clean worktree and the exact changelog-only scope.

## Release boundary

This PR changes release notes only. After merge, only `scripts/cut-release.ts` may stamp 0.9.19-alpha.4 on the detached Release commit. Pushing the version tag directly starts `publish.yml`; no duplicate normal publication dispatch is needed. This stage does not merge, tag, or publish.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791701587&installation_model_id=10562&pr_number=2985&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2985&signature=970defc0eb70d707de813d30c70580a2e0b52949f8736f1f53d55cf283c0d809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62968443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge; the published changelog sections are discoverable and generate the intended release notes.

What we checked:
- T-Rex ran the release notes validation script release_notes_0919_validation.sh to test the 0.9.19-alpha.4 build. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- T-Rex compared the pre-run state where the base changelog snapshot rejected the absent release version (exit 1) with the post-run state where the script found six headings including Breaking Changes, Added, Changed, and Fixed and exited with code 0. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- T-Rex reviewed the artifacts, including the validation script and three logs with accessible URLs, to support the observed results. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- This release-note update moves the existing Unreleased entries into dated `0.9.19-alpha.4` sections across six package changelogs. The release-note generator discovers all six sections and produces the expected combined Breaking Changes, Added, Changed, and Fixed content.

<sub>Reviews (1) · Last reviewed commit: ["docs(release): prepare 0.9.19-alpha.4 ch..."](https://github.com/bastani-inc/atomic/commit/609605b7b781b57613d1324aed577af761e60380)</sub>

<!-- /greptile_comment -->