### PR TITLE
fix(ci): give Linux integration and archive jobs measured headroom

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,13 +135,13 @@ jobs:
         include:
           - os: blacksmith-4vcpu-ubuntu-2404
             binary_platform: linux-x64
-            timeout_minutes: 4
+            timeout_minutes: 10
           - os: blacksmith-4vcpu-windows-2025
             binary_platform: windows-x64
             timeout_minutes: 14
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Linux: run 34142104101, 145s + 50%. Windows: setup + two attempts + 50%; see docs/ci.md.
+    # Setup + two attempts at measured cost + 50% per host; September 11 Linux repair in docs/ci.md.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:
       - uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1.1
@@ -283,13 +283,13 @@ jobs:
         include:
           - os: blacksmith-4vcpu-ubuntu-2404
             binary_platform: linux-x64
-            timeout_minutes: 2
+            timeout_minutes: 4
           - os: blacksmith-4vcpu-windows-2025
             binary_platform: windows-x64
             timeout_minutes: 7
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Two-run maximum plus 50% headroom, rounded up to minutes; see docs/ci.md.
+    # Linux: censored build + remaining packaging/smoke + 50%; September 11 repair in docs/ci.md.
     # Windows: run 34035777039 was cancelled at 244s after successful steps; ceil(244 * 1.5 / 60) = 7.
     timeout-minutes: ${{ matrix.timeout_minutes }}
     steps:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -207,10 +207,10 @@ The initial job caps used the latest two completed CI runs available at calibrat
 (PR, `bafc6ebd17`). Both succeeded. Run `33998194502` was still in progress
 and was excluded rather than treating unfinished durations as measurements.
 Those samples and caps remain unchanged except for unit tests, agent suites,
-Windows release archive and integration tests, recalibrated using the runs below.
+release archives and integration tests, recalibrated using the runs below.
 
-Except for the retry-inclusive Windows integration cap below, the cap in minutes is
-`ceil(max(run_1_seconds, run_2_seconds) × 1.5 / 60)`. Durations come from
+Except for integration's retry-inclusive caps and the Linux archive projection below,
+the cap in minutes is `ceil(max(run_1_seconds, run_2_seconds) × 1.5 / 60)`. Durations come from
 GitHub's job `completedAt - startedAt`, including setup and teardown but not
 time queued for a runner. Whole-minute rounding provides at least 50% headroom
 over the observed duration, not over an unobserved completion after a timeout.
@@ -219,11 +219,11 @@ over the observed duration, not over an unobserved completion after a timeout.
 | --- | --- | ---: | ---: | ---: |
 | Unit tests | Linux | 869 s (34270757695; timeout-censored, both attempts failed) | 371 s | 22 min |
 | Unit tests | Windows | 870 s (34270757695; timeout-censored during retry) | 511 s | 22 min |
-| Integration tests | Linux | 145 s (34142104101; success) | 118 s | 4 min |
+| Integration tests | Linux | 257 s (34652319107; timeout-censored) | 135 s setup + 2 × 116 s attempts + 7 s teardown, projected | 10 min |
 | Integration tests | Windows | 501 s (34275410217; timeout-censored during retry) | 147 s setup + 2 × 186.92 s attempts + 7 s teardown, projected | 14 min |
 | Agent suite | Linux | 382 s (34270757695; job timeout, test step succeeded) | 216 s | 10 min |
 | Agent suite | Windows | 552 s (34270757695; job timeout, test step succeeded) | 327 s | 14 min |
-| Release archive | Linux | 76 s | 80 s | 2 min |
+| Release archive | Linux | 137 s (34653564242; timeout-censored) | 49 s setup + 84 s partial build + 15 s packaging + 5 s smoke + 5 s tail, projected | 4 min |
 | Release archive | Windows | 244 s (34035777039; timeout-censored) | 149 s (34037177374; success) | 7 min |
 | Static checks | Linux | 78 s | 88 s | 3 min |
 | Final test gate | Linux matrix label | 4 s | 3 s | 1 min |
@@ -231,6 +231,69 @@ over the observed duration, not over an unobserved completion after a timeout.
 
 Both final gate legs execute on Linux. The topology contract pins the caps and
 the sampled matrix-job maxima used to calculate them.
+
+#### Linux setup and retry headroom, September 11, 2026
+
+The annotations for [integration job 103437056550](https://github.com/bastani-inc/atomic/actions/runs/34652319107/job/103437056550)
+and [archive job 103440964907](https://github.com/bastani-inc/atomic/actions/runs/34653564242/job/103440964907)
+explicitly report maximum execution times of **4m0s** and **2m0s**. Integration
+setup ran 22:04:24–22:06:39 UTC (135 s), including an 80 s native-build step;
+its first test attempt was cancelled at 22:08:37 without a completed JSON report.
+Archive setup ran 22:20:47–22:21:36 (49 s), then its build was cancelled at
+22:23:00 after 84 s, before smoke. The archive log shows native compilation
+finished at 22:22:54 and binary packaging began at 22:22:55; the job deadline
+interrupted remaining payload/archive work, not a failed compiler or smoke assertion.
+The 257 s / 137 s job durations include cancellation/teardown and are censored,
+not successful completion measurements.
+
+The five latest successful completed `Tests` runs before the integration failure
+provide this small sample (Blacksmith 4-vCPU Linux, Node 22, Bun 1.4.2). Each link
+identifies the exact job. Setup is job start to suite/binary-build step start;
+tail is the last work step's end to job completion, including upload/cleanup.
+All values are seconds from the Actions jobs API; skipped steps are excluded.
+
+| Run | Integration job: total = setup + test step + tail | Archive job: total = setup + binary build + smoke + tail |
+| --- | --- | --- |
+| 34646389961 | [103418078846](https://github.com/bastani-inc/atomic/actions/runs/34646389961/job/103418078846): 218 = 98 + 114 + 6 | [103418078959](https://github.com/bastani-inc/atomic/actions/runs/34646389961/job/103418078959): 113 = 36 + 68 + 5 + 4 |
+| 34648403746 | [103424602203](https://github.com/bastani-inc/atomic/actions/runs/34648403746/job/103424602203): 164 = 75 + 83 + 6 | [103424602069](https://github.com/bastani-inc/atomic/actions/runs/34648403746/job/103424602069): 94 = 32 + 55 + 3 + 4 |
+| 34650527115 | [103431358756](https://github.com/bastani-inc/atomic/actions/runs/34650527115/job/103431358756): 172 = 76 + 90 + 6 | [103431358750](https://github.com/bastani-inc/atomic/actions/runs/34650527115/job/103431358750): 112 = 37 + 66 + 5 + 4 |
+| 34650725978 | [103432003585](https://github.com/bastani-inc/atomic/actions/runs/34650725978/job/103432003585): 203 = 81 + 116 + 6 | [103432003438](https://github.com/bastani-inc/atomic/actions/runs/34650725978/job/103432003438): 96 = 34 + 54 + 4 + 4 |
+| 34652199575 | [103436681134](https://github.com/bastani-inc/atomic/actions/runs/34652199575/job/103436681134): 199 = 92 + 101 + 6 | [103436681082](https://github.com/bastani-inc/atomic/actions/runs/34652199575/job/103436681082): 96 = 33 + 55 + 4 + 4 |
+
+The logs show one completed integration attempt per success, no Rust-install
+retry, and Bun/npm cache hits in these ten jobs and both reported failures.
+The first four runs restored npm key suffix `3cea014a…`; the latest success and
+failures restored `bfde1d78…`. Native code was rebuilt, not restored from a Cargo
+target cache. Native integration steps took 41–58 s in the successes versus
+80 s in the reported failure. Cache hits do not make setup/build costs constant;
+these are neither cold-cache samples nor measurements of a successful full retry.
+Success selection under the old deadlines also truncates the sample's slow tail.
+
+- **Integration: 10 minutes**, `ceil((135 + 2 × 116 + 7) × 1.5 / 60)`.
+  Combine the slow observed setup with two complete maximum sampled test-step
+  durations and a 7 s tail allowance (observed 6 s plus 1 s rounding margin).
+  The 374 s retry-inclusive projection becomes 561 s, rounded to 600 s.
+  The second attempt is projected, not observed. The later main-run
+  [integration job 103440964881](https://github.com/bastani-inc/atomic/actions/runs/34653564242/job/103440964881)
+  also cancelled, after 148 s in its test step: longer than the 116 s successful
+  maximum but below its 174 s allowance with 50% headroom. This is another
+  censored observation, not proof that its attempt would finish in 174 s.
+- **Archive: 4 minutes**, `ceil((49 + 84 + 15 + 5 + 5) × 1.5 / 60)`.
+  Retain the full 84 s partial build and conservatively reserve an entire
+  packaging phase again. Successful log intervals from `Building binaries...`
+  to `Archives available` were 14.15, 11.05, 12.42, 12.83 and 12.02 s in table
+  order: round their maximum to 15 s. Smoke's maximum is 5 s; the 5 s tail
+  allowance is the observed 4 s plus 1 s margin. This projects 158 s, then
+  237 s with headroom, rounded to 240 s. The incomplete build is not treated
+  as a finished sample; remaining packaging at sampled cost is an assumption.
+
+Only these two Linux job caps change. All eleven contexts, Windows caps, result
+gates, test/smoke coverage, 30000 ms default, 40%/70% duration scoring, retry
+policy and concurrency stay unchanged. The caps cover the projected work at
+observed costs, not arbitrary downloads or two full four-minute Rust installs;
+in particular the four-minute archive job cannot guarantee the Rust retry fits.
+The enclosing deadline still wins. Exact-head hosted CI must confirm completion;
+no speedup or full-platform local execution is claimed.
 
 #### Prerelease 0.9.19-alpha.2 repair, September 8, 2026
 
@@ -346,19 +409,19 @@ duration. That release-archive recalibration left Linux's 2-minute cap, the
 other job caps, the 14-minute hang-detector ceiling, required contexts, smoke
 tests and per-test thresholds unchanged.
 
-Except for Windows integration's explicit retry-inclusive allowance above,
-these are two-run wall-clock limits, not a guarantee that a full suite retry or
+Except for integration's explicit retry-inclusive allowances and the Linux archive
+projection above, these are two-run wall-clock limits, not a guarantee that a full suite retry or
 a cold-cache toolchain download will fit. Bounded retries remain enabled but
 share the job's remaining time. Recalibrate with fresh evidence if those paths
 exceed the limits. No test coverage, retry count, or per-test timeout changes.
 
 The unchanged npm policy allows 85 seconds for one stalled request and its two
 retries: `3 × 25 s + 2 × 5 s` maximum backoff. The contract checks that this is
-less than the smallest **npm-installing** job cap (120 seconds, Linux release
-archive); the 60-second result gate never runs npm. The former one-third-of-a-job
-guarantee no longer applies: 255 seconds cannot fit into
-120 seconds. Even one 85-second allowance may not fit after setup and other
-work, and an install may make multiple requests. The job deadline wins; this
+less than the smallest **npm-installing** job cap (180 seconds, static checks);
+the 60-second result gate never runs npm. The former one-third-of-a-job
+guarantee no longer applies: 255 seconds cannot fit into 180 seconds.
+Even one 85-second allowance may not fit after setup and other work, and an install
+may make multiple requests. The job deadline wins; this
 contract does not guarantee that npm retries or the install will finish.
 
 Existing individual step limits remain unchanged: Rust installation and its

--- a/test/ci/test-workflow-topology.test.ts
+++ b/test/ci/test-workflow-topology.test.ts
@@ -112,7 +112,7 @@ test("every work job the gate names exists and is otherwise independent", async 
 	}
 });
 
-/** Measured headroom, including a full Windows integration retry; evidence lives in docs/ci.md. */
+/** Measured headroom, including a full integration retry on both hosts; evidence lives in docs/ci.md. */
 test("each split job retains its measured timeout hang detector", async () => {
 	const workflow = await readText(testPath);
 	const blocks = await jobs();
@@ -122,14 +122,21 @@ test("each split job retains its measured timeout hang detector", async () => {
 		// Run 34270757695: Linux job 102211457492 / Windows job 102211457215 were
 		// timeout-censored at 869s / 870s, including bounded retries and teardown.
 		"unit-tests": [Math.ceil((869 * 1.5) / 60), Math.ceil((870 * 1.5) / 60)],
-		// RFC #2884, run 34142104101: Linux job 101806128732 took 145s;
+		// Linux run 34652319107 / job 103437056550: 135s setup before cancellation;
+		// five successful runs on September 11: at most 116s per attempt; allow 7s tail (6s + 1s margin).
 		// PR #2934, run 34275410217 / job 102227085985: 147s setup, 186.92s first
-		// attempt, 7s teardown. Reserve two complete attempts, then add 50% headroom.
-		"integration-tests": [Math.ceil((145 * 1.5) / 60), Math.ceil(((147 + 2 * 186.92 + 7) * 1.5) / 60)],
+		// attempt, 7s teardown. Both hosts reserve two attempts, then add 50% headroom.
+		"integration-tests": [
+			Math.ceil(((135 + 2 * 116 + 7) * 1.5) / 60),
+			Math.ceil(((147 + 2 * 186.92 + 7) * 1.5) / 60),
+		],
 		// Run 34270757695: jobs 102211457418 / 102211457032 reached 382s / 552s. Test steps
 		// passed without retry, but both jobs still exceeded their 6/9-minute caps.
 		"agent-suite": [Math.ceil((382 * 1.5) / 60), Math.ceil((552 * 1.5) / 60)],
-		"release-archive": [Math.ceil((80 * 1.5) / 60), Math.ceil((244 * 1.5) / 60)],
+		// Linux run 34653564242 / job 103440964907: 49s setup + 84s censored build.
+		// Reserve another full 15s packaging (successful max rounded up), 5s smoke and 5s tail.
+		// The partial build is not a measured completion; docs/ci.md records this projection's limits.
+		"release-archive": [Math.ceil(((49 + 84 + 15 + 5 + 5) * 1.5) / 60), Math.ceil((244 * 1.5) / 60)],
 	};
 	for (const [job, [linux, windows]] of Object.entries(caps)) {
 		const block = blocks.get(job) as string;


### PR DESCRIPTION
## Summary

Increase only the Linux integration and release-archive job deadlines to accommodate measured setup and work costs. The existing deadlines cancelled [integration at 4 minutes](https://github.com/bastani-inc/atomic/actions/runs/34652319107/job/103437056550) and [archive at 2 minutes](https://github.com/bastani-inc/atomic/actions/runs/34653564242/job/103440964907), before their work could finish.

## Changes

- Linux integration: 4 → 10 minutes. Setup, two projected test attempts and teardown with 50% headroom give `ceil((135 + 2 × 116 + 7) × 1.5 / 60) = 10`.
- Linux archive: 2 → 4 minutes. Setup, censored build, remaining packaging, smoke and teardown with 50% headroom give `ceil((49 + 84 + 15 + 5 + 5) × 1.5 / 60) = 4`.
- Update the timeout regression contract and `docs/ci.md` with five successful Linux job pairs, source links, arithmetic and cache/retry limitations.

All eleven CI contexts, Windows caps and coverage, required fail-closed gates, test/smoke steps, retry policy, concurrency, 30000 ms per-test default and duration-scoring thresholds remain unchanged. This is infrastructure-only; user-facing docs and package changelogs need no change.

## Validation

The implementation receipt and three independent reviewers approved commit `7d507d071699a98014384bf0dedb903d121203b4` against base `aca13b906ca010958aae7bf4dbdf7a81704b704f`.

Recorded checks on that candidate:
- `npm run test:ci-contracts`: 97 tests passed across 17 files.
- `npm run check`: passed, with two unchanged informational Biome diagnostics.
- `qlty smells --include-tests --no-upgrade-check test/ci/test-workflow-topology.test.ts`: no findings.
- Regression checks rejected each old Linux cap independently.
- Independent YAML/AST comparison preserved all other workflow semantics and existing assertions. Actual gate-shell probes accepted only all-success across 1,024 result combinations plus empty input.

The publication stage inspected the clean branch and both base-relative diffs; it did not rerun the implementation checks. No application UI changed, so UI recordings are inapplicable.

## Limitations and follow-up

The successful samples had cache hits and one integration attempt each. The retry allowance is projected, and the failed archive build is a censored observation, not a completed measurement. Cold-cache downloads and two full four-minute Rust-install attempts are not guaranteed to fit. No performance optimization is claimed.

Parent-owned durable `test:ci-contracts` and `check` gates, followed by exact-head required hosted CI, must pass before the parent merges. This stage does not merge or bypass protections.

## Contract amendments received

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791759203&installation_model_id=10562&pr_number=2994&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2994&signature=f082c50fe2faf70c3ba4595ae75fbb9788c82216a9e8131c8010ead621c2f7c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63298544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: the intended Linux and unchanged Windows timeout settings are enforced by the workflow and its focused contract.

What we checked:
- I ran a narrow validator that executes the repository CI-contract suite and independently checks the workflow timeout matrices. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The dedicated timeout and topology contract passed all 9 checks. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Independent workflow assertions confirmed the timeouts: integration uses 10 minutes on Linux and 14 on Windows, while the release archive uses 4 minutes on Linux and 7 on Windows, with matrix-based timeout enforcement intact. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The broader CI-contract command surfaced unrelated unresolved imports in extension/build contracts, but this did not affect the passing timeout-specific contract. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The exact executed source for the timeout tests was trex-artifacts/validate-ci-linux-timeouts.mjs. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- Updates the Linux integration and release-archive job deadlines to provide the documented headroom.
- Preserves the Windows deadlines, matrix configuration, and workflow topology.
- The dedicated CI timeout contract and independent workflow checks confirm the intended limits are enforced.

Safe to merge.

<sub>Reviews (1) · Last reviewed commit: ["fix(ci): give Linux integration and arch..."](https://github.com/bastani-inc/atomic/commit/7d507d071699a98014384bf0dedb903d121203b4)</sub>

<!-- /greptile_comment -->