### PR TITLE
docs(release): prepare 0.9.19-alpha.5 changelogs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.5] - 2026-09-11
+
 ### Changed
 
 - Open Claude Design now starts with Claude Fable 5.1 at medium effort, followed by Copilot Fable 5.1 and Astra at medium effort, with the same Fable-first order on OpenRouter.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.5] - 2026-09-11
+
 ### Changed
 
 - The bundled debugger now uses GPT-6 Astra at `medium`, with Astra/Fable 5.1/Fable 5 fallbacks at `medium` and Sol at `high`. Its complete fallback order, other model efforts, and all other bundled agent configurations remain unchanged.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.19-alpha.5] - 2026-09-11
+
 ### Changed
 
 - Open Claude Design now starts with Anthropic Claude Fable 5.1 at `medium`, then Copilot Fable 5.1 and Codex/Copilot/OpenAI Astra at `medium`; its OpenRouter fallbacks also put Fable 5.1 before Astra.


### PR DESCRIPTION
## Summary

Prepare prerelease 0.9.19-alpha.5 by moving the existing Unreleased notes into dated sections in the coding-agent, subagents, and workflows changelogs. Existing notes and previously released history are unchanged.

## Validation

- Confirmed one changelog-only commit touching exactly the three prepared files, adding only a release heading and blank line to each.
- All eight workspace package manifests and lock entries remain at 0.0.0, along with the native dependency pin, Cargo workspace and lock versions, and generated native version checks. No manifests, lockfiles, Cargo files, or generated version files changed.
- `bun run test:unit -- test/unit/changelog.test.ts test/unit/build-release-notes.test.ts`: 19 tests passed.
- `bun run scripts/build-release-notes.ts 0.9.19-alpha.5`: combined release notes generated successfully.
- `bun run check`: passed, including typechecks and shrinkwrap verification. Two existing informational Biome diagnostics were left unchanged.
- Commit hooks and `git diff --check`: passed. Post-commit validation confirmed a clean worktree and the exact changelog-only scope.

## Release boundary

This PR changes release notes only. After merge, only `scripts/cut-release.ts` may stamp 0.9.19-alpha.5 on the detached Release commit. Pushing the version tag directly starts `publish.yml`; no duplicate normal publication dispatch is needed. This stage does not merge, tag, or publish.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791732743&installation_model_id=10562&pr_number=2988&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2988&signature=60781aaea308358aee2af93ffed446e3258804b6203952ddabbd2117758e0df7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63122347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: the release-note changes generate and combine correctly.

What we checked:
- The Windows retained-postgres check was run and its exit status was captured in the after-log, showing the blocker: cc-rs: failed to find tool 'lib.exe' (os error 2). <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The complete executed evidence-script source for the Windows run was uploaded as windows-retained-postgres-compile-evidence.sh. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The release-notes-alpha5-evidence.sh script was executed from the repository to gather release-note evidence. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Before and after outputs for the release-notes-alpha5 run were captured in release-notes-alpha5-01-before.log and release-notes-alpha5-02-after.log. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- Adds 0.9.19-alpha.5 sections to the coding-agent, subagents, and workflows changelogs.
- Consolidated release notes correctly include the updated entries in one Changed section.

## T-Rex validation blocked
- Windows retained-Postgres compilation could not be completed because the environment does not provide the MSVC `lib.exe` archiver.

<sub>Reviews (1) · Last reviewed commit: ["docs(release): prepare 0.9.19-alpha.5 ch..."](https://github.com/bastani-inc/atomic/commit/e9b7750ded9bb09856a7d8e29f1d2758bfb2ab94)</sub>

<!-- /greptile_comment -->