### PR TITLE
fix(intercom): settle broker refusals and stop redundant route republishing

### DIFF
--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Fixed
+
+- A broker refusal received by an already-registered client now rejects that client's outstanding requests with the broker's own reason instead of being discarded. Previously the refusal was delivered to a listener that `connect()` removes after registration, so pipelined work — notably the session-directory barrier behind workflow route updates — waited out its five-second timer and surfaced `List sessions timeout` or a generic disconnect. Reasons such as `Pending-stage route is not authorized` now reach callers as non-recoverable errors, and the `disconnected` event carries the same cause. Pre-registration rejection, transport-disconnect classification, and explicit shutdown are unchanged.
+
 ## [0.9.19-alpha.4] - 2026-09-10
 
 ### Fixed

--- a/packages/intercom/broker/client.ts
+++ b/packages/intercom/broker/client.ts
@@ -415,7 +415,25 @@ export class IntercomClient extends EventEmitter {
       }
       case "registration_failed": {
         if (typeof brokerMessage.reason !== "string") throw new Error("Invalid registration_failed message");
-        this.emit("_registration_failed", new Error(brokerMessage.reason));
+        const refusal = new Error(brokerMessage.reason);
+        if (this._sessionId === null) {
+          // Still registering: `connect()` owns the failure and its own cleanup.
+          this.emit("_registration_failed", refusal);
+          break;
+        }
+        // The broker reuses this frame to refuse an *established* client's request
+        // (for example a rejected pending-stage route update) and then ends the
+        // socket, deliberately dropping anything already pipelined behind it. By
+        // this point `connect()` has removed its `_registration_failed` listener,
+        // so emitting there would discard the refusal and leave every pipelined
+        // request — notably the `listSessions()` barrier — to expire on its own
+        // five-second timer with an unusable diagnostic. Record the refusal as the
+        // disconnect cause, settle outstanding work with it, and destroy the socket
+        // so no new work is accepted while we wait for the peer FIN. `onClose`
+        // still owns session/socket teardown and the `disconnected` emission.
+        this.disconnectError ??= refusal;
+        this.failPending(this.disconnectError);
+        this.socket?.destroy();
         break;
       }
       case "question_target": {

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Workflow stage routes are no longer republished to the broker when nothing about the route changed. Every store invalidation — including tool events, attachment changes, and notices that leave the route projection identical — previously re-announced every run, so a burst of unrelated activity could produce a thousand redundant broker round trips and surface as `Intercom event relay failed (atomic:workflow-pending-stage-route): List sessions timeout`. Genuine changes still publish immediately and are never debounced, and an announcement that is rejected or that no consumer acknowledges is retried on the next invalidation.
+
 ## [0.9.19-alpha.5] - 2026-09-11
 
 ### Changed

--- a/packages/workflows/src/extension/pending-stage-intercom.ts
+++ b/packages/workflows/src/extension/pending-stage-intercom.ts
@@ -80,6 +80,15 @@ interface PendingStageUndeliverableEvent extends Record<string, unknown> {
 	readonly reason: string;
 }
 
+/**
+ * Route announcement payload. The consumer (the lightweight relay or the heavy
+ * handler) attaches `completion` to the object in place, so the producer must
+ * project its signature before emitting and read the acknowledgement after.
+ */
+interface PendingStageRouteEvent extends Record<string, unknown> {
+	completion?: Promise<void>;
+}
+
 export function registerPendingStageIntercomBridge(pi: WorkflowEventSurface, activeStore: Store): () => void {
 	let disposed = false;
 	let sweepPromise: Promise<void> = Promise.resolve();
@@ -104,12 +113,25 @@ export function registerPendingStageIntercomBridge(pi: WorkflowEventSurface, act
 		pi.events?.emit?.(PENDING_STAGE_UNDELIVERABLE_EVENT, payload);
 		return payload.handled && (await payload.completion) === true;
 	};
+	/**
+	 * Latest route payload this bridge claims to have published, per run id.
+	 *
+	 * Every store invalidation republished every run, so tool events, attachment
+	 * changes, and notices — none of which alter the route projection — each cost a
+	 * broker round trip whose `listSessions()` barrier can expire on its own timer.
+	 * The cache is bridge-local: a new bridge, or a run whose durable owner is gone,
+	 * starts with no claim. An entry records a *claim*, not proof of acknowledgement,
+	 * so a rejected or unacknowledged emission invalidates it again below.
+	 */
+	const announcedRoutes = new Map<string, { readonly signature: string }>();
 	const announceRoutes = (): void => {
 		if (disposed) return;
+		const ownedRunIds = new Set<string>();
 		const runs = activeStore.runs();
 		for (const run of runs) {
 			const rootRunId = durableRootRunIdForRun(runs, run.id);
 			if (rootRunId === undefined) continue;
+			ownedRunIds.add(run.id);
 			const parentRun = runs.find((candidate) => candidate.id === run.parentRunId);
 			const boundary = parentRun?.stages.find((stage) => stage.id === run.parentStageId);
 			const parent =
@@ -121,7 +143,7 @@ export function registerPendingStageIntercomBridge(pi: WorkflowEventSurface, act
 								(key) => resolveChildRun(runs, parentRun, key)?.id === run.id,
 							),
 						};
-			pi.events?.emit?.(PENDING_STAGE_ROUTE_EVENT, {
+			const announcement: PendingStageRouteEvent = {
 				runId: run.id,
 				group: workflowInvocationIntercomGroup(rootRunId),
 				capability: workflowPendingStageRouteCapability(activeStore, run.id),
@@ -167,7 +189,43 @@ export function registerPendingStageIntercomBridge(pi: WorkflowEventSurface, act
 				// possible-future rows. Presence replaces, so a terminal root publishes `[]` and
 				// the broker drops the rows.
 				...(run.id === rootRunId ? { possibleStages: possibleStageRows(runs, rootRunId, run) } : {}),
-			});
+			};
+			// Compute the signature *before* emitting: the consumer mutates the payload
+			// by attaching `completion`, so a post-emit projection would never match.
+			const signature = JSON.stringify(announcement);
+			if (announcedRoutes.get(run.id)?.signature === signature) continue;
+			// Different snapshots are never debounced or serialized: A → B → A publishes
+			// all three immediately, even while an earlier completion is outstanding.
+			// Delaying a real change would hide new stages, nested aliases, and terminal
+			// rosters behind a slow acknowledgement.
+			const entry = { signature };
+			announcedRoutes.set(run.id, entry);
+			try {
+				pi.events?.emit?.(PENDING_STAGE_ROUTE_EVENT, announcement);
+			} catch (error) {
+				// Never cache a failed emission; the store observer owns the error.
+				if (announcedRoutes.get(run.id) === entry) announcedRoutes.delete(run.id);
+				throw error;
+			}
+			// Both the lightweight relay and the direct heavy handler assign this
+			// synchronously. It is observed, never awaited here and never overwritten.
+			const completion = announcement.completion;
+			if (completion === undefined) {
+				// No consumer claimed it: an absent event surface or a not-yet-installed
+				// relay must not make the route look published. Retry next invalidation.
+				announcedRoutes.delete(run.id);
+			} else {
+				completion.catch(() => {
+					// Identity, not signature: an older rejected A must not evict the
+					// newer A published after A → B → A. Reporting is the relay's job.
+					if (announcedRoutes.get(run.id) === entry) announcedRoutes.delete(run.id);
+				});
+			}
+		}
+		// Drop claims for runs with no currently resolvable durable owner, so a removed
+		// and re-added run re-announces instead of inheriting a stale claim.
+		for (const runId of announcedRoutes.keys()) {
+			if (!ownedRunIds.has(runId)) announcedRoutes.delete(runId);
 		}
 		sweepPromise = sweepPromise
 			.then(() => settleUndeliverablePendingStageMessages(activeStore, notifyUndeliverable))
@@ -268,6 +326,9 @@ export function registerPendingStageIntercomBridge(pi: WorkflowEventSurface, act
 		unsubscribeStore();
 		if (typeof subscription === "function") subscription();
 		if (typeof stickySubscription === "function") stickySubscription();
+		// A replacement bridge over the same store starts with no claims, and a
+		// completion still pending across disposal cannot evict the replacement's.
+		announcedRoutes.clear();
 	};
 	pi.on?.("session_shutdown", dispose);
 	return dispose;

--- a/test/integration/workflow-pending-stage-delivery.test.ts
+++ b/test/integration/workflow-pending-stage-delivery.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import net from "node:net";
 import { tmpdir } from "node:os";
@@ -8,6 +9,7 @@ import type { AgentSession, CreateAgentSessionOptions } from "@bastani/atomic";
 import { Type } from "typebox";
 import { afterAll, beforeAll, test, vi } from "vitest";
 import type { WorkflowStageAdmissionBoundary } from "../../packages/coding-agent/src/core/workflow-stage-admission.ts";
+import { isRecoverableIntercomDisconnect } from "../../packages/intercom/recoverable-disconnect.js";
 import type { BrokerMessage } from "../../packages/intercom/types.js";
 import type { StageSessionRuntime } from "../../packages/workflows/src/runs/foreground/stage-runner.js";
 import { createMockSdk } from "../unit/durable-dbos-backend-helpers.js";
@@ -780,10 +782,14 @@ test("control connections cannot acquire live workflow recipient aliases", async
 		});
 		control.registerPendingStageRoute(runId, group, "control-alias-capability");
 		await control.listDirectory();
+		// The broker refuses the unauthorized alias claim and ends the connection; the
+		// pipelined request settles with that refusal, which is never a recoverable
+		// transport disconnect, so callers see an actionable authorization failure.
 		await assert.rejects(
 			control.registerLiveWorkflowStageRoute(runId, ["tool-id", "tool-name"], "control-alias-capability"),
-			/Client disconnected/,
+			(error: unknown) => error instanceof Error && !isRecoverableIntercomDisconnect(error),
 		);
+		assert.equal(control.isConnected(), false);
 	} finally {
 		await control.disconnect();
 	}
@@ -844,8 +850,9 @@ test("a legacy route-ineligible roster row does not prevent a genuine agent from
 		await nonAgentRoute.connect({ ...registration, name: "not-a-tool-agent", recipientPurpose: "agent" });
 		await assert.rejects(
 			nonAgentRoute.registerLiveWorkflowStageRoute(runId, ["tool-id"], "legacy-roster-capability"),
-			/Client disconnected/,
+			(error: unknown) => error instanceof Error && !isRecoverableIntercomDisconnect(error),
 		);
+		assert.equal(nonAgentRoute.isConnected(), false);
 	} finally {
 		await nonAgentRoute.disconnect();
 		await agent.disconnect();
@@ -2803,6 +2810,124 @@ test("one composite workflow-stage target transitions atomically from durable qu
 		disposeBridge();
 		await sender.shutdown();
 		await owner.shutdown();
+	}
+});
+
+// Route republication used to fire on every store invalidation, so churn that leaves the
+// route projection untouched still cost a broker round trip whose same-socket
+// `listSessions()` barrier could expire on its own timer. A burst of route-neutral churn
+// must leave durable queueing, stage startup, and live delivery externally unchanged, and
+// must not produce a pending-stage-route relay failure.
+test("route-neutral store churn preserves durable queueing and live delivery for a starting stage", async () => {
+	const runId = randomUUID();
+	const group = `workflow:${runId}`;
+	const idTarget = `${group}/reviewer-id`;
+	const nameTarget = `${group}/reviewer`;
+	const stageSessionId = "burst-reviewer-session";
+	const store = createStore();
+	const backend = new InMemoryDurableBackend();
+	setDurableBackend(backend);
+	const owner = extensionFixture("burst-owner-session", "burst-owner", undefined, "default");
+	const sender = extensionFixture("burst-sender-session", "burst-sender", undefined, group);
+	intercom(owner.pi as never);
+	const disposeBridge = registerPendingStageIntercomBridge(owner.pi as never, store);
+	intercom(sender.pi as never);
+	let stage: ReturnType<typeof extensionFixture> | undefined;
+	const relayFailures: string[] = [];
+	const forwardConsoleError = console.error.bind(console);
+	// Forwarding spy: real failures still reach the reporter, they are only observed here.
+	const consoleError = vi.spyOn(console, "error").mockImplementation((...args) => {
+		if (typeof args[0] === "string" && args[0].includes("atomic:workflow-pending-stage-route")) {
+			relayFailures.push(args.map((value) => (value instanceof Error ? value.message : String(value))).join(" "));
+		}
+		forwardConsoleError(...args);
+	});
+
+	try {
+		await owner.start();
+		backend.registerWorkflow({ workflowId: runId, name: "burst", inputs: {}, status: "running", createdAt: 1 });
+		store.recordRunStart({
+			id: runId,
+			name: "burst",
+			inputs: {},
+			status: "running",
+			stages: [
+				{
+					id: "reviewer-id",
+					name: "reviewer",
+					// Started but not yet hosting a session: the projection advertises this
+					// pre-start identity as `lifecycle: "pending"`.
+					status: "running",
+					parentIds: [],
+					toolEvents: [],
+					pendingStageDeliveryAvailable: true,
+				},
+			],
+			startedAt: 1,
+		});
+		// Attachment is not part of the route projection, so none of these invalidations
+		// is a real routing change.
+		for (let index = 0; index < 1000; index += 1) store.recordStageAttached(runId, "reviewer-id", index % 2 === 0);
+		await owner.waitForEventCompletion("atomic:workflow-pending-stage-route");
+
+		await sender.start();
+		const pendingList = await executeIntercom(sender, { action: "list" });
+		assert.equal(pendingList.isError, false);
+		assert.equal(
+			(pendingList.content[0]?.text ?? "").includes(`[PENDING] — target: \`${idTarget}\``),
+			true,
+			pendingList.content[0]?.text,
+		);
+
+		const queued = await executeIntercom(sender, { action: "send", to: nameTarget, message: "queued-before-start" });
+		assert.equal(queued.isError, false);
+		assert.equal(queued.details.queued, true);
+		assert.equal(queued.details.delivered, false);
+		assert.equal(store.pendingStageMessagesFor(runId, "reviewer").length, 1);
+		assert.equal(store.pendingStageMessagesFor(runId, "reviewer")[0]?.id, queued.details.messageId);
+
+		const pendingStageDelivery = createWorkflowPendingStageDelivery(store, runId, "reviewer-id", "reviewer");
+		stage = extensionFixture(stageSessionId, "reviewer", pendingStageDelivery, group, {
+			intercomGroup: group,
+			kind: "workflow-stage",
+			workflowRunId: runId,
+			workflowStageId: "reviewer-id",
+			workflowStageName: "reviewer",
+			pendingStageDelivery,
+		});
+		intercom(stage.pi as never);
+		await stage.start();
+		store.recordStageSession(runId, "reviewer-id", { sessionId: stageSessionId });
+		await owner.waitForEventCompletion("atomic:workflow-pending-stage-route");
+
+		await stage.waitForInjectedCount(1);
+		assert.equal(stage.injectedMessages.filter(({ content }) => content?.includes("queued-before-start")).length, 1);
+		const drained = store.runs().find((entry) => entry.id === runId)?.pendingStageMessages ?? [];
+		assert.equal(drained.length, 1);
+		assert.equal(drained[0]?.stageId, "reviewer-id");
+		assert.equal(drained[0]?.status, "delivered");
+
+		for (const [to, marker] of [
+			[idTarget, "live-by-id"],
+			[nameTarget, "live-by-name"],
+		] as const) {
+			const live = await executeIntercom(sender, { action: "send", to, message: marker });
+			assert.equal(live.isError, false, live.content[0]?.text);
+			assert.equal(live.details.delivered, true);
+			assert.equal(live.details.queued, undefined);
+		}
+		await stage.waitForInjectedCount(3);
+		for (const marker of ["live-by-id", "live-by-name"]) {
+			assert.equal(stage.injectedMessages.filter(({ content }) => content?.includes(marker)).length, 1);
+		}
+		assert.equal(store.runs().find((entry) => entry.id === runId)?.stages[0]?.status, "running");
+		assert.deepEqual(relayFailures, []);
+	} finally {
+		consoleError.mockRestore();
+		if (stage !== undefined) await stage.shutdown();
+		await sender.shutdown();
+		await owner.shutdown();
+		disposeBridge();
 	}
 });
 

--- a/test/unit/intercom-client-transport-disconnect.test.ts
+++ b/test/unit/intercom-client-transport-disconnect.test.ts
@@ -272,6 +272,42 @@ test("pre-registration failures stay non-recoverable", async () => {
 	});
 });
 
+test("a post-registration refusal settles pipelined work with its reason while the broker stays open", async () => {
+	let brokerSide: net.Socket | undefined;
+	onConnection = acceptRegistration((socket) => {
+		brokerSide = socket;
+	});
+	const established = await connectedClient();
+	assert.ok(brokerSide);
+
+	// A real pipelined barrier the fake broker never answers: without the refusal
+	// reaching it, the only other way out is the client's own 5000 ms list timer.
+	const pending = established.client.listSessions();
+	const startedAt = Date.now();
+
+	// The broker reuses this frame to refuse an *established* client (a rejected
+	// pending-stage route) and deliberately keeps its own socket open here, so the
+	// refusal itself — not a peer FIN and not the timer — has to settle the barrier.
+	writeMessage(brokerSide, { type: "registration_failed", reason: "Invalid workflow-stage roster" });
+
+	let refusal: unknown;
+	await assert.rejects(pending, (error: unknown) => {
+		refusal = error;
+		assert.ok(error instanceof Error);
+		assert.equal(error.message, "Invalid workflow-stage roster");
+		assert.equal(isRecoverableIntercomDisconnect(error), false);
+		return true;
+	});
+	const elapsed = Date.now() - startedAt;
+	assert.equal(elapsed < 2000, true, `the refusal settled the list after ${elapsed}ms, not on the 5000ms timer`);
+	assert.equal(brokerSide.destroyed, false, "the broker side stayed open for the whole rejection");
+	assert.equal(established.client.isConnected(), false);
+
+	await established.closed;
+	assert.equal(established.disconnectPayload, refusal);
+	assert.equal(isRecoverableIntercomDisconnect(established.disconnectPayload), false);
+});
+
 test("plain errors cannot opt into recoverable classification by copying the marker", () => {
 	const spoofed = Object.assign(new Error("Client disconnected"), { intercomRecoverableDisconnect: true });
 	assert.equal(isRecoverableIntercomDisconnect(spoofed), false);

--- a/test/unit/intercom-pending-stage-route-security.test.ts
+++ b/test/unit/intercom-pending-stage-route-security.test.ts
@@ -9,6 +9,7 @@ import type { PendingStageMessageRequest } from "../../packages/intercom/broker/
 import { createMessageReader, writeMessage } from "../../packages/intercom/broker/framing.js";
 import { getBrokerSocketPath } from "../../packages/intercom/broker/paths.js";
 import { getJitiCliPath } from "../../packages/intercom/broker/spawn.js";
+import { isRecoverableIntercomDisconnect } from "../../packages/intercom/recoverable-disconnect.js";
 import type { BrokerMessage, ClientMessage, Message } from "../../packages/intercom/types.js";
 
 const repoRoot = resolve(import.meta.dirname, "../..");
@@ -1441,6 +1442,68 @@ test("broker rejects same-group replacement of an active pending route owner", a
 		false,
 	);
 	assert.equal(brokerOutput.includes(canary), false);
+});
+
+test("a refused production route settles its pipelined list barrier with the broker's authorization reason", async () => {
+	// Regression: the broker refuses an unauthorized route update with the same
+	// `registration_failed` frame it uses before registration, then ends the socket
+	// and drops everything pipelined behind it. An established client must surface
+	// that reason to the barrier instead of letting it expire on the five-second
+	// list timer or reporting a recoverable transport disconnect.
+	const runId = "0c8f4d21-6b3a-4d9e-8f41-72d5a1c0b9e3";
+	const group = `workflow:${runId}`;
+	const stages = [
+		{
+			stageId: "reviewer-id",
+			stageName: "reviewer",
+			target: `workflow:${runId}/reviewer-id`,
+			lifecycle: "pending" as const,
+			routeEligible: true,
+			group,
+		},
+	];
+	const owner = new IntercomClient();
+	const intruder = new IntercomClient();
+	for (const client of [owner, intruder]) {
+		realClients.add(client);
+		client.on("error", () => {});
+	}
+	await owner.connect(productionRegistration("capability-conflict-owner", group));
+	await intruder.connect(productionRegistration("capability-conflict-intruder", group));
+
+	owner.registerPendingStageRoute(runId, group, "owner-capability", stages);
+	await owner.listSessions();
+
+	const intruderDisconnect = Promise.withResolvers<unknown>();
+	intruder.once("disconnected", (error: unknown) => intruderDisconnect.resolve(error));
+	intruder.registerPendingStageRoute(runId, group, "different-capability", stages);
+	const refusal = await intruder.listSessions().then(
+		() => undefined,
+		(error: unknown) => error,
+	);
+	assert.ok(refusal instanceof Error);
+	assert.equal(refusal.message, "Pending-stage route is not authorized");
+	assert.equal(isRecoverableIntercomDisconnect(refusal), false);
+	assert.equal(intruder.isConnected(), false);
+	const disconnectCause = await intruderDisconnect.promise;
+	assert.ok(disconnectCause instanceof Error);
+	assert.equal(disconnectCause.message, "Pending-stage route is not authorized");
+	assert.equal(isRecoverableIntercomDisconnect(disconnectCause), false);
+
+	owner.registerPendingStageRoute(runId, group, "owner-capability", stages);
+	await owner.listSessions();
+	assert.equal(owner.isConnected(), true);
+	assert.deepEqual((await owner.listDirectory()).workflowStages, [
+		{
+			kind: "workflow-stage",
+			runId,
+			stageId: "reviewer-id",
+			stageName: "reviewer",
+			target: `workflow:${runId}/reviewer-id`,
+			lifecycle: "pending",
+			group,
+		},
+	]);
 });
 
 test("broker rejects an attacker-first live route without the workflow capability", async () => {

--- a/test/unit/intercom-pending-stage-routing.test.ts
+++ b/test/unit/intercom-pending-stage-routing.test.ts
@@ -18,7 +18,7 @@ import { DbosDurableBackend } from "../../packages/workflows/src/durable/dbos-ba
 import { setDurableBackend } from "../../packages/workflows/src/durable/factory.js";
 import { registerPendingStageIntercomBridge } from "../../packages/workflows/src/extension/pending-stage-intercom.js";
 import { createWorkflowPendingStageDelivery } from "../../packages/workflows/src/runs/foreground/pending-stage-delivery.js";
-import { createStore } from "../../packages/workflows/src/shared/store.js";
+import { createStore, type Store } from "../../packages/workflows/src/shared/store.js";
 import { createMockSdk } from "./durable-dbos-backend-helpers.js";
 
 const RUN_ID = "4ac72924-c452-4e5f-9e63-2435722109f7";
@@ -191,7 +191,7 @@ test("pending-stage ask refusal recommends nonblocking send", () => {
 });
 
 describe("workflows-owned pending-stage delivery event bridge", () => {
-	function harness() {
+	function harness(onRoute?: (payload: Record<string, unknown>) => void) {
 		const store = createStore();
 		store.recordRunStart({
 			id: RUN_ID,
@@ -219,6 +219,9 @@ describe("workflows-owned pending-stage delivery event bridge", () => {
 			events: {
 				emit(event: string, payload: Record<string, unknown>) {
 					emitted.push({ event, payload });
+					// A route consumer claims the announcement synchronously by assigning
+					// `completion`; every other event keeps today's plain fan-out.
+					if (event === "atomic:workflow-pending-stage-route") onRoute?.(payload);
 					listeners.get(event)?.(payload);
 				},
 				on(event: string, listener: (payload: unknown) => void) {
@@ -257,7 +260,7 @@ describe("workflows-owned pending-stage delivery event bridge", () => {
 			listeners.get("atomic:workflow-pending-stage-message")?.(payload);
 			return { payload, result: payload.completion === undefined ? undefined : await payload.completion };
 		};
-		return { store, backend, emitted, request, dispose };
+		return { store, backend, emitted, pi, request, dispose };
 	}
 
 	test("announces ownership and enforces group isolation without requesting", async () => {
@@ -740,6 +743,135 @@ describe("workflows-owned pending-stage delivery event bridge", () => {
 		assert.equal(completion.outcome, "forward");
 		assert.equal(completion.target, advertisedTarget);
 		dispose();
+	});
+
+	// Route publication deduplication: every store invalidation used to republish every
+	// run, so tool events, attachment toggles, and notices each cost a broker round trip
+	// whose `listSessions()` barrier can expire on its own 5s timer.
+	const turn = (): Promise<void> => new Promise<void>((resolve) => setImmediate(resolve));
+	/** Observable route payload, without the acknowledgement the consumer attaches. */
+	const routeData = (payload: Record<string, unknown>): Record<string, unknown> =>
+		Object.fromEntries(Object.entries(payload).filter(([key]) => key !== "completion"));
+	const pendingReviewerStages = [
+		{
+			stageId: "reviewer-id",
+			stageName: "reviewer",
+			target: `workflow:${RUN_ID}/reviewer-id`,
+			lifecycle: "pending",
+			routeEligible: true,
+			group: GROUP,
+		},
+	];
+	const runningReviewerStages = pendingReviewerStages.map((stage) => ({ ...stage, lifecycle: "running" }));
+	const toggleAttachment = (store: Store, count: number): void => {
+		for (let index = 0; index < count; index += 1) {
+			store.recordStageAttached(RUN_ID, "reviewer-id", index % 2 === 0);
+		}
+	};
+	const claimingHarness = (routes: Record<string, unknown>[], claims: PromiseWithResolvers<void>[]) =>
+		harness((payload) => {
+			routes.push(payload);
+			const claim = Promise.withResolvers<void>();
+			claims.push(claim);
+			payload.completion = claim.promise;
+		});
+
+	test("an unchanged route is republished neither while its acknowledgement is pending nor after it resolves", async () => {
+		const routes: Record<string, unknown>[] = [];
+		const claims: PromiseWithResolvers<void>[] = [];
+		const { store, dispose } = claimingHarness(routes, claims);
+		assert.equal(routes.length, 1);
+		assert.deepEqual(routes[0]?.stages, pendingReviewerStages);
+		// 1,000 attachment toggles leave the route projection identical. Before the fix
+		// this measured 1,001 announcements — one broker directory request each.
+		toggleAttachment(store, 1000);
+		assert.equal(routes.length, 1);
+		assert.deepEqual(routes[0]?.stages, pendingReviewerStages);
+		claims[0]?.resolve();
+		await turn();
+		toggleAttachment(store, 1000);
+		assert.equal(routes.length, 1);
+		// A genuine routing change is never debounced behind the acknowledged claim.
+		store.recordStageSession(RUN_ID, "reviewer-id", { sessionId: "reviewer-session" });
+		assert.equal(routes.length, 2);
+		assert.deepEqual(routes[1]?.stages, runningReviewerStages);
+		dispose();
+	});
+
+	test("a rejected route publication is retried on the next unchanged invalidation", async () => {
+		const routes: Record<string, unknown>[] = [];
+		const claims: PromiseWithResolvers<void>[] = [];
+		const { store, dispose } = claimingHarness(routes, claims);
+		assert.equal(routes.length, 1);
+		claims[0]?.reject(new Error("relay failed"));
+		await turn();
+		toggleAttachment(store, 1);
+		assert.equal(routes.length, 2);
+		assert.deepEqual(routeData(routes[1]!), routeData(routes[0]!));
+		// The retry is claimed, so the unchanged route stops republishing again.
+		toggleAttachment(store, 2);
+		assert.equal(routes.length, 2);
+		dispose();
+	});
+
+	test("a stale rejection cannot evict the claim of a route republished after A -> B -> A", async () => {
+		const routes: Record<string, unknown>[] = [];
+		const claims: PromiseWithResolvers<void>[] = [];
+		const { store, dispose } = claimingHarness(routes, claims);
+		const initialRun = structuredClone(store.runs()[0]!);
+		assert.equal(routes.length, 1);
+		assert.deepEqual(routes[0]?.stages, pendingReviewerStages);
+		// B publishes immediately even though A is still unacknowledged.
+		store.recordStageSession(RUN_ID, "reviewer-id", { sessionId: "reviewer-session" });
+		assert.equal(routes.length, 2);
+		assert.deepEqual(routes[1]?.stages, runningReviewerStages);
+		// A again, from the pre-session snapshot of the same run.
+		store.removeRun(RUN_ID);
+		store.recordRunStart(initialRun);
+		assert.equal(routes.length, 3);
+		assert.deepEqual(routeData(routes[2]!), routeData(routes[0]!));
+		claims[0]?.reject(new Error("relay failed"));
+		await turn();
+		toggleAttachment(store, 1);
+		assert.equal(routes.length, 3);
+		dispose();
+	});
+
+	test("an unclaimed announcement republishes until a consumer acknowledges it", () => {
+		const routes: Record<string, unknown>[] = [];
+		let acknowledging = false;
+		const { store, dispose } = harness((payload) => {
+			routes.push(payload);
+			if (acknowledging) payload.completion = Promise.resolve();
+		});
+		assert.equal(routes.length, 1);
+		// Nobody claimed the initial emission, so it is not proof of publication.
+		acknowledging = true;
+		toggleAttachment(store, 1);
+		assert.equal(routes.length, 2);
+		assert.deepEqual(routeData(routes[1]!), routeData(routes[0]!));
+		assert.deepEqual(routes[1]?.stages, pendingReviewerStages);
+		toggleAttachment(store, 2);
+		assert.equal(routes.length, 2);
+		dispose();
+	});
+
+	test("a replacement bridge republishes once and survives the disposed bridge's late rejection", async () => {
+		const routes: Record<string, unknown>[] = [];
+		const claims: PromiseWithResolvers<void>[] = [];
+		const { store, pi, dispose } = claimingHarness(routes, claims);
+		assert.equal(routes.length, 1);
+		dispose();
+		const replacement = registerPendingStageIntercomBridge(pi, store);
+		assert.equal(routes.length, 2);
+		assert.deepEqual(routeData(routes[1]!), routeData(routes[0]!));
+		// The disposed bridge's claim was still outstanding; its rejection belongs to a
+		// cache that no longer exists and must not invalidate the replacement's claim.
+		claims[0]?.reject(new Error("relay failed"));
+		await turn();
+		toggleAttachment(store, 1);
+		assert.equal(routes.length, 2);
+		replacement();
 	});
 });
 


### PR DESCRIPTION
## Summary

Repairs the two defects behind `Intercom event relay failed (atomic:workflow-pending-stage-route): Error: List sessions timeout`: the pending-stage bridge republished unchanged routes on every store invalidation, and a broker refusal arriving after registration was discarded instead of settling the requests pipelined behind it.

Closes #2990

## Changes

### Deduplicate unchanged workflow route publications

`packages/workflows/src/extension/pending-stage-intercom.ts` now keeps a bridge-local cache of the last announced payload signature per run.

- The signature is `JSON.stringify(announcement)` computed **before** emitting because the consumer mutates the payload by attaching `completion`. It covers the entire route projection.
- An identical signature skips only that run's emission while other runs and the undeliverable sweep continue.
- Different snapshots are never debounced or serialized: A → B → A publishes all three immediately, preserving new-stage visibility, nested aliases, and terminal roster updates.
- A synchronous emit failure, an absent completion, or a rejected completion invalidates the claim so the next store invalidation retries. Rejection uses entry identity, so an older rejected A cannot evict the newer A after A → B → A.
- Claims for runs without a resolvable durable owner are pruned each pass, and disposal clears bridge-local state.

### Settle post-registration broker refusals

`packages/intercom/broker/client.ts` now distinguishes initial registration failure from a refusal delivered to an established client.

- Pre-registration behavior is unchanged: `_registration_failed` still lets `connect()` reject through its existing cleanup path.
- After registration, the refusal becomes the first-recorded disconnect cause, settles outstanding work through the existing `failPending`, and destroys the rejected socket.
- The normal `onClose` path still owns session/socket cleanup and emits `disconnected` with that same non-recoverable cause.

No public signature or broker protocol changed. The 5,000 ms list timeout, same-socket `listSessions()` processing barriers, retry policy, and durable message settlement remain unchanged.

## Verification

The regressions fail before the source patches and pass afterward. Reverting only the two source files causes all 6 new tests to fail while all 27 pre-existing tests in the same files continue to pass.

- Bridge regression: one initial announcement plus 1,000 route-neutral attachment toggles produces **1** announcement instead of **1,001**; after acknowledgement, 1,000 more toggles still produce none. A genuine lifecycle change publishes synchronously.
- Fake-broker regression: while the broker-side socket remains open, an outstanding `listSessions()` rejects with `"Invalid workflow-stage roster"` in under two seconds, rather than waiting five seconds for `"List sessions timeout"`. The client closes and `disconnected` carries the same error object.
- Real-broker regression: a conflicting capability receives `"Pending-stage route is not authorized"` as a non-recoverable error; the legitimate owner remains usable.
- Integration regression: after 1,000 route-neutral invalidations, a message queues before stage startup, is admitted exactly once on startup, and ID/name targets both deliver live afterward. No pending-stage-route relay failure is logged.

| Check | Result |
|---|---|
| `prek run --from-ref HEAD~1 --to-ref HEAD` | pass |
| `npm run check` | pass |
| affected unit suites | 134/134 tests pass |
| delivery and reconnect-recovery integration suites | 53/53 tests pass |

`test/integration/intercom-reconnect-recovery.test.ts` has an existing Windows-only suite-level `EPERM` while deleting its temporary directory in `afterAll`. It reproduces identically with the source patches reverted; all eight tests in that file pass either way.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791736214&installation_model_id=10562&pr_number=2991&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2991&signature=3e00a6bffb2e7bbce6dee0ceca6248e59b77994ec00b0db7c350cdbc23e5b955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63147060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Not ready to merge until the required issue-number references are added beside the new regression tests.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Add issue references** <a href="https://github.com/bastani-inc/atomic/pull/2991#discussion_r3991366892">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
test/unit/intercom-client-transport-disconnect.test.ts:275
This new regression test has no nearby `#2990` reference. Add the issue number here and beside the related newly added regression tests in the route-security, route-routing, and workflow-delivery suites. The repository requires regression tests that fix a GitHub issue to identify that issue, so this requirement must be satisfied before merging.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Adds broker-refusal handling so established clients reject pending work with the broker-provided reason.
- Avoids redundant pending-stage route publication when route data has not changed, while retaining retry behavior for unclaimed or failed publications.
- The added regression tests need nearby issue-number references to meet the repository’s test convention.

## Merge safety

Not ready to merge: the repository requirement for regression-test issue references must be satisfied first.

<sub>Reviews (1) · Last reviewed commit: ["fix(intercom): settle broker refusals an..."](https://github.com/bastani-inc/atomic/commit/d852180fea819fe95f531efd0a9a77cc692636a0)</sub>

<!-- /greptile_comment -->