### PR TITLE
perf(tasks): optimize Windows live transcript rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,7 @@ If a user asks to publish a release or prerelease, route the request through the
 
 - ALWAYS keep the user-facing docs in `packages/coding-agent/docs` up-to-date with the latest changes after you make changes. Prefer to keep other docs up-to-date as well, but the coding-agent docs are the most important since they are user-facing and often consulted by users and other agents.
 - `packages/coding-agent/docs` is user-facing documentation. Explain how to use, configure, and troubleshoot Atomic. Do not include internal implementation details, test infrastructure, debugging histories, verification evidence, or maintainer-only design notes. Keep those in repository-level docs, code/test comments, or PR descriptions. Keep user guides concise and focused on what users need to know.
+- Update user guides only when a change affects how users use, configure, or troubleshoot Atomic. An internal optimization does not require a guide edit merely to say that something is faster, uses less CPU, or needs no configuration. If there is no actionable user guidance, leave the guide unchanged. Put user-visible performance improvements in the package changelog and measurements or implementation rationale in repository-level notes or the PR description.
 - To update docs, prefer using your `release-docs` workflow to thoroughly update all relevant docs with the latest changes. If you need to make a quick fix or update, you can also edit the markdown files directly, but make sure to keep them comprehensive and up-to-date.
 
 ## Changelog

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduced CPU work in long `/tasks` live transcripts on Windows by reusing unchanged message rendering during streaming, without dropping history or delaying live updates.
+
 ## [0.9.19-alpha.6] - 2026-09-11
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/subagents.md
+++ b/packages/coding-agent/docs/subagents.md
@@ -197,6 +197,8 @@ Transcript inspection uses a dedicated scrolling view with pinned identity, posi
 
 Open live transcripts subscribe to child-session events, so streaming text and partial/final tool results refresh without reopening the page or waiting for a task-activity counter. Earlier pages remain anchored while updates arrive. Leaving the transcript releases its subscription without affecting execution.
 
+Long live transcripts use less CPU during streaming on Windows without limiting retained history or slowing event updates. No configuration is required; scrolling and terminal resizing remain available while the child runs.
+
 Detail views pin task identity, state, available metrics, and the selected action while PageUp/PageDown scrolls the body. Recent activity shows up to five retained tool actions; errors and input requests appear explicitly. Left returns to the previous view. `x` requests cancellation without bypassing confirmation or configured task bindings. Shell inspection shows a bounded output tail with omission markers.
 
 After a confirmed `x` stop settles, the owning chat receives a visible **stopped** notification and the parent model receives the stop context, even if the child returns no final message. Repeated stops do not duplicate notifications or replace an already-recorded terminal result. Closing the owner still suppresses late completion delivery.

--- a/packages/coding-agent/docs/subagents.md
+++ b/packages/coding-agent/docs/subagents.md
@@ -197,8 +197,6 @@ Transcript inspection uses a dedicated scrolling view with pinned identity, posi
 
 Open live transcripts subscribe to child-session events, so streaming text and partial/final tool results refresh without reopening the page or waiting for a task-activity counter. Earlier pages remain anchored while updates arrive. Leaving the transcript releases its subscription without affecting execution.
 
-Long live transcripts use less CPU during streaming on Windows without limiting retained history or slowing event updates. No configuration is required; scrolling and terminal resizing remain available while the child runs.
-
 Detail views pin task identity, state, available metrics, and the selected action while PageUp/PageDown scrolls the body. Recent activity shows up to five retained tool actions; errors and input requests appear explicitly. Left returns to the previous view. `x` requests cancellation without bypassing confirmation or configured task bindings. Shell inspection shows a bounded output tail with omission markers.
 
 After a confirmed `x` stop settles, the owning chat receives a visible **stopped** notification and the parent model receives the stop context, even if the child returns no final message. Repeated stops do not duplicate notifications or replace an already-recorded terminal result. Closing the owner still suppresses late completion delivery.

--- a/packages/coding-agent/src/modes/interactive/components/task-live-transcript.ts
+++ b/packages/coding-agent/src/modes/interactive/components/task-live-transcript.ts
@@ -13,7 +13,9 @@ export class TaskLiveTranscript implements Component {
 	private readonly entries: ChatMessageEntry[];
 	private readonly live: LiveChatEntriesController;
 	private readonly unsubscribe?: () => void;
-	private components?: Component[];
+	// LiveChatEntriesController replaces changed entries, including in-place message deltas.
+	// Weak keys release superseded generations without retaining a cache of the stream.
+	private components = new WeakMap<ChatMessageEntry, Component>();
 	readonly source: TaskTranscriptSource;
 	private readonly requestRender: () => void;
 	constructor(source: TaskTranscriptSource, messages: AgentMessage[], requestRender: () => void) {
@@ -23,24 +25,28 @@ export class TaskLiveTranscript implements Component {
 		this.live = new LiveChatEntriesController(this.entries);
 		this.live.hydrateStreamingAssistantMessage(source.getStreamingMessage?.());
 		this.unsubscribe = source.subscribe?.((event) => {
-			if (this.live.applyEvent(event)) this.components = undefined;
+			this.live.applyEvent(event);
 			this.requestRender();
 		});
 	}
 	invalidate(): void {
-		this.components = undefined;
+		this.components = new WeakMap();
 	}
 	render(width: number): string[] {
-		this.components ??= this.entries.map((entry) =>
-			renderChatMessageEntry(entry, {
-				ui: { requestRender: this.requestRender },
-				cwd: process.cwd(),
-				hideThinkingBlock: true,
-				toolOutputExpanded: true,
-				showImages: false,
-			}),
-		);
-		return this.components.flatMap((component) => component.render(width));
+		return this.entries.flatMap((entry) => {
+			let component = this.components.get(entry);
+			if (!component) {
+				component = renderChatMessageEntry(entry, {
+					ui: { requestRender: this.requestRender },
+					cwd: process.cwd(),
+					hideThinkingBlock: true,
+					toolOutputExpanded: true,
+					showImages: false,
+				});
+				this.components.set(entry, component);
+			}
+			return component.render(width);
+		});
 	}
 	dispose(): void {
 		this.unsubscribe?.();

--- a/research/windows-task-transcript-baseline-preload.ts
+++ b/research/windows-task-transcript-baseline-preload.ts
@@ -1,0 +1,19 @@
+import { appendFileSync, readFileSync } from "node:fs";
+import { plugin } from "bun";
+
+// Baseline control only: substitute exactly one module without editing the checkout.
+const baseline = process.env.TASK_TERMINAL_BASELINE;
+if (baseline) {
+	plugin({
+		name: "task-transcript-baseline-control",
+		setup(build) {
+			build.onLoad({ filter: /[\\/]task-live-transcript\.ts$/ }, () => {
+				appendFileSync(
+					process.env.TASK_TERMINAL_EVENTS!,
+					`${JSON.stringify({ kind: "baseline-loaded", at: performance.now(), path: baseline })}\n`,
+				);
+				return { contents: readFileSync(baseline, "utf8"), loader: "ts" };
+			});
+		},
+	});
+}

--- a/research/windows-task-transcript-performance.md
+++ b/research/windows-task-transcript-performance.md
@@ -1,0 +1,61 @@
+# Windows task transcript rendering
+
+## Reproduce
+
+From the repository root, after `npm ci --ignore-scripts` and `npm run build`:
+
+```powershell
+bun --no-install research/windows-task-transcript-probe.mjs --baseline
+bun --no-install research/windows-task-transcript-probe.mjs
+```
+
+The baseline mode reads the exact `TaskLiveTranscript` source at `ff55b141109e3f9f5980c1f0c718dea39f6b2fd9` through `git show`, transpiles it in memory, and uses this checkout's unchanged shared message renderers. It does not switch branches or write baseline product files. The candidate imports the current source directly. Keep the shared renderers unchanged for this comparison.
+
+The probe exercises 100, 500 and 1,000 retained Markdown assistant messages, width 100, a hydrated streaming assistant and 30 text deltas. It checks every history marker exactly once, every delta in order, all 30 render requests, and unsubscribe. Each event is rendered immediately. No refresh interval, transcript limit or platform override is used.
+
+## Measured result
+
+Native Windows Server 2022, x64, AMD EPYC-v4 with eight logical processors, Bun 1.4.2. The benchmark uses real message components but headless stdout, not a terminal. Bun's `process.version` is not the installed Node CLI version.
+
+The first same-workload run immediately before and after implementation measured:
+
+| History | Baseline median / p95 | Candidate median / p95 |
+| --- | --- | --- |
+| 100 | 5.46 / 11.39 ms | 0.079 / 0.432 ms |
+| 500 | 41.25 / 47.20 ms | 0.146 / 0.366 ms |
+| 1,000 | 77.25 / 87.20 ms | 0.280 / 0.757 ms |
+
+At 1,000 messages both variants return 9,003 rows and 1,000,226 rendered-string bytes from 407,891 serialized history bytes. CPU time across the timed loop fell from 2,563 to 16 ms. Process CPU accounting is coarse on Windows; zero reported by the smallest candidate workload does not mean zero work.
+
+A second run using the committed probe's in-memory baseline mode, while other checks were running, measured 103.13 / 142.69 ms versus 0.358 / 1.458 ms at 1,000 messages. CPU totals were 3,140 versus 94 ms. These loaded-machine samples confirm the reduction but are not uncontended latency measurements.
+
+The research CPU profile attributed 86.9% inclusive sampled time to `AssistantMessageComponent.render`, including Markdown parsing, highlighting, wrapping and Unicode width work. Previously every changed event discarded all message components. Retaining components for unchanged controller entry identities preserves their rendering caches. Superseded identities are weakly held. Width changes still reach each component, explicit invalidation recreates all components, and renderer callbacks still request rendering directly.
+
+The structural regression test in `test/unit/task-live-transcript.test.ts` failed on the original implementation with 3,131 message reconstructions, then passed with 131. It asserts work rather than a machine-dependent time limit. Fresh-render parity also covers duplicate content, Unicode, thinking, tool arguments, partial/final tool results, aborted/error completion, widths and theme invalidation.
+
+## Limits
+
+These numbers prove a Windows component-rendering bottleneck and its reduction. Intermediate rendered bytes are not terminal-write bytes. They do not explain Windows-versus-Linux/macOS terminal differences. Linux and macOS measurements were not executed. Native terminal scenario evidence is recorded separately from this headless benchmark; neither is evidence of visible Windows Terminal smoothness.
+
+No change to task source selection, paging, navigation, event delivery, refresh scheduling or subscription lifecycle is part of the optimization.
+
+## Native Windows terminal scenario
+
+```powershell
+$evidence = Join-Path $env:TEMP ('task-transcript-' + [guid]::NewGuid())
+New-Item -ItemType Directory $evidence | Out-Null
+bun --no-install research/windows-task-transcript-terminal-probe.ts "$evidence/candidate"
+$baseline = git show ff55b141109e3f9f5980c1f0c718dea39f6b2fd9:packages/coding-agent/src/modes/interactive/components/task-live-transcript.ts
+$env:TASK_TERMINAL_BASELINE = "$evidence/baseline.ts"
+[IO.File]::WriteAllText($env:TASK_TERMINAL_BASELINE, ($baseline -join "`n"))
+bun --no-install research/windows-task-transcript-terminal-probe.ts "$evidence/baseline"
+Remove-Item Env:TASK_TERMINAL_BASELINE
+```
+
+This uses an owned atomic-natives Windows ConPTY, Bun and the source local ChatSessionHost. It types `/tasks`, opens the transcript, loads earlier history, emits 1,000 messages with 8,000 deltas, scrolls during streaming, resizes 120×40 to 72×24 and back, reaches LIVE-0999 with End, completes the task and verifies unsubscribe/exit. The baseline preload replaces only the transcript module and logs a receipt proving it loaded. Output directories retain source hashes, frame/event JSONL, terminal ANSI bytes and result assertions.
+
+Both final runs passed. The candidate produced 255 instrumented render calls, 92,351 terminal bytes and median/p95 render times 1.84/10.63 ms. The baseline produced 247 calls, 91,036 bytes and 25.57/109.60 ms. Other checks were running, so these are loaded-machine observations, not controlled display-latency numbers. Frame logging is synchronous and perturbs timing. Both use the same event cadence; physical frames and terminal chunks are not equivalent.
+
+End was explicitly characterized during growth. Both baseline and candidate retained the numeric position reached by End rather than following later growth. This existing non-sticky behavior is unchanged; pressing End again reaches the latest content.
+
+This scenario validates a real native PTY input/output path with deterministic task events. It does not validate the default isolated engine, real-provider/artifact I/O, or final screen pixels in a visible terminal window. No video was produced. Tool/error/fallback semantics are covered by focused tests, not this terminal scenario.

--- a/research/windows-task-transcript-probe.mjs
+++ b/research/windows-task-transcript-probe.mjs
@@ -1,0 +1,54 @@
+// Run after npm ci --ignore-scripts and npm run build. Native Bun, no terminal writes.
+// bun --no-install research/windows-task-transcript-probe.mjs [--baseline]
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { stripVTControlCharacters as strip } from "node:util";
+import { TaskLiveTranscript as CandidateTranscript } from "../packages/coding-agent/src/modes/interactive/components/task-live-transcript.ts";
+import { initTheme } from "../packages/coding-agent/src/modes/interactive/theme/theme.ts";
+const baseline = process.argv.includes("--baseline");
+const baselineRef = "ff55b141109e3f9f5980c1f0c718dea39f6b2fd9";
+async function transcriptClass() {
+	if (!baseline) return CandidateTranscript;
+	const source = execFileSync("git", ["show", `${baselineRef}:packages/coding-agent/src/modes/interactive/components/task-live-transcript.ts`], { encoding: "utf8" });
+	// Compile the exact baseline component in memory, resolving its unchanged renderer
+	// against this checkout. No checkout switching or temporary product files.
+	const js = new Bun.Transpiler({ loader: "ts" }).transformSync(source).replace(
+		'"./chat-message-renderer.ts"',
+		JSON.stringify(new URL("../packages/coding-agent/src/modes/interactive/components/chat-message-renderer.ts", import.meta.url).href),
+	);
+	return (await import(`data:text/javascript;base64,${Buffer.from(js).toString("base64")}`)).TaskLiveTranscript;
+}
+const TaskLiveTranscript = await transcriptClass();
+initTheme("dark");
+const assistant = (text) => ({ role: "assistant", content: [{ type: "text", text }], api: "openai-responses", provider: "openai", model: "fixture", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }, stopReason: "stop", timestamp: 1 });
+const quantile = (a, p) => [...a].sort((x, y) => x - y)[Math.ceil(a.length * p) - 1];
+console.log(JSON.stringify({ platform: process.platform, arch: process.arch, node: process.version, bun: Bun.version, tty: !!process.stdout.isTTY, backend: "headless component render; no terminal writes", width: 100, samples: 30 }));
+console.log(JSON.stringify({ variant: baseline ? "exact baseline component with current unchanged shared renderers" : "candidate", baselineRef }));
+for (const count of [100, 500, 1000]) {
+ let listener;
+ let requests = 0;
+ const messages = Array.from({ length: count }, (_, i) => assistant(`HISTORY-${String(i).padStart(4, "0")} **bold** and inline \`code\`\n\n- item one\n- item two\n\n\`\`\`typescript\nconst value = ${i};\n\`\`\``));
+ const source = { getSessionId: () => "bench", getEntries: () => [], subscribe: (cb) => { listener = cb; return () => { listener = undefined; }; }, getStreamingMessage: () => assistant("LIVE") };
+ const view = new TaskLiveTranscript(source, messages, () => requests++);
+ let rows = view.render(100);
+ const times = [];
+ const cached = [];
+ const cpu = process.cpuUsage();
+ for (let i = 0; i < 30; i++) {
+  const start = performance.now();
+  listener({ type: "message_update", message: assistant(""), assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: ` D${i}`, partial: assistant("") } });
+  rows = view.render(100);
+  times.push(performance.now() - start);
+  const next = performance.now();
+  view.render(100);
+  cached.push(performance.now() - next);
+ }
+ const used = process.cpuUsage(cpu);
+ const plain = strip(rows.join("\n"));
+ for (let i = 0; i < count; i++) assert.equal(plain.split(`HISTORY-${String(i).padStart(4, "0")}`).length - 1, 1);
+ assert.deepEqual(plain.match(/\bD\d+\b/g), Array.from({ length: 30 }, (_, i) => `D${i}`));
+ assert.equal(requests, 30);
+ console.log(JSON.stringify({ count, historyInputBytes: Buffer.byteLength(JSON.stringify(messages)), rows: rows.length, renderedBytes: Buffer.byteLength(rows.join("\n")), eventRenderMedianMs: quantile(times, .5), eventRenderP95Ms: quantile(times, .95), cachedRenderMedianMs: quantile(cached, .5), cachedRenderP95Ms: quantile(cached, .95), cpuMs: (used.user + used.system) / 1000, requests, assertions: "every history marker exactly once; all deltas in order; 30 update requests; subscription disposed" }));
+ view.dispose();
+ assert.equal(listener, undefined);
+}

--- a/research/windows-task-transcript-terminal-probe.ts
+++ b/research/windows-task-transcript-terminal-probe.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { startConpty } from "../scripts/perf/windows-startup/conpty.js";
+
+const out = process.argv[2];
+assert.ok(out, "provide an external evidence directory");
+mkdirSync(out, { recursive: true });
+const eventsPath = join(out, "events.jsonl");
+writeFileSync(eventsPath, "");
+writeFileSync(join(out, "terminal.ansi"), "");
+interface Event {
+	kind: string;
+	at: number;
+	text?: string;
+	fullscreen?: boolean;
+	picker?: boolean;
+	count?: number;
+	width?: number;
+	rows?: number;
+	renderMs?: number;
+	eventMs?: number;
+	listeners?: number;
+	tty?: boolean[];
+}
+const events = (): Event[] =>
+	readFileSync(eventsPath, "utf8")
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line));
+const wait = async (predicate: (event: Event) => boolean, after = 0) => {
+	const deadline = Date.now() + 60000;
+	while (Date.now() < deadline) {
+		const found = events().slice(after).find(predicate);
+		if (found) return found;
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+	throw new Error(`barrier timed out: ${predicate}`);
+};
+const sources = [
+	"packages/coding-agent/src/modes/interactive/components/task-live-transcript.ts",
+	"test/fixtures/windows-task-transcript-terminal.ts",
+	"research/windows-task-transcript-terminal-probe.ts",
+];
+const hash = () =>
+	Object.fromEntries(sources.map((path) => [path, createHash("sha256").update(readFileSync(path)).digest("hex")]));
+const before = hash();
+const metadata = {
+	head: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+	sources: before,
+	platform: process.platform,
+	runtime: process.version,
+	bun: Bun.version,
+	backend: "atomic-natives PtySession Windows ConPTY; cmd.exe; Bun child",
+	visibleWindow: false,
+	mode: "local ChatSessionHost fixture; not isolated engine",
+};
+if (process.env.TASK_TERMINAL_BASELINE)
+	writeFileSync(
+		join(out, "baseline-control.json"),
+		JSON.stringify(
+			{
+				path: process.env.TASK_TERMINAL_BASELINE,
+				sha256: createHash("sha256").update(readFileSync(process.env.TASK_TERMINAL_BASELINE)).digest("hex"),
+				note: "Only task-live-transcript.ts substituted via Bun preload onLoad; all other modules current checkout",
+			},
+			null,
+			2,
+		),
+	);
+writeFileSync(join(out, "metadata.json"), JSON.stringify(metadata, null, 2));
+let bytes = 0;
+let chunks = 0;
+const env = Object.fromEntries(
+	Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+);
+const child = startConpty({
+	command: `bun --no-install --preload ./research/windows-task-transcript-baseline-preload.ts test/fixtures/windows-task-transcript-terminal.ts`,
+	cwd: process.cwd(),
+	env: { ...env, TASK_TERMINAL_EVENTS: eventsPath },
+	timeoutMs: 180000,
+	onChunk(chunk, atNs) {
+		bytes += Buffer.byteLength(chunk);
+		chunks++;
+		appendFileSync(join(out, "terminal.ansi"), chunk);
+		appendFileSync(
+			join(out, "chunks.jsonl"),
+			`${JSON.stringify({ atNs: atNs.toString(), bytes: Buffer.byteLength(chunk) })}\n`,
+		);
+	},
+});
+async function input(data: string, predicate: (event: Event) => boolean) {
+	const after = events().length;
+	child.write(data);
+	return wait(predicate, after);
+}
+let finished = false;
+try {
+	const ready = await wait((event) => event.kind === "ready");
+	if (process.env.TASK_TERMINAL_BASELINE) assert.ok(events().some((event) => event.kind === "baseline-loaded"));
+	assert.deepEqual(ready.tty, [true, true, true]);
+	await input("/tasks\r", (event) => event.kind === "frame" && event.picker === true);
+	await input("\r", (event) => event.kind === "frame" && event.fullscreen === true);
+	// Drill into the agent transcript from task detail.
+	await input("\r", (event) => event.kind === "subscribe");
+	await input("\u001b[5~", (event) => event.kind === "frame" && !!event.text?.includes("HISTORY-000"));
+	const anchored = events()
+		.filter((event) => event.kind === "frame")
+		.at(-1)!;
+	await input("\u001bOS", (event) => event.kind === "burst-start");
+	await wait((event) => event.kind === "burst" && event.count! >= 100);
+	const during = events()
+		.filter((event) => event.kind === "frame")
+		.at(-1)!;
+	assert.ok(during.text?.includes("HISTORY-000"), "history remains anchored during burst");
+	assert.equal(
+		during.text?.split("Lines ")[0],
+		anchored.text?.split("Lines ")[0],
+		"historical viewport unchanged during live growth",
+	);
+	await input("\u001b[6~", (event) => event.kind === "frame" && !event.text?.includes("HISTORY-000"));
+	let after = events().length;
+	child.resize(72, 24);
+	await wait((event) => event.kind === "frame" && event.width === 72 && event.rows === 24, after);
+	after = events().length;
+	child.resize(120, 40);
+	await wait((event) => event.kind === "frame" && event.width === 120 && event.rows === 40, after);
+	const endFrame = await input("\u001b[F", (event) => event.kind === "frame");
+	await wait((event) => event.kind === "frame" && event.count! >= endFrame.count! + 80);
+	const grownFrame = events()
+		.filter((event) => event.kind === "frame")
+		.at(-1)!;
+	writeFileSync(
+		join(out, "follow-tail.json"),
+		JSON.stringify(
+			{
+				endCount: endFrame.count,
+				laterCount: grownFrame.count,
+				endMarkers: endFrame.text?.match(/LIVE-\d+/g),
+				laterMarkers: grownFrame.text?.match(/LIVE-\d+/g),
+				note: "Characterization only: End clamps to the current bottom; compare markers after growth, without asserting sticky follow-tail",
+			},
+			null,
+			2,
+		),
+	);
+	await wait((event) => event.kind === "burst-end");
+	await input("\u001b[F", (event) => event.kind === "frame" && !!event.text?.includes("LIVE-0999"));
+	await input("\u001b[15~", (event) => event.kind === "completed");
+	await input("\u001b", (event) => event.kind === "unsubscribe");
+	await input("\u0003", (event) => event.kind === "exit");
+	const exited = await child.exited;
+	finished = true;
+	assert.equal(exited.exitCode, 0);
+	assert.equal(events().find((event) => event.kind === "exit")?.listeners, 0);
+	assert.deepEqual(hash(), before, "candidate source unchanged during scenario");
+	const frames = events().filter((event) => event.kind === "frame");
+	const times = frames.map((event) => event.renderMs!).sort((a, b) => a - b);
+	const result = {
+		passed: true,
+		exited,
+		frames: frames.length,
+		terminalBytes: bytes,
+		terminalChunks: chunks,
+		frameRenderMedianMs: times[Math.floor(times.length * 0.5)],
+		frameRenderP95Ms: times[Math.floor(times.length * 0.95)],
+		assertions: [
+			"native Windows TTY",
+			"typed /tasks",
+			"picker and fullscreen drilldown",
+			"1000 live messages with 8000 deltas",
+			"historical viewport anchored during growth",
+			"PageDown during streaming",
+			"72x24 and 120x40 resize",
+			"final LIVE-0999 visible after End",
+			"task completion",
+			"unsubscribe and exit",
+		],
+		limits: [
+			"No visible terminal window or video",
+			"Local host only; no isolated RPC transport",
+			"Fixture renderer instrumentation and output logging perturb timings",
+			"No assertion of sticky follow-tail",
+			"Deterministic task events, not real provider or artifact I/O",
+		],
+	};
+	writeFileSync(join(out, "result.json"), JSON.stringify(result, null, 2));
+	console.log(JSON.stringify(result));
+} catch (error) {
+	writeFileSync(join(out, "failure.txt"), String(error));
+	throw error;
+} finally {
+	if (!finished) child.kill();
+}

--- a/test/fixtures/windows-task-transcript-terminal.ts
+++ b/test/fixtures/windows-task-transcript-terminal.ts
@@ -1,0 +1,178 @@
+import { appendFileSync } from "node:fs";
+import { stripVTControlCharacters } from "node:util";
+import type { AssistantMessage } from "@bastani/pi-ai/compat";
+import type { AgentSessionEvent } from "../../packages/coding-agent/src/core/agent-session.js";
+import { SessionManager } from "../../packages/coding-agent/src/core/session-manager.js";
+import { ChatSessionHost } from "../../packages/coding-agent/src/modes/interactive/components/chat-session-host.js";
+import { Key, matchesKey, setKeybindings } from "@earendil-works/pi-tui";
+import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.js";
+import { bindOwnerTaskStore } from "../../packages/coding-agent/src/core/tasks/owner-store.js";
+import { createFullscreenTui } from "../../packages/coding-agent/src/modes/interactive/interactive-tui.js";
+import { taskFixture } from "../helpers/task-projection.js";
+import { editorTheme, plainStyle } from "../unit/chat-session-host-working-lifecycle-fixture.js";
+import { createStageSkillFixture } from "./stage-chat-skill-session.js";
+
+// Real local host and terminal, deterministic task runner; no provider/network requests.
+const evidence = process.env.TASK_TERMINAL_EVENTS!;
+const record = (value: object) => appendFileSync(evidence, `${JSON.stringify({ at: performance.now(), ...value })}\n`);
+const workflow = await createStageSkillFixture();
+const keys = new KeybindingsManager();
+setKeybindings(keys);
+const tui = createFullscreenTui({
+	showHardwareCursor: false,
+	logDirectory: process.env.TEMP!,
+	shouldHandleViewportInput: () => false,
+});
+const tasks = taskFixture();
+bindOwnerTaskStore(workflow.main.session, tasks.store);
+const main = new ChatSessionHost({
+	taskRowsInChat: false,
+	style: plainStyle,
+	editorTheme,
+	tui,
+	keybindings: keys,
+	getAgentSession: () => workflow.main.session,
+	requestRender: () => tui.requestRender(),
+	commands: {
+		handleSlashCommand: (text): boolean => {
+			record({ kind: "slash", text });
+			return text === "/tasks" && main.openTasks();
+		},
+	},
+});
+const session = SessionManager.inMemory();
+const listeners = new Set<(event: AgentSessionEvent) => void>();
+const assistant = (text: string): AssistantMessage => ({
+	role: "assistant",
+	content: [{ type: "text", text }],
+	api: "openai-responses",
+	provider: "openai",
+	model: "fixture",
+	usage: {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	},
+	stopReason: "stop",
+	timestamp: Date.now(),
+});
+for (let i = 0; i < 120; i++)
+	session.appendMessage(
+		assistant(`HISTORY-${String(i).padStart(3, "0")} **retained**\n\n\`\`\`ts\nconst n = ${i};\n\`\`\``),
+	);
+await tasks.start("Windows burst transcript");
+tasks.runners[0].context.bindTranscript({
+	getSessionId: () => session.getSessionId(),
+	getEntries: () => session.getEntries(),
+	subscribe: (listener) => {
+		listeners.add(listener);
+		record({ kind: "subscribe", count: listeners.size });
+		return () => {
+			listeners.delete(listener);
+			record({ kind: "unsubscribe", count: listeners.size });
+		};
+	},
+});
+let timer: ReturnType<typeof setInterval> | undefined;
+let count = 0;
+let stopping = false;
+const emit = (event: AgentSessionEvent) => {
+	for (const listener of listeners) listener(event);
+};
+function burst() {
+	if (timer) return;
+	record({ kind: "burst-start" });
+	timer = setInterval(() => {
+		const start = performance.now();
+		for (let j = 0; j < 4; j++) {
+			const marker = `LIVE-${String(count++).padStart(4, "0")}`;
+			emit({ type: "message_start", message: assistant(marker) });
+			for (let k = 0; k < 8; k++)
+				emit({
+					type: "message_update",
+					message: assistant(""),
+					assistantMessageEvent: {
+						type: "text_delta",
+						contentIndex: 0,
+						delta: ` delta-${k}`,
+						partial: assistant(""),
+					},
+				});
+			const final = assistant(
+				`${marker} delta-0 delta-1 delta-2 delta-3 delta-4 delta-5 delta-6 delta-7\n\n**burst retained markdown**`,
+			);
+			session.appendMessage(final);
+			emit({ type: "message_end", message: final });
+		}
+		record({ kind: "burst", count, eventMs: performance.now() - start });
+		if (count >= 1000) {
+			clearInterval(timer);
+			timer = undefined;
+			record({ kind: "burst-end", count });
+		}
+	}, 20);
+}
+async function stop() {
+	if (stopping) return;
+	stopping = true;
+	clearInterval(timer);
+	main.dispose();
+	tui.stop();
+	await tasks.dispose();
+	await workflow.cleanup();
+	record({ kind: "exit", listeners: listeners.size });
+	process.exit(0);
+}
+const component = {
+	focused: true,
+	invalidate() {
+		main.invalidate();
+	},
+	render(width: number) {
+		const start = performance.now();
+		const rows = tui.terminal.rows;
+		const footer = main.renderFooter(width);
+		const editor = main.hasTaskInspector ? [] : main.renderEditor(width);
+		const lines = main.taskInspectorFullscreen
+			? main.renderBody(width, rows)
+			: [...main.renderBody(width, Math.max(1, rows - footer.length - editor.length)), ...editor, ...footer];
+		record({
+			kind: "frame",
+			width,
+			rows,
+			fullscreen: main.taskInspectorFullscreen,
+			picker: main.hasTaskInspector,
+			count,
+			renderMs: performance.now() - start,
+			text: stripVTControlCharacters(lines.join("\n")),
+		});
+		return lines;
+	},
+	handleInput(data: string) {
+		record({ kind: "input", data });
+		if (matchesKey(data, Key.ctrl("c"))) {
+			void stop();
+			return true;
+		}
+		if (matchesKey(data, "f4")) burst();
+		else if (matchesKey(data, "f5"))
+			void tasks.settle().then(() => {
+				record({ kind: "completed" });
+				tui.requestRender();
+			});
+		else if (!main.handleTaskInput(data)) main.handleInput(data);
+		tui.requestRender();
+		return true;
+	},
+};
+tui.showOverlay(component, { anchor: "center", width: "100%", maxHeight: "100%", margin: 0 });
+tui.start();
+record({
+	kind: "ready",
+	platform: process.platform,
+	tty: [process.stdin.isTTY, process.stdout.isTTY, process.stderr.isTTY],
+});
+process.once("SIGTERM", () => void stop());

--- a/test/unit/task-live-transcript.test.ts
+++ b/test/unit/task-live-transcript.test.ts
@@ -2,11 +2,18 @@ import assert from "node:assert/strict";
 import { stripVTControlCharacters } from "node:util";
 import type { AssistantMessage } from "@bastani/pi-ai/compat";
 import { getKeybindings, setKeybindings } from "@earendil-works/pi-tui";
-import { test } from "vitest";
+import { test, vi } from "vitest";
 import type { AgentSessionEvent } from "../../packages/coding-agent/src/core/agent-session.js";
 import { KeybindingsManager } from "../../packages/coding-agent/src/core/keybindings.js";
 import { SessionManager } from "../../packages/coding-agent/src/core/session-manager.js";
+import { AssistantMessageComponent } from "../../packages/coding-agent/src/modes/interactive/components/assistant-message.js";
+import {
+	chatEntriesFromAgentMessages,
+	LiveChatEntriesController,
+	renderChatMessageEntry,
+} from "../../packages/coding-agent/src/modes/interactive/components/chat-message-renderer.js";
 import { TaskInspector } from "../../packages/coding-agent/src/modes/interactive/components/task-inspector.js";
+import { TaskLiveTranscript } from "../../packages/coding-agent/src/modes/interactive/components/task-live-transcript.js";
 import { initTheme } from "../../packages/coding-agent/src/modes/interactive/theme/theme.js";
 import { taskFixture } from "../helpers/task-projection.js";
 
@@ -157,4 +164,163 @@ test("live transcript keeps earlier pages and scroll position while new state ar
 		await fixture.dispose();
 		setKeybindings(keys);
 	}
+});
+
+test("streaming rebuilds only changed message components and invalidation refreshes history", () => {
+	initTheme("dark");
+	let listener: ((event: AgentSessionEvent) => void) | undefined;
+	let requests = 0;
+	const history = Array.from({ length: 100 }, (_, index) => assistant(`HISTORY-${index} **retained**`));
+	const updates = vi.spyOn(AssistantMessageComponent.prototype, "updateContent");
+	const transcript = new TaskLiveTranscript(
+		{
+			getSessionId: () => "retention-test",
+			getEntries: () => [],
+			getStreamingMessage: () => assistant("Live"),
+			subscribe: (callback) => {
+				listener = callback;
+				return () => {
+					listener = undefined;
+				};
+			},
+		},
+		history,
+		() => {
+			requests++;
+		},
+	);
+	try {
+		const initial = transcript.render(80);
+		assert.equal(updates.mock.calls.length, 101);
+		for (let index = 0; index < 30; index++) {
+			listener?.({
+				type: "message_update",
+				message: assistant(""),
+				assistantMessageEvent: {
+					type: "text_delta",
+					contentIndex: 0,
+					delta: ` delta-${index}`,
+					partial: assistant(""),
+				},
+			});
+			transcript.render(80);
+		}
+		assert.equal(requests, 30);
+		assert.equal(updates.mock.calls.length, 131, "historical Markdown must not be reconstructed per delta");
+		const final = transcript.render(80);
+		assert.deepEqual(final.slice(0, initial.length - 2), initial.slice(0, initial.length - 2));
+		for (const width of [40, 100, 80]) {
+			const text = stripVTControlCharacters(transcript.render(width).join("\n"));
+			for (let index = 0; index < 100; index++) assert.equal(text.split(`HISTORY-${index} `).length - 1, 1);
+		}
+		assert.equal(updates.mock.calls.length, 131, "resize reuses components and their width-aware renderers");
+		listener?.({ type: "agent_end", messages: [] });
+		transcript.render(80);
+		assert.equal(updates.mock.calls.length, 131);
+		transcript.invalidate();
+		assert.deepEqual(transcript.render(80), final);
+		assert.equal(updates.mock.calls.length, 232);
+	} finally {
+		transcript.dispose();
+		updates.mockRestore();
+	}
+	assert.equal(listener, undefined);
+});
+
+test("retained components match fresh rendering through tools, thinking, errors and theme changes", () => {
+	initTheme("dark");
+	const messages = [assistant("Duplicate"), assistant("Duplicate"), assistant("Unicode 界 👩‍💻 and **Markdown**")];
+	const entries = chatEntriesFromAgentMessages(messages);
+	const controller = new LiveChatEntriesController(entries);
+	let listener: ((event: AgentSessionEvent) => void) | undefined;
+	const transcript = new TaskLiveTranscript(
+		{
+			getSessionId: () => "parity",
+			getEntries: () => [],
+			subscribe: (callback) => {
+				listener = callback;
+				return () => {
+					listener = undefined;
+				};
+			},
+		},
+		messages,
+		() => {},
+	);
+	const compare = () => {
+		for (const width of [80, 37, 100, 80]) {
+			const expected = entries.flatMap((entry) =>
+				renderChatMessageEntry(entry, {
+					ui: { requestRender: () => {} },
+					cwd: process.cwd(),
+					hideThinkingBlock: true,
+					toolOutputExpanded: true,
+					showImages: false,
+				}).render(width),
+			);
+			assert.deepEqual(transcript.render(width), expected);
+		}
+	};
+	const emit = (event: AgentSessionEvent) => {
+		// Separate controller state: text deltas mutate the streaming message in place.
+		controller.applyEvent(structuredClone(event));
+		listener?.(structuredClone(event));
+		compare();
+	};
+	try {
+		compare();
+		emit({ type: "message_start", message: assistant("") });
+		emit({
+			type: "message_update",
+			message: assistant(""),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 0,
+				delta: "  live\n\n**raw** 界  ",
+				partial: assistant(""),
+			},
+		});
+		emit({
+			type: "message_end",
+			message: {
+				...assistant("finished"),
+				content: [
+					{ type: "thinking", thinking: "hidden reasoning" },
+					{ type: "text", text: "finished" },
+					{ type: "toolCall", id: "call", name: "bash", arguments: { command: "echo first" } },
+				],
+			},
+		});
+		emit({ type: "tool_execution_start", toolCallId: "call", toolName: "bash", args: { command: "echo final" } });
+		emit({
+			type: "tool_execution_update",
+			toolCallId: "call",
+			toolName: "bash",
+			args: {},
+			partialResult: {
+				content: [{ type: "text", text: "partial\noutput" }],
+			},
+		});
+		emit({
+			type: "tool_execution_end",
+			toolCallId: "call",
+			toolName: "bash",
+			isError: false,
+			result: {
+				content: [{ type: "text", text: "complete\noutput" }],
+			},
+		});
+		for (const stopReason of ["aborted", "error"] as const) {
+			emit({ type: "message_start", message: assistant("") });
+			emit({ type: "tool_execution_start", toolCallId: stopReason, toolName: "read", args: { path: "a.ts" } });
+			emit({ type: "message_end", message: { ...assistant(""), stopReason, errorMessage: `test ${stopReason}` } });
+		}
+		initTheme("light");
+		transcript.invalidate();
+		compare();
+	} finally {
+		transcript.dispose();
+		initTheme("dark");
+	}
+	assert.equal(listener, undefined);
 });


### PR DESCRIPTION
## Summary

Reduce Windows CPU cost in long `/tasks` live transcripts by retaining renderers for unchanged messages instead of reconstructing the entire history on every live event.

## Changes

- Cache message components by controller entry identity in a WeakMap. Changed entries get fresh renderers; superseded entries are weakly held. Width-aware rendering and explicit invalidation remain intact.
- Add structural work-count and fresh-render parity regressions for streaming, duplicate/Unicode content, tools, errors, resize and theme changes.
- Add repeatable component and native Windows ConPTY probes, measurement notes, user documentation and an Unreleased fix entry.
- No refresh throttling, history truncation, platform flags, API changes or test-budget changes.

## Windows measurements

Same workload, Windows Server 2022 x64, Bun 1.4.2, width 100, 30 updates per history size:

| Retained messages | Baseline median / p95 | Candidate median / p95 |
| --- | --- | --- |
| 100 | 5.46 / 11.39 ms | 0.079 / 0.432 ms |
| 500 | 41.25 / 47.20 ms | 0.146 / 0.366 ms |
| 1,000 | 77.25 / 87.20 ms | 0.280 / 0.757 ms |

At 1,000 messages, both variants preserve 9,003 rendered rows, 1,000,226 rendered-string bytes and all 30 update callbacks. Independent review reproduced the component improvement at 87.62 to 0.32 ms median and passed 120 baseline/candidate rendering comparisons. The structural regression reduces message reconstructions from 3,131 to 131.

The native ConPTY scenario types `/tasks`, opens the transcript, streams 1,000 messages with 8,000 deltas, scrolls, resizes, completes and verifies unsubscribe/exit. Baseline and candidate pass. Reproduction commands and measured terminal results are in `research/windows-task-transcript-performance.md`.

## Validation

Candidate: `b2352ef500d808fd8752765b557ef63241945e81`, based on `ff55b141109e3f9f5980c1f0c718dea39f6b2fd9`.

- Build, `npm run check`, and installed commit hooks passed.
- Focused tests: 62 passed. CI contracts: 97 passed.
- Final root unit suite: 8,225 passed, 73 skipped.
- Final coding-agent suite: 4,558 passed, 95 skipped.
- `git diff origin/main...HEAD --check` passed; working tree clean.
- Two independent reviewers found no functional defect. Their duplicate missing-commit findings were resolved by the attributed commit with hooks. The controller independently verified all nine validated SHA256s and committed blob identities before PR creation.

Earlier full-suite attempts failed during concurrent build/generated-data mutation and unrelated timing-sensitive tests. These failures were retained in local evidence; unchanged-source retries passed with no overlapping builds. No tests, timeouts or suite concurrency were weakened. Full integration was not run.

## Limits and delivery

Component timings are headless measurements, not display latency. The terminal scenario uses a real native Windows ConPTY with the local ChatSessionHost and deterministic task events. It does not validate the default isolated engine, real-provider/artifact I/O, visible Windows Terminal pixels or subjective smoothness. Linux/macOS measurements and video were not produced. Existing non-sticky End behavior is unchanged. This proves a Windows rendering bottleneck and its reduction, not the full cause of the Windows-versus-POSIX difference.

The workflow stalled starting its final commit-only reviewers. The user requested direct completion; the run was stopped before this PR was created. Earlier independent behavioral review evidence was preserved, and the remaining commit evidence was verified directly. Hosted CI is separate from local validation and must be checked before any merge. No merge or release is included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/3005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791791558&installation_model_id=10562&pr_number=3005&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F3005&signature=cae1f5f416541b2183befe0270f60754f08c8fcf43dbda4dd9f83475aba3bc0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63385405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: no confirmed behavior regressions or repository-requirement violations remain.

What we checked:
- Before implementation, the log captures show the prior whole-array component cache state and its invalidation after a changed event. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- After implementation, the log shows the entry-keyed WeakMap cache and an explicit invalidation reset. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The runtime test run produced decisive output indicating Test Files 1 passed (1), Tests 4 passed (4), Exit code 0. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- This change improves live `/tasks` transcript responsiveness by reusing unchanged message renderers while preserving streaming updates, width-aware layout, and explicit invalidation. Focused coverage confirms parity for retained history, Markdown and Unicode content, tool output, error states, resizing, and theme changes.

<sub>Reviews (1) · Last reviewed commit: ["docs(agents): keep user guides actionabl..."](https://github.com/bastani-inc/atomic/commit/20b20e1be4ae849d00778a667432984b20764fda)</sub>

<!-- /greptile_comment -->