### PR TITLE
docs(release): prepare 0.9.19-alpha.6 changelogs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.6] - 2026-09-11
+
 ### Breaking Changes
 
 - `write` no longer silently overwrites a file this session has never seen. Replacing an existing file now requires the session to have already observed exactly the content being replaced, checked under the same per-file mutation queue as the write. A session with no version of its own is refused with `no_prior_observation`; one whose recorded version no longer matches the file on disk is refused with `changed_since_observation` and told which line diverged, what it assumed was there, and what the file holds instead. Both carry the same `FILE_MUTATION_CONFLICT` code and requester identity as an `edit` conflict. Creating a new file, and overwriting one this session read, wrote, or edited, are unaffected ([#2329](https://github.com/bastani-inc/atomic/issues/2329)).

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.19-alpha.6] - 2026-09-11
+
 ### Fixed
 
 - A broker refusal received by an already-registered client now rejects that client's outstanding requests with the broker's own reason instead of being discarded. Previously the refusal was delivered to a listener that `connect()` removes after registration, so pipelined work — notably the session-directory barrier behind workflow route updates — waited out its five-second timer and surfaced `List sessions timeout` or a generic disconnect. Reasons such as `Pending-stage route is not authorized` now reach callers as non-recoverable errors, and the `disconnected` event carries the same cause. Pre-registration rejection, transport-disconnect classification, and explicit shutdown are unchanged.

--- a/packages/subagents/CHANGELOG.md
+++ b/packages/subagents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.6] - 2026-09-11
+
 ### Changed
 
 - Delegation guidance now favors keeping immediately blocking work local unless specialist expertise, context isolation, or an explicit request warrants a child. Parents are guided to continue independent work and wait on dependencies rather than repeatedly polling. Background launch defaults and explicit foreground waits are unchanged.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.19-alpha.6] - 2026-09-11
+
 ### Breaking Changes
 
 - `fetch_content` now requires a nonempty `urls` array of nonempty strings for both single and batch requests. Replace `{ url: "..." }` with `{ urls: ["..."] }`. Invalid argument shapes and unrecognized fields are rejected before fetching; the `get_search_content` selectors are unchanged.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.19-alpha.6] - 2026-09-11
+
 ### Fixed
 
 - Workflow stage routes are no longer republished to the broker when nothing about the route changed. Every store invalidation — including tool events, attachment changes, and notices that leave the route projection identical — previously re-announced every run, so a burst of unrelated activity could produce a thousand redundant broker round trips and surface as `Intercom event relay failed (atomic:workflow-pending-stage-route): List sessions timeout`. Genuine changes still publish immediately and are never debounced, and an announcement that is rejected or that no consumer acknowledges is retried on the next invalidation.


### PR DESCRIPTION
## Summary

Prepare prerelease 0.9.19-alpha.6 by moving existing Unreleased notes into dated sections in the coding-agent, intercom, subagents, web-access, and workflows changelogs. Existing notes and previously released history are unchanged.

## Validation

- Confirmed one changelog-only commit touching exactly the five prepared files, adding only a release heading and blank line to each.
- All eight workspace package manifests and lock entries remain at 0.0.0, along with the native dependency pin, Cargo workspace and lock versions, shrinkwrap versions, and generated native version checks. No manifests, lockfiles, Cargo files, or generated version files changed.
- `bun run test:unit -- test/unit/changelog.test.ts test/unit/build-release-notes.test.ts`: 19 tests passed.
- `bun run scripts/build-release-notes.ts 0.9.19-alpha.6`: combined release notes generated successfully.
- `bun run check`: passed, including typechecks and shrinkwrap verification. Two existing informational Biome diagnostics were left unchanged.
- Commit hooks and `git diff --check`: passed. Post-commit validation confirmed a clean worktree and the exact changelog-only scope.

## Release boundary

This PR changes release notes only. After merge, only `scripts/cut-release.ts` may stamp 0.9.19-alpha.6 on the detached Release commit. Pushing the version tag directly starts `publish.yml`; no duplicate normal publication dispatch is needed. This stage does not merge, tag, or publish.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/3000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791772713&installation_model_id=10562&pr_number=3000&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F3000&signature=a68eb34a2d6b5742c81ac31441bf6d24bd20c51ebe5574ff731720cd512bc230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63347469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge; the release-note generation path correctly discovers and renders all five new release sections.

What we checked:
- Authored the release-notes-0-9-19-alpha-6-validation.sh script to perform the validation. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Executed the script with execute permissions, capturing the real command, working directory, exit code, stdout, and stderr as part of the validation run. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Created three artifacts documenting the run: a shellscript source artifact and two URL-linked logs. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validated that the run recorded attribution assertions as part of the validation output. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- The five package changelogs now place their existing release notes under `0.9.19-alpha.6` while leaving `Unreleased` ready for future changes. Generated release notes include the new sections from coding-agent, intercom, subagents, web-access, and workflows.

<sub>Reviews (1) · Last reviewed commit: ["docs(release): prepare 0.9.19-alpha.6 ch..."](https://github.com/bastani-inc/atomic/commit/c1c8dc31e3585918e2b871cc535adb74944788df)</sub>

<!-- /greptile_comment -->