### PR TITLE
fix(ci): align bundled web-access contracts and metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10988,7 +10988,7 @@
         "@earendil-works/pi-protocol": "0.85.1",
         "@earendil-works/pi-tui": "0.85.1",
         "@modelcontextprotocol/ext-apps": "^1.7.5",
-        "@modelcontextprotocol/sdk": "^1.30.0",
+        "@modelcontextprotocol/sdk": "1.30.0",
         "@mozilla/readability": "^0.6.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "6.0.0",

--- a/packages/coding-agent/docs/docs.json
+++ b/packages/coding-agent/docs/docs.json
@@ -70,6 +70,7 @@
         "pages": [
           "tools",
           "tools/edit",
+          "web-access",
           "session-format"
         ]
       },

--- a/packages/coding-agent/npm-shrinkwrap.json
+++ b/packages/coding-agent/npm-shrinkwrap.json
@@ -17,7 +17,7 @@
 				"@earendil-works/pi-protocol": "0.85.1",
 				"@earendil-works/pi-tui": "0.85.1",
 				"@modelcontextprotocol/ext-apps": "^1.7.5",
-				"@modelcontextprotocol/sdk": "^1.30.0",
+				"@modelcontextprotocol/sdk": "1.30.0",
 				"@mozilla/readability": "^0.6.0",
 				"@silvia-odwyer/photon-node": "0.3.4",
 				"chalk": "6.0.0",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -87,7 +87,7 @@
     "@earendil-works/pi-protocol": "0.85.1",
     "@earendil-works/pi-tui": "0.85.1",
     "@modelcontextprotocol/ext-apps": "^1.7.5",
-    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@mozilla/readability": "^0.6.0",
     "@silvia-odwyer/photon-node": "0.3.4",
     "chalk": "6.0.0",

--- a/packages/coding-agent/test/suite/regressions/1728-web-access-native-heavy-import.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1728-web-access-native-heavy-import.test.ts
@@ -6,10 +6,12 @@ import { describe, expect, it } from "vitest";
 const repoRoot = resolve(__dirname, "../../../../..");
 
 describe("regression #1728 web-access native heavy import", () => {
-	it("loads the real heavy graph before returning normal lazy-tool validation errors", () => {
+	it("loads the real heavy graph and returns normal lazy-tool errors with the current fetch contract", () => {
 		const extensionUrl = pathToFileURL(resolve(repoRoot, "packages/web-access/index.ts")).href;
 		const script = `
 const { default: webAccess } = await import(${JSON.stringify(extensionUrl)});
+const assert = (await import("node:assert/strict")).default;
+const { validateToolArguments } = await import("@earendil-works/pi-ai");
 const tools = new Map();
 const pi = {
   registerTool(tool) { tools.set(tool.name, tool); },
@@ -17,12 +19,21 @@ const pi = {
   registerShortcut() {},
   registerMessageRenderer() {},
   on() {},
+  appendEntry() {},
 };
 webAccess(pi);
+// Missing, legacy singular, and empty inputs fail at the host boundary, before execute.
+const fetchTool = tools.get("fetch_content");
+for (const args of [{}, { url: "https://example.com" }, { urls: [] }, { urls: [""] }]) {
+  assert.throws(
+    () => validateToolArguments(fetchTool, { type: "toolCall", id: "invalid-fetch", name: "fetch_content", arguments: args }),
+    /Validation failed for tool "fetch_content":.*urls/s,
+  );
+}
 const calls = [
   ["web_search", {}],
   ["code_search", { repoName: "owner/repo", query: "" }],
-  ["fetch_content", {}],
+  ["fetch_content", { urls: ["not-a-url"] }],
   ["get_search_content", { responseId: "missing-1728-regression" }],
 ];
 const signal = new AbortController().signal;
@@ -30,6 +41,10 @@ const results = {};
 for (const [name, params] of calls) {
   const tool = tools.get(name);
   if (!tool?.execute) throw new Error("Web-access lazy tool was not registered: " + name);
+  // A nonempty string is schema-valid, but URL parsing fails without network access.
+  if (name === "fetch_content") {
+    validateToolArguments(tool, { type: "toolCall", id: "1728-fetch", name, arguments: params });
+  }
   const result = await tool.execute("1728-" + name, params, signal, undefined, undefined);
   results[name] = result;
 }
@@ -55,8 +70,15 @@ console.log(JSON.stringify(results));
 			details: { error: "No query provided" },
 		});
 		expect(output.fetch_content).toMatchObject({
-			content: [{ type: "text", text: "Error: No URL provided." }],
-			details: { error: "No URL provided" },
+			content: [{ type: "text", text: "Error: Invalid URL" }],
+			details: {
+				outcome: "all_failed",
+				stage: "fetch",
+				urls: ["not-a-url"],
+				urlCount: 1,
+				successful: 0,
+				error: "Invalid URL",
+			},
 		});
 		expect(output.get_search_content).toMatchObject({
 			content: [{ type: "text", text: 'Error: No stored results for "missing-1728-regression"' }],

--- a/test/ci/fast-model-identity-contracts.test.ts
+++ b/test/ci/fast-model-identity-contracts.test.ts
@@ -191,6 +191,11 @@ const proseNames = new Set([
 	"openai",
 	"anthropic",
 	// Parameter and request-field names, never exports.
+	// PR #2998 names bundled web-access tools and their parameters, not package-root exports.
+	"code_search",
+	"web_search",
+	"repoName",
+	"query",
 	// Subagent tool/action names and targeting fields are not package-root exports.
 	"subagent",
 	"interrupt",


### PR DESCRIPTION
## Summary

Repair the four remaining failure classes from [CI run 34663257699](https://github.com/bastani-inc/atomic/actions/runs/34663257699), using current main after #2995 and preserving the intentional web-access APIs from #2997 and #2998.

## Changes

- Classify `code_search`, `web_search`, `repoName`, and `query` as tool/argument names in the changelog contract, rather than package-root exports. Export assertions remain intact.
- Pin the host MCP SDK to `1.30.0`, matching bundled requirements in the manifest, package lock, and shrinkwrap. Resolved dependencies do not change.
- Restore the existing `web-access` page to documentation navigation.
- Update the native-heavy lazy-loading regression for required `urls`. Reject missing, legacy singular, and empty inputs through host validation, then exercise real lazy extraction with a schema-valid malformed URL and assert structured failure details.

Six files changed, 35 insertions and 7 deletions. No production web-access source, CI configuration, platform coverage, shared timeouts, suite concurrency, or package versions changed. No release or publication is included.

## Validation

Candidate: `7e7fab3b8a76f30a78e4a5e5c3247eb804c30b9d`.

The implementation receipt and three independent workflow reviewers report passing validation. The PR preparation stage inspected the focused-test and typecheck/shrinkwrap logs without rerunning expensive checks.

| Check | Result |
| --- | --- |
| Focused changelog CI contracts | 6 passed |
| Unmodified package metadata tests | 13 passed |
| Documentation and native-heavy regression tests | 2 passed |
| CI-contract project | 97 passed, implementation receipt |
| Web-access preservation tests | 33 passed, reviewer evidence |
| Real DeepWiki HTTP integration | 1 passed, reviewer evidence |
| Focused #2995 diagnostic regressions | 22 passed, implementation receipt |
| `npm run check` and commit hooks | Passed, implementation receipt |
| Independent typecheck and shrinkwrap verification | Passed, inspected log |
| `git diff origin/main...HEAD --check` | Passed during PR preparation |

The native regression runs a real Bun child and lazy extraction. Reviewers also exercised schema rejection, permitted raw inputs, ordering/duplicates, and cancellation. No UI behavior changed, so no browser or terminal recording is claimed.

## Review and remaining gate

Goal `0f8d3c04-e56d-41bc-a9dd-9d6e1f573117` reached candidate approval with three independent approvals, no findings, and no unresolved blockers. The ledger, implementation receipt, and latest review round informed this description. Their approval is local candidate evidence, not remote CI or merge success.

The parent must resolve actual PR CI failures, verify all expected and required checks for the exact head, including Windows, then merge that head into main without admin bypass. Remote CI and merge remain unverified at creation.

## Contract amendments received

User-authored amendments supersede the original local-suite prohibition:

> Full local test suites are now permitted when they provide a tighter feedback loop than remote CI. This supersedes every earlier prohibition on entire local suites in workflow inputs, objectives, acceptance criteria, and stage prompts. Use focused tests first where useful, then broader local suites when worthwhile. Do not treat full-suite execution as a requirement or repeat expensive suites without reason. All other scope, test-rigor, exact-head CI gates, and no-admin-bypass merge requirements remain unchanged.

> Use current main and intentional merged API changes as the contract. If history and source confirm fetch_content now requires urls, fix stale tests to exercise the new valid input contract while preserving meaningful invalid-input coverage; do not revert the intended API merely to satisfy old assertions. Continue bounded diagnosis and repair with focused or full local suites as useful. No success claim until evidence is verified. Escalate only a material unresolved product decision, not a stale-test update supported by history.

PR-stage authorization clarification:

> Do not infer lack of usable auth from gh auth status alone. Try the same read-only API/list commands using /home/coder/.local/bin/gh. If they succeed, proceed with the already-authorized PR creation through that CLI and read back exact head. Do not inspect, copy, or transmit credentials. If actual API access fails, report the exact non-secret error and preserve prepared PR body.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/2999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791768991&installation_model_id=10562&pr_number=2999&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F2999&signature=7e851a4c7e5ece23b9c2e33dd4a6f8b3bf0af54bf97d8101f8fc24ad46edaf77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63337318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

No merge-blocking issues were identified; the dependency metadata synchronization check passed.

What we checked:
- Attempted the focused web-access regression and the focused changelog identifier contract; the web-access test halted before tool registration due to no workspace build output from the binding, and the changelog contract halted because the required compatibility package was unavailable. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- A prerequisite check confirmed that the missing amazon-bedrock.json blocks building the pi-ai workspace alias. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- A shrinkwrap synchronization check was run and reported that packages/coding-agent/npm-shrinkwrap.json is up to date. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The after-logs were reviewed to verify the exact command sources and the post-run outputs for the web-access regression and the fast-model-identity-contracts tests. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The prerequisite blocker log was reviewed to confirm that missing amazon-bedrock.json is the root cause of the workspace build failure. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- Pins `@modelcontextprotocol/sdk` to `1.30.0` consistently in the coding-agent manifest, root lockfile, and published shrinkwrap.
- Restores the existing web-access guide to the coding-agent documentation navigation.
- Updates web-access regression coverage and changelog terminology handling for the current bundled tool contracts.

## T-Rex validation blocked
- The focused web-access regression and changelog contract could not complete because the workspace `@bastani/pi-ai` build output is unavailable. Building it is blocked by the missing `packages/ai/src/providers/data/amazon-bedrock.json` prerequisite. The shrinkwrap synchronization check completed successfully.

<sub>Reviews (1) · Last reviewed commit: ["fix(ci): align bundled web-access contra..."](https://github.com/bastani-inc/atomic/commit/7e7fab3b8a76f30a78e4a5e5c3247eb804c30b9d)</sub>

<!-- /greptile_comment -->