### PR TITLE
docs: require issue approval before external contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Thanks for your interest in contributing to Atomic. This guide explains how to p
 
 For every external contribution, first open a proposal issue for a new idea or discuss an existing issue with your intended approach. Wait for explicit maintainer approval of the proposed scope before implementing it and opening a pull request. This applies to all changes, including small fixes and documentation-only changes, and to draft pull requests.
 
-Opening an issue, expressing interest, silence, or assignment alone does not constitute scope approval. A maintainer will respond within 24 hours. An expression of interest alone does not reserve an issue.
+Opening an issue, expressing interest, silence, or assignment alone does not constitute scope approval. A maintainer will respond as soon as possible. An expression of interest alone does not reserve an issue.
 
 Assignments are normally held for seven days. Post a progress update if you need more time. Maintainers may release an assignment when there has been no activity.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,15 @@ Thanks for your interest in contributing to Atomic. This guide explains how to p
 
 ## Claiming an issue
 
-For external contributors, before starting substantial work on an existing issue, comment with your intended approach and wait for a maintainer to assign the issue or explicitly approve the work. A maintainer will respond within 24 hours. An expression of interest alone does not reserve an issue.
+For every external contribution, first open a proposal issue for a new idea or discuss an existing issue with your intended approach. Wait for explicit maintainer approval of the proposed scope before implementing it and opening a pull request. This applies to all changes, including small fixes and documentation-only changes, and to draft pull requests.
+
+Opening an issue, expressing interest, silence, or assignment alone does not constitute scope approval. A maintainer will respond within 24 hours. An expression of interest alone does not reserve an issue.
 
 Assignments are normally held for seven days. Post a progress update if you need more time. Maintainers may release an assignment when there has been no activity.
 
 Avoid competing pull requests for assigned issues. Coordinate with the assignee and a maintainer first; uncoordinated duplicate pull requests may be closed.
 
-Assignment reserves the opportunity to work on an issue but does not guarantee merge. Maintainers may work on issues and open pull requests without being assigned.
+Assignment reserves the opportunity to work on an issue but does not guarantee merge. Maintainers are exempt from this issue-first approval process and may work on issues and open pull requests without being assigned.
 
 ## Testing and checks
 
@@ -64,10 +66,12 @@ vitest runs test files concurrently and this repository sets no pool or worker l
 
 ## Pull requests
 
+External contributors must complete the issue discussion and explicit scope approval process above before opening any PR. PRs opened without prior approval may be closed pending discussion.
+
 When opening a PR:
 
 - Describe the problem and the solution clearly.
-- When applicable, link an issue with `Closes #<issue-number>` or `Related: #<issue-number>`.
+- External contributors must link the approved issue with `Closes #<issue-number>` or `Related: #<issue-number>`.
 - Include test output or explain why tests were not run.
 - Call out breaking changes, migration steps, or follow-up work.
 


### PR DESCRIPTION
## Summary

Make the issue-first approval process explicit for every external contribution. Contributors must discuss a proposal issue or an existing issue, obtain explicit maintainer approval of the proposed scope, then implement and open a PR linked to that approved issue.

## Changes

- Cover small fixes, documentation-only changes, and draft PRs without exceptions.
- Clarify that filing an issue, expressing interest, silence, or assignment alone is not scope approval, and that unapproved PRs may be closed pending discussion.
- Preserve the maintainer exemption, seven-day assignment and progress guidance, duplicate-work coordination, and the non-guarantee of merge.

Only `CONTRIBUTING.md` changes: 7 additions and 3 deletions. This is a maintainer-authorized policy update, not a retrospective judgment on existing contributions.

## Validation

- `git diff --check origin/main` and `git diff --cached --check origin/main` passed.
- Mandatory commit hooks, including `npm run check`, passed in an authorized clean same-repository worktree. The shared checkout contains pre-existing ignored audit artifacts that interfere with typechecking; those artifacts and repository configuration were left unchanged. The validated patch matches the delivered commit.
- Three independent reviewers approved with no remaining findings. Their checks covered new features, existing issues, typo/docs-only changes, unapproved draft PRs, assignment without explicit approval, and maintainer-authored PRs.
- No full product test suite or UI scenario was run for this prose-only change.

## Notes

Reviewed commit: `6c852b32a712dee83dfa373eb40aee357dad8a3b`.

Prepared for flora131 to review and merge. No merge is requested from automation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/3004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791790587&installation_model_id=10562&pr_number=3004&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F3004&signature=5a73935904794bfe2d3832f48dac8b760a323d511e844be36ed40cbb09daeaf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63383905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

<h3>Summary</h3>

- Makes explicit maintainer approval of scope mandatory before external contributors implement changes or open pull requests.
- Clarifies that opening an issue, expressing interest, silence, and assignment do not constitute approval.
- Requires external pull requests to link their approved issue while preserving the maintainer exemption.

No merge-blocking issues found.

<sub>Reviews (1) · Last reviewed commit: ["docs: remove fixed maintainer response d..."](https://github.com/bastani-inc/atomic/commit/22efeb8a1799999ff87b5b2044047507420f0dfe)</sub>

<!-- /greptile_comment -->