### PR TITLE
fix(web-access): make batch fetch failures actionable

### DIFF
--- a/packages/coding-agent/docs/web-access.md
+++ b/packages/coding-agent/docs/web-access.md
@@ -35,4 +35,6 @@ If argument validation fails, check that:
 - The array contains at least one nonempty string.
 - The call has no unrecognized fields.
 
+If every URL in a batch fails, the error lists each URL and its cause. Check the URLs and retry transient failures individually with `fetch_content({ urls: ["<failed URL>"] })`. For blocked pages or repeated extraction failures, try an accessible alternate URL or use `web_search`. `get_search_content` cannot recover content from a failed fetch.
+
 When fetched content is truncated, follow the returned `get_search_content` call to retrieve the stored content.

--- a/packages/coding-agent/docs/web-access.md
+++ b/packages/coding-agent/docs/web-access.md
@@ -35,6 +35,6 @@ If argument validation fails, check that:
 - The array contains at least one nonempty string.
 - The call has no unrecognized fields.
 
-If every URL in a batch fails, the error lists each URL and its cause. Check the URLs and retry transient failures individually with `fetch_content({ urls: ["<failed URL>"] })`. For blocked pages or repeated extraction failures, try an accessible alternate URL or use `web_search`. `get_search_content` cannot recover content from a failed fetch.
+If every URL in a batch fails, the error lists each URL and its cause. Extraction errors may still include partial content, shown as incomplete excerpts. Check the URLs and retry transient failures individually with `fetch_content({ urls: ["<failed URL>"] })`. For blocked pages or repeated extraction failures, try an accessible alternate URL or use `web_search`. `get_search_content` cannot recover missing content from a failed fetch.
 
 When fetched content is truncated, follow the returned `get_search_content` call to retrieve the stored content.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- `fetch_content` now shows each URL's error and recovery steps when an entire batch fails, instead of hiding the causes behind a generic failure count or suggesting retrieval of content that was not fetched.
+- `fetch_content` now shows each URL's error and recovery steps when an entire batch fails, instead of hiding the causes behind a generic failure count. Retained partial content is shown as incomplete excerpts rather than incorrectly reported as absent.
 
 ## [0.9.19-alpha.6] - 2026-09-11
 

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `fetch_content` now shows each URL's error and recovery steps when an entire batch fails, instead of hiding the causes behind a generic failure count or suggesting retrieval of content that was not fetched.
+
 ## [0.9.19-alpha.6] - 2026-09-11
 
 ### Breaking Changes

--- a/packages/web-access/content-tools.ts
+++ b/packages/web-access/content-tools.ts
@@ -174,13 +174,20 @@ export function registerContentTools(pi: ExtensionAPI, deps: RegisterContentTool
 					output += `- ${title || url} (${content.length} chars)\n`;
 				}
 			}
-			output += `\n---\nUse get_search_content({ responseId: "${responseId}", urlIndex: 0 }) to retrieve full content.`;
-
 			const allFailed = successful === 0;
+			if (allFailed) {
+				output = `All ${urlList.length} URL fetch(es) failed. No content was retrieved.\n\n${output}` +
+					"\nCheck each URL and its error above. Retry transient failures individually with " +
+					'fetch_content({ urls: ["<failed URL>"] }). If access is blocked or extraction keeps failing, ' +
+					"try an accessible alternate URL or use web_search to find the information. " +
+					"get_search_content cannot recover content from these failed fetches.";
+			} else {
+				output += `\n---\nUse get_search_content({ responseId: "${responseId}", urlIndex: 0 }) to retrieve full content.`;
+			}
 			return {
 				content: [{ type: "text", text: output }],
 				details: {
-					...(allFailed ? { outcome: "all_failed", stage: "fetch", error: `All ${urlList.length} URL fetch(es) failed`, failedUrls: urlList.length } : {}),
+					...(allFailed ? { outcome: "all_failed", stage: "fetch", error: output, failedUrls: urlList.length } : {}),
 					urls: urlList, urlCount: urlList.length, successful, totalChars, responseId,
 				},
 			};

--- a/packages/web-access/content-tools.ts
+++ b/packages/web-access/content-tools.ts
@@ -170,17 +170,27 @@ export function registerContentTools(pi: ExtensionAPI, deps: RegisterContentTool
 			for (const { url, title, content, error } of fetchResults) {
 				if (error) {
 					output += `- ${url}: Error - ${error}\n`;
+					if (content.length > 0) {
+						output += `\nPartial content (incomplete):\n${content.slice(0, deps.maxInlineContent)}\n`;
+						if (content.length > deps.maxInlineContent) output += "[Partial content truncated...]\n";
+						output += "\n";
+					}
 				} else {
 					output += `- ${title || url} (${content.length} chars)\n`;
 				}
 			}
 			const allFailed = successful === 0;
 			if (allFailed) {
-				output = `All ${urlList.length} URL fetch(es) failed. No content was retrieved.\n\n${output}` +
+				const contentStatus = totalChars > 0
+					? "Partial content was retained; extraction is incomplete."
+					: "No content was retrieved.";
+				output = `All ${urlList.length} URL fetch(es) failed. ${contentStatus}\n\n${output}` +
 					"\nCheck each URL and its error above. Retry transient failures individually with " +
 					'fetch_content({ urls: ["<failed URL>"] }). If access is blocked or extraction keeps failing, ' +
 					"try an accessible alternate URL or use web_search to find the information. " +
-					"get_search_content cannot recover content from these failed fetches.";
+					(totalChars > 0
+						? "get_search_content cannot recover the missing content; use the incomplete excerpts above with caution."
+						: "get_search_content cannot recover content from these failed fetches.");
 			} else {
 				output += `\n---\nUse get_search_content({ responseId: "${responseId}", urlIndex: 0 }) to retrieve full content.`;
 			}

--- a/test/unit/web-access-fetch-urls.test.ts
+++ b/test/unit/web-access-fetch-urls.test.ts
@@ -27,13 +27,14 @@ interface WebAccessModule {
 }
 
 const fetchAllContent = vi.hoisted(() =>
-	vi.fn(async (urls: string[]) =>
-		urls.map((url) => ({
-			url,
-			title: "Example",
-			content: "Example content",
-			error: null,
-		})),
+	vi.fn(
+		async (urls: string[]): Promise<ExtractedContent[]> =>
+			urls.map((url) => ({
+				url,
+				title: "Example",
+				content: "Example content",
+				error: null,
+			})),
 	),
 );
 vi.mock("../../packages/web-access/extract.js", () => ({ fetchAllContent }));
@@ -148,4 +149,44 @@ test("fetch_content passes single and multiple URLs to extraction unchanged", as
 		assert.ok(typeof result.details === "object" && result.details !== null && "successful" in result.details);
 		assert.equal(result.details.successful, urls.length);
 	}
+});
+
+test("fetch_content reports each failed URL and recovery steps when a batch fails", async () => {
+	const urls = ["https://example.com/blocked", "https://example.com/timeout"];
+	fetchAllContent.mockResolvedValueOnce([
+		{ url: urls[0], title: "", content: "", error: "HTTP 403 Forbidden" },
+		{ url: urls[1], title: "", content: "", error: "Request timed out" },
+	]);
+	const result = await registrations
+		.heavy()
+		.execute("test", { urls }, new AbortController().signal, undefined, {} as ExtensionContext);
+	assert.ok(typeof result.details === "object" && result.details !== null && "error" in result.details);
+	const error = result.details.error;
+	assert.equal(typeof error, "string");
+	assert.match(String(error), /All 2 URL fetch\(es\) failed\. No content was retrieved/);
+	assert.match(String(error), /https:\/\/example.com\/blocked: Error - HTTP 403 Forbidden/);
+	assert.match(String(error), /https:\/\/example.com\/timeout: Error - Request timed out/);
+	assert.match(String(error), /fetch_content\(\{ urls: \["<failed URL>"\] \}\)/);
+	assert.match(String(error), /web_search/);
+	assert.match(String(error), /get_search_content cannot recover content/);
+	assert.doesNotMatch(String(error), /to retrieve full content/);
+	assert.deepEqual(result.content, [{ type: "text", text: error }]);
+});
+
+test("fetch_content preserves successful content retrieval guidance for mixed batches", async () => {
+	const urls = ["https://example.com/good", "https://example.com/blocked"];
+	fetchAllContent.mockResolvedValueOnce([
+		{ url: urls[0], title: "Good page", content: "Readable content", error: null },
+		{ url: urls[1], title: "", content: "", error: "HTTP 403 Forbidden" },
+	]);
+	const result = await registrations
+		.heavy()
+		.execute("test", { urls }, new AbortController().signal, undefined, {} as ExtensionContext);
+	assert.ok(typeof result.details === "object" && result.details !== null);
+	assert.equal("error" in result.details, false);
+	const text = result.content.find((item) => item.type === "text");
+	assert.ok(text?.type === "text");
+	assert.match(text.text, /Good page/);
+	assert.match(text.text, /HTTP 403 Forbidden/);
+	assert.match(text.text, /get_search_content.*to retrieve full content/);
 });

--- a/test/unit/web-access-fetch-urls.test.ts
+++ b/test/unit/web-access-fetch-urls.test.ts
@@ -173,6 +173,33 @@ test("fetch_content reports each failed URL and recovery steps when a batch fail
 	assert.deepEqual(result.content, [{ type: "text", text: error }]);
 });
 
+// PR #3002: extraction errors can retain useful partial markdown.
+test("fetch_content exposes retained excerpts when every extraction reports an error", async () => {
+	const urls = ["https://example.com/empty", "https://example.com/partial"];
+	for (const firstContent of ["", "First retained excerpt"]) {
+		fetchAllContent.mockResolvedValueOnce([
+			{ url: urls[0], title: "", content: firstContent, error: "Incomplete extraction" },
+			{ url: urls[1], title: "", content: "Retained evidence " + "x".repeat(1100), error: "Incomplete extraction" },
+		]);
+		const result = await registrations
+			.heavy()
+			.execute("test", { urls }, new AbortController().signal, undefined, {} as ExtensionContext);
+		assert.ok(typeof result.details === "object" && result.details !== null && "error" in result.details);
+		assert.ok("outcome" in result.details && result.details.outcome === "all_failed");
+		assert.ok("successful" in result.details && result.details.successful === 0);
+		const text = String(result.details.error);
+		assert.match(text, /Partial content was retained/);
+		assert.match(text, /https:\/\/example.com\/partial: Error - Incomplete extraction/);
+		assert.match(text, /Partial content \(incomplete\):\nRetained evidence/);
+		assert.match(text, /Partial content truncated/);
+		assert.doesNotMatch(text, /x{1001}/);
+		if (firstContent) assert.ok(text.includes(firstContent));
+		assert.doesNotMatch(text, /No content was retrieved|cannot recover content from these failed fetches/);
+		assert.match(text, /Retry transient failures/);
+		assert.deepEqual(result.content, [{ type: "text", text }]);
+	}
+});
+
 test("fetch_content preserves successful content retrieval guidance for mixed batches", async () => {
 	const urls = ["https://example.com/good", "https://example.com/blocked"];
 	fetchAllContent.mockResolvedValueOnce([


### PR DESCRIPTION
## Summary

When every URL fails, fetch_content now shows the per-URL causes and recovery guidance instead of only a failure count. Fetching and fallback behavior are unchanged.

## Changes

- Include individual URL errors in the displayed error and model-visible response.
- Suggest checking URLs, retrying transient failures individually, or finding accessible alternatives with web_search.
- Stop suggesting full-content retrieval when nothing was fetched.
- Add regression tests, troubleshooting guidance, and a changelog entry.

## Notes

Validation passed:
- npm run test:unit -- test/unit/web-access-fetch-urls.test.ts (7 tests)
- npm run check
- All applicable pre-commit hooks

Implemented in the separate ../atomic-fetch-errors worktree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/3002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791784976&installation_model_id=10562&pr_number=3002&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F3002&signature=99c0c8f2590aa7d50a44d15402a69409ccdcb98e9cb74614178d655882f619d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63373472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

<h3>Summary</h3>

- Reports each failed URL and its individual error.
- Displays bounded, clearly marked excerpts retained from incomplete extractions.
- Provides retry and alternative-source guidance without suggesting unavailable full-content retrieval.
- Adds regression coverage, troubleshooting documentation, and a user-facing changelog entry.

<sub>Reviews (2) · Last reviewed commit: ["fix(web-access): retain excerpts from fa..."](https://github.com/bastani-inc/atomic/commit/78c35960979fddda40b8ec73694525ba734e4851)</sub>

<!-- /greptile_comment -->