### PR TITLE
fix(web-access)!: require one urls array for content fetching

### DIFF
--- a/packages/coding-agent/docs/web-access.md
+++ b/packages/coding-agent/docs/web-access.md
@@ -1,0 +1,38 @@
+# Fetching web content
+
+Atomic's bundled `fetch_content` tool reads webpages, PDFs, GitHub repositories, YouTube videos, and local video files.
+
+## Arguments
+
+Always pass the lowercase `urls` field as a nonempty array of strings, even for one URL:
+
+```json
+{"urls": ["https://example.com/article"]}
+```
+
+For multiple pages:
+
+```json
+{"urls": ["https://example.com/one", "https://example.com/two"]}
+```
+
+For a video, include the question in `prompt`:
+
+```json
+{"urls": ["/path/to/recording.mp4"], "prompt": "What error appears on screen?"}
+```
+
+Existing prompts or integrations using `{"url": "..."}` must change to `{"urls": ["..."]}`. The singular `url` field is no longer accepted by `fetch_content`. This does not change the `url` selector on `get_search_content`.
+
+Atomic can normalize a scalar `urls` string into a one-item array. Always use the documented array form in prompts and integrations; the legacy `url` field is not normalized.
+
+## Troubleshooting
+
+If argument validation fails, check that:
+
+- The field is `urls`, not `URLs` or `url`.
+- Its value is an array, not a string or an object.
+- The array contains at least one nonempty string.
+- The call has no unrecognized fields.
+
+When fetched content is truncated, follow the returned `get_search_content` call to retrieve the stored content.

--- a/packages/subagents/agents/codebase-online-researcher.md
+++ b/packages/subagents/agents/codebase-online-researcher.md
@@ -28,7 +28,7 @@ You research current technical information from authoritative external sources: 
 
 Check `research/web/` for a recent cached copy first; fetch only when it is missing or stale. Reuse repositories already under `/tmp/atomic-github-repos/`, and persist reusable high-value fetches to `research/web/`.
 
-For static pages, use the least expensive route that succeeds: `fetch_content <url>`; then the site's `/llms.txt`; then `bash` with `curl <url> -H "Accept: text/markdown"` (inspect `content-type: text/markdown` and `x-markdown-tokens`); then `playwright-cli`. Start with the authoritative source rather than broad search when it is known.
+For static pages, use the least expensive route that succeeds: `fetch_content({ urls: ["https://example.com"] })`; then the site's `/llms.txt`; then `bash` with `curl <url> -H "Accept: text/markdown"` (inspect `content-type: text/markdown` and `x-markdown-tokens`); then `playwright-cli`. Start with the authoritative source rather than broad search when it is known.
 
 Batch independent calls in one turn to reduce round-trips. `fetch_content({ urls: [...] })` fetches three URLs concurrently; independent git/gh commands may use `&` plus `wait`. Tool calls otherwise execute sequentially.
 
@@ -44,7 +44,7 @@ Choose the route that matches the question:
 - **Technical solutions:** search exact errors and terms, official issues/discussions, Stack Overflow or technical forums, and comparable implementations.
 - **Comparisons:** use migration guides, benchmarks, performance evidence, and explicit decision criteria or matrices.
 
-For source repositories, prefer raw GitHub URLs over HTML when reading a known file. For version-specific questions, clone the tagged version with `fetch_content("https://github.com/<owner>/<repo>/tree/v1.0.0")`; resolve a tag SHA with `gh api repos/<owner>/<repo>/git/refs/tags/v1.0.0 --jq '.object.sha'` when needed.
+For source repositories, prefer raw GitHub URLs over HTML when reading a known file. For version-specific questions, clone the tagged version with `fetch_content({ urls: ["https://github.com/<owner>/<repo>/tree/v1.0.0"] })`; resolve a tag SHA with `gh api repos/<owner>/<repo>/git/refs/tags/v1.0.0 --jq '.object.sha'` when needed.
 
 ## Video evidence
 
@@ -53,11 +53,11 @@ For source repositories, prefer raw GitHub URLs over HTML when reading a known f
 Examples of distinct calls:
 
 ```typescript
-fetch_content({ url: "https://youtube.com/watch?v=abc", prompt: "What libraries are imported?" })
-fetch_content({ url: "https://youtube.com/watch?v=abc", timestamp: "23:41" })
-fetch_content({ url: "https://youtube.com/watch?v=abc", timestamp: "23:41-25:00", frames: 3 })
-fetch_content({ url: "https://youtube.com/watch?v=abc", frames: 6 })
-fetch_content({ url: "/path/to/demo.mp4", prompt: "What error appears?" })
+fetch_content({ urls: ["https://youtube.com/watch?v=abc"], prompt: "What libraries are imported?" })
+fetch_content({ urls: ["https://youtube.com/watch?v=abc"], timestamp: "23:41" })
+fetch_content({ urls: ["https://youtube.com/watch?v=abc"], timestamp: "23:41-25:00", frames: 3 })
+fetch_content({ urls: ["https://youtube.com/watch?v=abc"], frames: 6 })
+fetch_content({ urls: ["/path/to/demo.mp4"], prompt: "What error appears?" })
 fetch_content({ urls: ["https://youtube.com/watch?v=abc", "https://youtube.com/watch?v=def"], prompt: "What packages are installed?" })
 ```
 

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- `fetch_content` now requires a nonempty `urls` array of nonempty strings for both single and batch requests. Replace `{ url: "..." }` with `{ urls: ["..."] }`. Invalid argument shapes and unrecognized fields are rejected before fetching; the `get_search_content` selectors are unchanged.
+
 ## [0.9.14] - 2026-08-19
 
 Cumulative release of the `0.9.14-alpha.3` – `0.9.14-alpha.4` prereleases. The summary below covers the user-visible outcome of that work; the per-change detail remains in the prerelease sections below.

--- a/packages/web-access/README.md
+++ b/packages/web-access/README.md
@@ -58,16 +58,16 @@ Requires Pi v0.37.3+.
 web_search({ query: "TypeScript best practices 2025" })
 
 // Fetch a page
-fetch_content({ url: "https://docs.example.com/guide" })
+fetch_content({ urls: ["https://docs.example.com/guide"] })
 
 // Clone a GitHub repo
-fetch_content({ url: "https://github.com/owner/repo" })
+fetch_content({ urls: ["https://github.com/owner/repo"] })
 
 // Understand a YouTube video
-fetch_content({ url: "https://youtube.com/watch?v=abc", prompt: "What libraries are shown?" })
+fetch_content({ urls: ["https://youtube.com/watch?v=abc"], prompt: "What libraries are shown?" })
 
 // Analyze a screen recording
-fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on screen?" })
+fetch_content({ urls: ["/path/to/recording.mp4"], prompt: "What error appears on screen?" })
 ```
 
 ## Tools
@@ -116,18 +116,22 @@ code_search({ query: "Express middleware error handling", maxTokens: 10000 })
 
 Fetch URL(s) and extract readable content as markdown. Automatically detects and handles GitHub repos, YouTube videos, PDFs, local video files, and regular web pages.
 
+Use the lowercase `urls` field with a nonempty array of strings, even for one URL. Replace legacy `{ url: "..." }` calls with `{ urls: ["..."] }`. Missing targets, empty arrays, empty strings, object entries, and unrecognized fields are rejected before fetching. Atomic's standard argument normalization can convert a scalar `urls` string into a one-item array, but prompts and integrations should always send the documented array form.
+
+See [Atomic's fetch argument guide](../coding-agent/docs/web-access.md) for examples and validation troubleshooting.
+
 ```typescript
-fetch_content({ url: "https://example.com/article" })
-fetch_content({ urls: ["url1", "url2", "url3"] })
-fetch_content({ url: "https://github.com/owner/repo" })
-fetch_content({ url: "https://youtube.com/watch?v=abc", prompt: "What libraries are shown?" })
-fetch_content({ url: "/path/to/recording.mp4", prompt: "What error appears on screen?" })
-fetch_content({ url: "https://youtube.com/watch?v=abc", timestamp: "23:41-25:00", frames: 4 })
+fetch_content({ urls: ["https://example.com/article"] })
+fetch_content({ urls: ["https://example.com/one", "https://example.com/two"] })
+fetch_content({ urls: ["https://github.com/owner/repo"] })
+fetch_content({ urls: ["https://youtube.com/watch?v=abc"], prompt: "What libraries are shown?" })
+fetch_content({ urls: ["/path/to/recording.mp4"], prompt: "What error appears on screen?" })
+fetch_content({ urls: ["https://youtube.com/watch?v=abc"], timestamp: "23:41-25:00", frames: 4 })
 ```
 
 | Parameter | Description |
 |-----------|-------------|
-| `url` / `urls` | Single URL/path or multiple URLs |
+| `urls` | Required nonempty array of URL/path strings, including for a single target |
 | `prompt` | Question to ask about a YouTube video or local video file |
 | `timestamp` | Extract frame(s) — single (`"23:41"`), range (`"23:41-25:00"`), or seconds (`"85"`) |
 | `frames` | Number of frames to extract (max 12) |
@@ -168,11 +172,11 @@ Fallback: Gemini API (Files API upload) → Gemini Web when browser cookies are 
 Use `timestamp` and/or `frames` on any YouTube URL or local video file to extract visual frames as images.
 
 ```typescript
-fetch_content({ url: "...", timestamp: "23:41" })                       // single frame
-fetch_content({ url: "...", timestamp: "23:41-25:00" })                 // range, 6 frames
-fetch_content({ url: "...", timestamp: "23:41-25:00", frames: 3 })      // range, custom count
-fetch_content({ url: "...", timestamp: "23:41", frames: 5 })            // 5 frames at 5s intervals
-fetch_content({ url: "...", frames: 6 })                                // sample whole video
+fetch_content({ urls: ["..."], timestamp: "23:41" })                   // single frame
+fetch_content({ urls: ["..."], timestamp: "23:41-25:00" })             // range, 6 frames
+fetch_content({ urls: ["..."], timestamp: "23:41-25:00", frames: 3 })  // range, custom count
+fetch_content({ urls: ["..."], timestamp: "23:41", frames: 5 })        // 5 frames at 5s intervals
+fetch_content({ urls: ["..."], frames: 6 })                            // sample whole video
 ```
 
 Requires `ffmpeg` (and `yt-dlp` for YouTube). Timestamps accept `H:MM:SS`, `MM:SS`, or bare seconds.
@@ -191,7 +195,7 @@ When Readability fails or returns only a cookie notice, the extension retries vi
 web_search(query)
   → Exa (direct API with key, MCP without) → Perplexity → Gemini API → Gemini Web (if browser cookies enabled)
 
-fetch_content(url)
+fetch_content({ urls: [url] })
   → Video file?  Gemini API (Files API) → Gemini Web (if browser cookies enabled)
   → GitHub URL?  Clone repo, return file contents + local path
   → YouTube URL? Gemini Web (if browser cookies enabled) → Gemini API → Perplexity

--- a/packages/web-access/content-tools.ts
+++ b/packages/web-access/content-tools.ts
@@ -61,8 +61,10 @@ export function registerContentTools(pi: ExtensionAPI, deps: RegisterContentTool
 		promptSnippet:
 			"Use to extract readable content from URL(s), YouTube, GitHub repos, or local videos. For video questions, pass the user's exact question in prompt.",
 		parameters: Type.Object({
-			url: Type.Optional(Type.String({ description: "Single URL to fetch" })),
-			urls: Type.Optional(Type.Array(Type.String(), { description: "Multiple URLs (parallel)" })),
+			urls: Type.Array(Type.String({ minLength: 1 }), {
+				minItems: 1,
+				description: 'URLs or local video paths to fetch. Always use an array, even for one URL: {"urls":["https://example.com"]}. Multiple URLs are fetched in parallel.',
+			}),
 			forceClone: Type.Optional(Type.Boolean({
 				description: "Force cloning large GitHub repositories that exceed the size threshold",
 			})),
@@ -80,16 +82,10 @@ export function registerContentTools(pi: ExtensionAPI, deps: RegisterContentTool
 			model: Type.Optional(Type.String({
 				description: "Override the Gemini model for video/YouTube analysis (e.g. 'gemini-2.5-flash', 'gemini-3-flash-preview'). Defaults to config or gemini-3-flash-preview.",
 			})),
-		}),
+		}, { additionalProperties: false }),
 
 		async execute(_toolCallId, params, signal, onUpdate) {
-			const urlList = params.urls ?? (params.url ? [params.url] : []);
-			if (urlList.length === 0) {
-				return {
-					content: [{ type: "text", text: "Error: No URL provided." }],
-					details: { error: "No URL provided" },
-				};
-			}
+			const urlList = params.urls;
 
 			onUpdate?.({
 				content: [{ type: "text", text: `Fetching ${urlList.length} URL(s)...` }],

--- a/packages/web-access/index.ts
+++ b/packages/web-access/index.ts
@@ -359,14 +359,16 @@ export default function webAccess(pi: ExtensionAPI) {
 		description: "Fetch URL(s) and extract readable content as markdown. Supports YouTube video transcripts (with thumbnail), GitHub repository contents, and local video files (with frame thumbnail). Video frames can be extracted via timestamp/range or sampled across the entire video with frames alone. Falls back to Gemini for pages that block bots or fail Readability extraction. For YouTube and video files: ALWAYS pass the user's specific question via the prompt parameter — this directs the AI to focus on that aspect of the video, producing much better results than a generic extraction. Content is always stored and can be retrieved with get_search_content.",
 		promptSnippet: "Use to extract readable content from URL(s), YouTube, GitHub repos, or local videos. For video questions, pass the user's exact question in prompt.",
 		parameters: Type.Object({
-			url: Type.Optional(Type.String({ description: "Single URL to fetch" })),
-			urls: Type.Optional(Type.Array(Type.String(), { description: "Multiple URLs (parallel)" })),
+			urls: Type.Array(Type.String({ minLength: 1 }), {
+				minItems: 1,
+				description: 'URLs or local video paths to fetch. Always use an array, even for one URL: {"urls":["https://example.com"]}. Multiple URLs are fetched in parallel.',
+			}),
 			forceClone: Type.Optional(Type.Boolean({ description: "Force cloning large GitHub repositories that exceed the size threshold" })),
 			prompt: Type.Optional(Type.String({ description: "Question or instruction for video analysis (YouTube and video files)." })),
 			timestamp: Type.Optional(Type.String({ description: "Extract video frame(s) at a timestamp or time range." })),
 			frames: Type.Optional(Type.Integer({ minimum: 1, maximum: 12, description: "Number of frames to extract." })),
 			model: Type.Optional(Type.String({ description: "Override the Gemini model for video/YouTube analysis." })),
-		}),
+		}, { additionalProperties: false }),
 		execute: (...args) => executeHeavyTool(loadHeavy, "fetch_content", args),
 		renderResult: (...args) => renderHeavyToolResult(loadedHeavy?.heavy ?? null, "fetch_content", args),
 	});

--- a/test/unit/web-access-fetch-urls.test.ts
+++ b/test/unit/web-access-fetch-urls.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@bastani/atomic";
+import { validateToolArguments } from "@bastani/pi-ai";
+import { Value } from "typebox/value";
+import { test, vi } from "vitest";
+
+interface ExtractedContent {
+	url: string;
+	title: string;
+	content: string;
+	error: string | null;
+}
+
+interface ContentToolsModule {
+	registerContentTools(
+		pi: ExtensionAPI,
+		deps: {
+			maxInlineContent: number;
+			stripThumbnails(results: ExtractedContent[]): ExtractedContent[];
+			formatFullResults(): string;
+		},
+	): void;
+}
+
+interface WebAccessModule {
+	default(pi: ExtensionAPI): void;
+}
+
+const fetchAllContent = vi.hoisted(() =>
+	vi.fn(async (urls: string[]) =>
+		urls.map((url) => ({
+			url,
+			title: "Example",
+			content: "Example content",
+			error: null,
+		})),
+	),
+);
+vi.mock("../../packages/web-access/extract.js", () => ({ fetchAllContent }));
+vi.mock("../../packages/web-access/code-search.js", () => ({ executeCodeSearch: vi.fn() }));
+vi.mock("../../packages/web-access/storage.js", () => ({
+	generateId: () => "fetch-test",
+	getResult: vi.fn(),
+	storeResult: vi.fn(),
+}));
+
+// Keep excluded legacy web-access sources out of the root typecheck, while testing the real modules.
+const { registerContentTools } = await vi.importActual<ContentToolsModule>(
+	"../../packages/web-access/content-tools.js",
+);
+const { default: registerWebAccess } = await vi.importActual<WebAccessModule>("../../packages/web-access/index.js");
+
+function capture(register: (pi: ExtensionAPI) => void): ToolDefinition {
+	const tools: ToolDefinition[] = [];
+	const pi: Pick<ExtensionAPI, "registerTool" | "on" | "registerShortcut" | "registerCommand" | "appendEntry"> = {
+		registerTool: (tool) => {
+			tools.push(tool);
+		},
+		on: () => {},
+		registerShortcut: () => {},
+		registerCommand: () => {},
+		appendEntry: () => {},
+	};
+	register(pi as ExtensionAPI);
+	const tool = tools.find((tool) => tool.name === "fetch_content");
+	assert.ok(tool);
+	return tool;
+}
+
+const registrations = {
+	lazy: () => capture(registerWebAccess),
+	heavy: () =>
+		capture((pi) =>
+			registerContentTools(pi, {
+				maxInlineContent: 1000,
+				stripThumbnails: (results) => results,
+				formatFullResults: () => "",
+			}),
+		),
+};
+
+for (const [name, register] of Object.entries(registrations)) {
+	test(`${name} fetch_content requires one nonempty urls array`, () => {
+		const { parameters } = register();
+		assert.ok(
+			"properties" in parameters && typeof parameters.properties === "object" && parameters.properties !== null,
+		);
+		assert.equal("url" in parameters.properties, false);
+		for (const input of [
+			{},
+			{ url: "https://example.com" },
+			{ URLs: ["https://example.com"] },
+			{ urls: [] },
+			{ urls: "https://example.com" },
+			{ urls: [{ url: "https://example.com" }] },
+			{ urls: [""] },
+			{ urls: ["https://example.com"], url: "https://other.example" },
+		]) {
+			assert.equal(Value.Check(parameters, input), false, JSON.stringify(input));
+			if (typeof input.urls !== "string") {
+				const tool = register();
+				assert.throws(
+					() =>
+						validateToolArguments(tool, {
+							type: "toolCall",
+							id: "invalid",
+							name: tool.name,
+							arguments: input,
+						}),
+					/Validation failed for tool "fetch_content"/,
+				);
+			}
+		}
+		for (const urls of [
+			["https://example.com"],
+			["https://example.com", "https://other.example"],
+			["/tmp/video.mp4"],
+		]) {
+			assert.equal(Value.Check(parameters, { urls }), true);
+		}
+	});
+
+	test(`${name} fetch_content retains host normalization of a scalar urls string`, () => {
+		const tool = register();
+		assert.deepEqual(
+			validateToolArguments(tool, {
+				type: "toolCall",
+				id: "scalar",
+				name: tool.name,
+				arguments: { urls: "https://example.com" },
+			}),
+			{ urls: ["https://example.com"] },
+		);
+	});
+}
+
+test("fetch_content passes single and multiple URLs to extraction unchanged", async () => {
+	const tool = registrations.heavy();
+	for (const urls of [["https://example.com"], ["https://example.com", "https://other.example"]]) {
+		const result = await tool.execute(
+			"test",
+			{ urls },
+			new AbortController().signal,
+			undefined,
+			{} as ExtensionContext,
+		);
+		assert.deepEqual(fetchAllContent.mock.lastCall?.[0], urls);
+		assert.ok(typeof result.details === "object" && result.details !== null && "successful" in result.details);
+		assert.equal(result.details.successful, urls.length);
+	}
+});


### PR DESCRIPTION
## Summary

Simplify `fetch_content` to one required `urls` array, so agents no longer choose between two optional fields with silent precedence.

## Changes

- Require a nonempty array of nonempty strings in both lazy and heavy tool registrations, with an inline single-URL example.
- Reject unknown fields, including conflicting `url` + `urls`, before fetching.
- Remove the execution fallback to singular `url`; keep historical call rendering unchanged.
- Migrate bundled researcher examples and the web-access README; add an Atomic user guide and breaking-change release note.
- Test both schemas, the actual host validator, and single/batch extraction dispatch.

## Breaking Changes

Replace `fetch_content({ url: "https://example.com" })` with `fetch_content({ urls: ["https://example.com"] })`.

Atomic's existing argument normalization still converts a scalar `urls` string to a one-item array. No global validation behavior changes. `get_search_content` retains its existing selectors.

## Validation

- `npm run build` passed.
- `npx vitest run --project unit test/unit/web-access-fetch-urls.test.ts test/unit/web-access-flat-string.test.ts test/unit/web-search-features-error-path.test.ts test/unit/web-search-resolve-workflow.test.ts` passed: 15 tests across 4 files.
- `npm run check` passed, including both typecheck passes and shrinkwrap validation.
- `git diff --check` passed.

Provider requests are mocked in the dispatch regression test; this change does not modify provider extraction behavior. Work was done in the separate `../atomic-fetch-urls` worktree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791764944&installation_model_id=10562&pr_number=2997&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2997&signature=9f8ed8656a51b8347fca7ce8847b5791cbe92ee41856ea56838c183d66e6f217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63324786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The implementation changes are safe to merge, but the packaged README should link to reachable migration guidance before release. This documentation issue does not affect runtime behavior.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Fix packaged guide link** <a href="https://github.com/bastani-inc/atomic/pull/2997#discussion_r3994427338">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
packages/web-access/README.md:121
This relative link assumes the monorepo layout. In the published web-access package, the README is at the package root but the linked coding-agent guide is not included, so the link resolves to a missing file. This is a non-blocking documentation concern, but users following the breaking-change guidance from the installed package cannot reach the migration instructions. Use a stable public URL or package the guide alongside this README.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- This PR standardizes `fetch_content` on a nonempty `urls` array, updates bundled guidance and examples, and adds regression coverage for argument validation and dispatch behavior.
- One documentation issue remains: the web-access package README links to migration guidance that is not included in the published package.

<sub>Reviews (1) · Last reviewed commit: ["fix(web-access)!: require one urls array..."](https://github.com/bastani-inc/atomic/commit/39f6049bbe967e1c5c4e4986a49aaca863e5b62d)</sub>

<!-- /greptile_comment -->