### PR TITLE
test(docs): compare parsed origins for anchor citations

### DIFF
--- a/test/unit/docs-information-architecture.test.ts
+++ b/test/unit/docs-information-architecture.test.ts
@@ -821,14 +821,41 @@ describe("docs reader anchors (#2847)", () => {
 			if (written === "") return ownRoute;
 			// The published site is the same page under a different spelling; a
 			// docs.bastani.ai citation is a live reader citation like any other.
-			if (written.startsWith("https://docs.bastani.ai")) {
-				const route = written.slice("https://docs.bastani.ai".length).replace(/\/$/u, "");
+			if (URL.canParse(written)) {
+				const url = new URL(written);
+				if (url.origin !== "https://docs.bastani.ai") return undefined;
+				const route = url.pathname.replace(/\/$/u, "");
 				return route === "" ? "/" : route;
 			}
 			if (written.startsWith("/")) return written;
 			const [, tail] = written.split("docs/");
 			return tail === undefined ? undefined : `/${tail.replace(/\.mdx?$/u, "")}`;
 		};
+		// Regression coverage for code-scanning alert 199: compare parsed origins,
+		// not prefixes, and never reinterpret external URLs as relative docs paths.
+		for (const written of [
+			"https://docs.bastani.ai.evil.example/docs/workflows",
+			"https://docs.bastani.ai@evil.example/docs/workflows",
+			"https://evil.example/docs/workflows",
+			"http://docs.bastani.ai/workflows",
+			"https://docs.bastani.ai:444/workflows",
+		]) {
+			assert.equal(routeOf(written, undefined), undefined, written);
+		}
+		for (const [written, expected] of [
+			["https://docs.bastani.ai", "/"],
+			["https://docs.bastani.ai/", "/"],
+			["https://docs.bastani.ai/workflows/", "/workflows"],
+			["https://docs.bastani.ai/workflows?source=guide", "/workflows"],
+			["https://DOCS.BASTANI.AI:443/workflows", "/workflows"],
+			["/workflows", "/workflows"],
+			["../docs/workflows.md", "/workflows"],
+			["../docs/workflows.mdx", "/workflows"],
+		] as const) {
+			assert.equal(routeOf(written, undefined), expected, written);
+		}
+		assert.equal(routeOf("", "/workflows"), "/workflows");
+		assert.equal(routeOf("", undefined), undefined);
 		const citers = new Map<string, Set<string>>();
 		const collect = (file: string, ownRoute: string | undefined, text: string): void => {
 			for (const match of text.matchAll(pattern)) {


### PR DESCRIPTION
## Summary

Fix the test-only URL classification bug reported by [code-scanning alert 199](https://github.com/bastani-inc/atomic/security/code-scanning/199). The docs anchor provenance checker used a string prefix that also accepted lookalike domains and userinfo URLs. This is a correctness gap in test infrastructure, not a shipped runtime security boundary.

## Changes

- Parse absolute URLs and require the exact HTTPS docs origin before mapping their pathname to a local route.
- Ignore external origins instead of falling through to relative docs-path handling.
- Add regression assertions for lookalike domains, userinfo, ports, queries, canonical URLs, and existing relative links.

## Validation

- Docs information architecture suite: 26 tests passed.
- Mandatory commit hooks passed, including formatting and `npm run check`.
- `git diff --check origin/main...HEAD` passed.
- Initial validation hit stale dependencies from a reused node_modules symlink; a worktree-local `npm ci --ignore-scripts` resolved it.

Implemented in `../atomic-fix-alert-199`. No shipped behavior changes, so no user-guide or package changelog changes. CodeQL confirmation remains for CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/3006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791792753&installation_model_id=10562&pr_number=3006&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F3006&signature=067d2d7f2c3e75dbd11866de3f963018bc309e780241cbe0abf74b9f2ad828ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63387372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: the focused documentation-anchor test suite passes, and the changed URL-origin behavior correctly preserves supported routes while rejecting external ones.

What we checked:
- Before capture, the prefix implementation incorrectly mapped deceptive URLs such as https://evil.example/docs/workflows to /workflows. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- After capture, all five deceptive URLs resolve to undefined, while canonical and relative forms resolve to their intended routes. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The complete narrow-unit output confirms the changed test suite passes. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- Updated the docs-anchor provenance test to classify absolute citations by parsed URL origin instead of a string prefix.
- Confirmed deceptive and external absolute URLs are rejected before they can be treated as local documentation routes.
- Confirmed canonical `https://docs.bastani.ai` URLs and existing relative documentation paths still resolve as intended.

<sub>Reviews (1) · Last reviewed commit: ["test(docs): compare parsed origins for a..."](https://github.com/bastani-inc/atomic/commit/27cce1808b9b690b42f3119003f495c52b9d3e10)</sub>

<!-- /greptile_comment -->