### PR TITLE
test(models): refresh Baseten catalog expectation

### DIFF
--- a/packages/coding-agent/test/baseten-qwen-provider.test.ts
+++ b/packages/coding-agent/test/baseten-qwen-provider.test.ts
@@ -26,6 +26,7 @@ const PROVIDERS: readonly ProviderCase[] = [
 			"deepseek-ai/DeepSeek-V4-Flash-0731",
 			"deepseek-ai/DeepSeek-V4-Pro",
 			"deepseek-ai/DeepSeek-V4-Pro-0813",
+			"deepseek-ai/DeepSeek-V4.1-Flash",
 			"moonshotai/Kimi-K2.5",
 			"moonshotai/Kimi-K2.6",
 			"moonshotai/Kimi-K2.7-Code",


### PR DESCRIPTION
## Summary

Fix the Baseten catalog assertion failing in [CI run 34618456811](https://github.com/bastani-inc/atomic/actions/runs/34618456811/job/103326139369). The build-generated models.dev catalog now includes `deepseek-ai/DeepSeek-V4.1-Flash`, but the test's expected list omitted it.

## Changes

- Add the missing model to the exact, ordered catalog fixture.
- Preserve all authentication, default-model, thinking-level, and full-catalog assertions. No shipped behavior changes.

## Validation

- Reproduced the linked failure locally before the change: 1 failed, 5 passed.
- `npm run check` passed, including regeneration of model data, typechecks, and shrinkwrap validation.
- `npm run test --workspace=@bastani/atomic -- test/baseten-qwen-provider.test.ts` passed: 6 tests.
- `git diff --check` passed.

The full suite was not rerun locally; PR CI will validate the broader suites. Future upstream catalog additions may require another fixture refresh under the existing exact-catalog test policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791735616&installation_model_id=10562&pr_number=2989&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2989&signature=1aef333320e45862136b6cbe7f951bf6c059020be11116db7429a439625f2b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63143019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: the updated catalog expectation matches the built-in offline runtime catalog and its focused tests pass.

What we checked:
- Ran an isolated offline ModelRuntime catalog check with network access disabled and filtered to the Baseten provider. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Verified that omitting the new model ID changes the expected catalog list when compared to the actual catalog. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Updated the ordered catalog to match the actual catalog exactly and confirmed the new model ID appears once. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Executed the Baseten provider tests and confirmed the baseten-qwen-provider.test.ts suite ran with all tests passing. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validated Baseten catalog validation tests, including pre-change and exact-match checks, with outputs captured in the artifacts. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- The Baseten catalog expectation now includes `deepseek-ai/DeepSeek-V4.1-Flash`.
- The declared list exactly matches the offline built-in Baseten catalog, including ordering and a single occurrence of the new model.
- The focused provider test suite passes. Safe to merge.

<sub>Reviews (1) · Last reviewed commit: ["test(models): refresh Baseten catalog ex..."](https://github.com/bastani-inc/atomic/commit/5224e1dbf7d0eb1db58c6aa9bc4dd6b52290ec41)</sub>

<!-- /greptile_comment -->