### PR TITLE
fix(workflows): discover warm-first parallel stage names

### DIFF
--- a/packages/coding-agent/docs/workflows/api-reference.md
+++ b/packages/coding-agent/docs/workflows/api-reference.md
@@ -738,6 +738,8 @@ readonly failFast?: boolean;
 
 `WorkflowParallelOptions` uses `concurrency` to bound active tasks in an authored `ctx.parallel(...)`. When omitted, the runtime uses the workflow's `defaultConcurrency` setting, which defaults to `3`; explicit configuration and per-call concurrency remain honored. Parallel execution is fail-fast unless `failFast` is explicitly `false`.
 
+For a dynamic parallel step array that cannot be scanned, set `possibleStageNames: ["review-*"]` in the call's options. Supply a literal array covering every possible step name; `*` matches a varying name component. This metadata only controls advance stage discovery, not execution or concurrency. Named helpers can forward `options.possibleStageNames` directly to their parallel calls when every direct caller supplies a literal array, including through named relative imports. Opaque forwarding and unannotated dynamic calls still produce discovery warnings.
+
 ### Stage prompt options (`StagePromptOptions`)
 
 ```typescript

--- a/packages/coding-agent/docs/workflows/api-reference.md
+++ b/packages/coding-agent/docs/workflows/api-reference.md
@@ -738,7 +738,7 @@ readonly failFast?: boolean;
 
 `WorkflowParallelOptions` uses `concurrency` to bound active tasks in an authored `ctx.parallel(...)`. When omitted, the runtime uses the workflow's `defaultConcurrency` setting, which defaults to `3`; explicit configuration and per-call concurrency remain honored. Parallel execution is fail-fast unless `failFast` is explicitly `false`.
 
-For a dynamic parallel step array that cannot be scanned, set `possibleStageNames: ["review-*"]` in the call's options. Supply a literal array covering every possible step name; `*` matches a varying name component. This metadata only controls advance stage discovery, not execution or concurrency. Named helpers can forward `options.possibleStageNames` directly to their parallel calls when every direct caller supplies a literal array, including through named relative imports. Opaque forwarding and unannotated dynamic calls still produce discovery warnings.
+For a dynamic parallel step array that cannot be scanned, set `possibleStageNames: ["review-*"]` in the call's options. Supply a literal array covering every possible step name; `*` matches a varying name component. This metadata only controls advance stage discovery, not execution or concurrency. Named helpers can forward `options.possibleStageNames` directly to their parallel calls when every direct caller supplies a literal array, including through named relative imports. Use plain data properties in those caller options; options methods/getters, mutation, and side-effecting parameter defaults are not supported for discovery. Opaque forwarding and unannotated dynamic calls still produce discovery warnings.
 
 ### Stage prompt options (`StagePromptOptions`)
 

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Warm-first verifier and tournament judge groups now advertise conservative possible-stage names in source and bundled workflows without the builtin `warmSteps`/`restSteps` discovery warnings. Call-scoped `possibleStageNames` metadata leaves execution unchanged and retains diagnostics for unsupported dynamic calls ([#3001](https://github.com/bastani-inc/atomic/issues/3001)).
+
 ## [0.9.19-alpha.6] - 2026-09-11
 
 ### Fixed

--- a/packages/workflows/builtin/adversarial-verification-runner.ts
+++ b/packages/workflows/builtin/adversarial-verification-runner.ts
@@ -276,7 +276,7 @@ export async function runAdversarialVerification(ctx: WorkflowRunContext<Inputs>
 				ctx,
 				pending.map((cell) => scoreStep(cell, reaskWave, scoringHead, criteriaPath)),
 				() => scoringHead,
-				{ concurrency: Math.min(pending.length, 4), failFast: false },
+				{ concurrency: Math.min(pending.length, 4), failFast: false, possibleStageNames: ["verifier-*-*-*", "verifier-*-*-*-reask-*"] },
 			);
 			const byName = new Map<string, (typeof reports)[number]>();
 			for (const report of reports) {

--- a/packages/workflows/builtin/tournament-runner.ts
+++ b/packages/workflows/builtin/tournament-runner.ts
@@ -233,7 +233,7 @@ export async function runTournament(ctx: WorkflowRunContext<TournamentInputs>) {
 			ctx,
 			stages.map((stage) => stage.step),
 			(_step, index) => `${stages[index]!.slot1}:${stages[index]!.slot2}`,
-			{ concurrency: maxConcurrency, failFast: false },
+			{ concurrency: maxConcurrency, failFast: false, possibleStageNames: ["judge-*-*-*-r*"] },
 		);
 		const phaseResults = [...results];
 		for (const stage of stages) {

--- a/packages/workflows/builtin/verification-prompts.ts
+++ b/packages/workflows/builtin/verification-prompts.ts
@@ -177,6 +177,7 @@ export async function warm_first_fan_out<K>(
 					inheritedConcurrency,
 				),
 				failFast: false,
+				possibleStageNames: options.possibleStageNames,
 			});
 			for (const [resultIndex, result] of warmResults.entries()) {
 				const originalIndex = warmIndices[resultIndex];
@@ -192,6 +193,7 @@ export async function warm_first_fan_out<K>(
 		const restResults = await ctx.parallel(restSteps, {
 			...parallelOptions,
 			concurrency: boundedConcurrency(restSteps.length, undefined, inheritedConcurrency),
+			possibleStageNames: options.possibleStageNames,
 		});
 		for (const [resultIndex, result] of restResults.entries()) {
 			const originalIndex = restIndices[resultIndex];

--- a/packages/workflows/src/shared/authoring-contract-stage.ts
+++ b/packages/workflows/src/shared/authoring-contract-stage.ts
@@ -428,6 +428,8 @@ export interface WorkflowChainOptions extends WorkflowSharedTaskDefaults {
 export interface WorkflowParallelOptions extends WorkflowSharedTaskDefaults {
 	readonly concurrency?: number;
 	readonly failFast?: boolean;
+	/** Static discovery only: literal conservative stage names/globs for an otherwise opaque step array. */
+	readonly possibleStageNames?: readonly string[];
 }
 
 export type WorkflowTaskSessionOptions = StageOptions & WorkflowTaskSessionFields;

--- a/packages/workflows/src/shared/possible-stages.ts
+++ b/packages/workflows/src/shared/possible-stages.ts
@@ -1182,6 +1182,8 @@ class PossibleStagesScanner {
 		}
 		// A property read may be repeated, but rebinding/shadowing the options parameter is not supported.
 		const body = unit.tokens.slice(owner.bodyOpen, owner.bodyClose);
+		// The arguments object exposes parameter aliases outside the supported named forwarding shape.
+		if (body.some((token) => token.kind === "ident" && token.value === "arguments")) return undefined;
 		if (hasDiscoveryDestructuringWrite(body, value[0].value)) return undefined;
 		// Only direct parallel-option forwarding is proven safe; aliases, escapes and
 		// chained array operations can mutate the caller's literal metadata.
@@ -1210,11 +1212,9 @@ class PossibleStagesScanner {
 						return undefined;
 				}
 			}
-			if (body[index + 1]?.value !== "." && !destructured) return undefined;
-			if (!destructured && ["(", ".", "[", "?", "?."].includes(body[index + 3]?.value ?? "")) return undefined;
-			if (["delete", "+", "-"].includes(body[index - 1]?.value ?? "")) return undefined;
-			if (["=", "+", "-", "*", "/", "%", "&", "|", "^", "?", "<", ">"].includes(body[index + 3]?.value ?? ""))
-				return undefined;
+			// Support only the two authored shapes: direct metadata forwarding and
+			// destructuring plain caller fields. Other member uses may execute or escape.
+			if (!destructured && !forwarded.has(body[index]!)) return undefined;
 		}
 		const names: string[] = [];
 		for (const callerPath of this.closure) {

--- a/packages/workflows/src/shared/possible-stages.ts
+++ b/packages/workflows/src/shared/possible-stages.ts
@@ -803,6 +803,9 @@ function discoveryField(object: readonly Token[] | undefined): readonly Token[] 
 	if (object?.[0]?.value !== "{" || object.at(-1)?.value !== "}") return undefined;
 	let value: readonly Token[] | undefined;
 	for (const field of arrayElements(object)) {
+		// Computed fields/accessors may overwrite the metadata with an unproven value.
+		const key = ["get", "set", "async", "*"].includes(field[0]?.value ?? "") ? field.slice(1) : field;
+		if (key[0]?.value === "[" || (key[0]?.value === "*" && key[1]?.value === "[")) return undefined;
 		if (field[0]?.value === ".") {
 			if (value !== undefined) return undefined;
 			continue;
@@ -830,6 +833,7 @@ interface DiscoveryHelper {
 	readonly params: readonly (readonly Token[])[];
 	readonly bodyOpen: number;
 	readonly bodyClose: number;
+	readonly declaration: boolean;
 }
 
 /** Named declarations only. Arrow helpers and further forwarding remain unsupported. */
@@ -846,15 +850,30 @@ function discoveryHelpers(tokens: readonly Token[]): DiscoveryHelper[] {
 		while (bodyOpen < tokens.length && tokens[bodyOpen]?.value !== "{") bodyOpen += 1;
 		const bodyClose = matchBracket(tokens, bodyOpen, "{", "}");
 		if (bodyClose === undefined) continue;
+		const preceding = tokens[index - (tokens[index - 1]?.value === "async" ? 2 : 1)]?.value;
 		helpers.push({
 			name: tokens[index + 1]!.value,
 			nameIndex: index + 1,
 			params: splitTopLevelArguments({ method: "parallel", argsOpen: open }, tokens),
 			bodyOpen,
 			bodyClose,
+			declaration: preceding === undefined || ["export", ";", "{", "}"].includes(preceding),
 		});
 	}
 	return helpers;
+}
+
+/** An enclosing destructuring target can write a property far from its assignment token. */
+function hasDiscoveryDestructuringWrite(tokens: readonly Token[], parameter: string): boolean {
+	for (let index = 0; index < tokens.length; index += 1) {
+		const open = tokens[index]?.value;
+		if (open !== "[" && open !== "{") continue;
+		const close = matchBracket(tokens, index, open, open === "[" ? "]" : "}");
+		if (close === undefined || !["=", "of", "in"].includes(tokens[close + 1]?.value ?? "")) continue;
+		if (tokens.slice(index + 1, close).some((token) => token.kind === "ident" && token.value === parameter))
+			return true;
+	}
+	return false;
 }
 
 /** Fail closed on aliases, rebindings and shadowed names rather than borrowing another scope's metadata. */
@@ -1134,17 +1153,20 @@ class PossibleStagesScanner {
 		const owner = discoveryHelpers(unit.tokens)
 			.filter((helper) => helper.bodyOpen < call.argsOpen && helper.bodyClose > call.argsOpen)
 			.at(-1);
-		if (owner === undefined) return undefined;
+		if (owner === undefined || !owner.declaration) return undefined;
 		const parameter = owner.params.findIndex((param) => param[0]?.value === value[0]?.value);
 		if (parameter < 0) return undefined;
 		// A property read may be repeated, but rebinding/shadowing the options parameter is not supported.
 		const body = unit.tokens.slice(owner.bodyOpen, owner.bodyClose);
+		if (hasDiscoveryDestructuringWrite(body, value[0].value)) return undefined;
 		for (let index = 0; index < body.length; index += 1) {
 			if (body[index]?.value !== value[0]?.value) continue;
 			const destructured =
 				body[index - 2]?.value === "}" && body[index - 1]?.value === "=" && body[index + 1]?.value === ";";
 			if (body[index + 1]?.value !== "." && !destructured) return undefined;
-			if (["=", "+", "-"].includes(body[index + 3]?.value ?? "")) return undefined;
+			if (["delete", "+", "-"].includes(body[index - 1]?.value ?? "")) return undefined;
+			if (["=", "+", "-", "*", "/", "%", "&", "|", "^", "?", "<", ">"].includes(body[index + 3]?.value ?? ""))
+				return undefined;
 		}
 		const names: string[] = [];
 		for (const callerPath of this.closure) {

--- a/packages/workflows/src/shared/possible-stages.ts
+++ b/packages/workflows/src/shared/possible-stages.ts
@@ -803,9 +803,10 @@ function discoveryField(object: readonly Token[] | undefined): readonly Token[] 
 	if (object?.[0]?.value !== "{" || object.at(-1)?.value !== "}") return undefined;
 	let value: readonly Token[] | undefined;
 	for (const field of arrayElements(object)) {
-		// Computed fields/accessors may overwrite the metadata with an unproven value.
-		const key = ["get", "set", "async", "*"].includes(field[0]?.value ?? "") ? field.slice(1) : field;
-		if (key[0]?.value === "[" || (key[0]?.value === "*" && key[1]?.value === "[")) return undefined;
+		// Accessors and prefixed methods can replace a data property just like computed keys.
+		let key = field;
+		while (["get", "set", "async", "*"].includes(key[0]?.value ?? "")) key = key.slice(1);
+		if (key[0]?.value === "[" || (key !== field && key[0]?.value === "possibleStageNames")) return undefined;
 		if (field[0]?.value === ".") {
 			if (value !== undefined) return undefined;
 			continue;
@@ -1159,10 +1160,33 @@ class PossibleStagesScanner {
 		// A property read may be repeated, but rebinding/shadowing the options parameter is not supported.
 		const body = unit.tokens.slice(owner.bodyOpen, owner.bodyClose);
 		if (hasDiscoveryDestructuringWrite(body, value[0].value)) return undefined;
+		// Only direct parallel-option forwarding is proven safe; aliases, escapes and
+		// chained array operations can mutate the caller's literal metadata.
+		const forwarded = new Set<Token>();
+		for (let index = 0; index < body.length; index += 1) {
+			const parallel = matchCtxCall(body, index, this.aliasPool);
+			if (parallel?.method !== "parallel") continue;
+			const field = discoveryField(splitTopLevelArguments(parallel, body)[1]);
+			if (
+				field?.length === 3 &&
+				field[0]?.value === value[0].value &&
+				field[1]?.value === "." &&
+				field[2]?.value === "possibleStageNames"
+			)
+				forwarded.add(field[0]);
+		}
 		for (let index = 0; index < body.length; index += 1) {
 			if (body[index]?.value !== value[0]?.value) continue;
+			if (body[index + 2]?.value === "possibleStageNames" && !forwarded.has(body[index]!)) return undefined;
 			const destructured =
 				body[index - 2]?.value === "}" && body[index - 1]?.value === "=" && body[index + 1]?.value === ";";
+			if (destructured) {
+				for (let open = 0; open < index - 2; open += 1) {
+					if (body[open]?.value !== "{" || matchBracket(body, open, "{", "}") !== index - 2) continue;
+					if (body.slice(open + 1, index - 2).some((token) => token.value === "possibleStageNames"))
+						return undefined;
+				}
+			}
 			if (body[index + 1]?.value !== "." && !destructured) return undefined;
 			if (["delete", "+", "-"].includes(body[index - 1]?.value ?? "")) return undefined;
 			if (["=", "+", "-", "*", "/", "%", "&", "|", "^", "?", "<", ">"].includes(body[index + 3]?.value ?? ""))

--- a/packages/workflows/src/shared/possible-stages.ts
+++ b/packages/workflows/src/shared/possible-stages.ts
@@ -1188,10 +1188,18 @@ class PossibleStagesScanner {
 		// Only direct parallel-option forwarding is proven safe; aliases, escapes and
 		// chained array operations can mutate the caller's literal metadata.
 		const forwarded = new Set<Token>();
+		const spreadOptions = new Set<Token>();
 		for (let index = 0; index < body.length; index += 1) {
 			const parallel = matchCtxCall(body, index, this.aliasPool);
 			if (parallel?.method !== "parallel") continue;
-			const field = discoveryField(splitTopLevelArguments(parallel, body)[1]);
+			const parallelOptions = splitTopLevelArguments(parallel, body)[1];
+			const field = discoveryField(parallelOptions);
+			if (parallelOptions?.[0]?.value === "{") {
+				for (const entry of arrayElements(parallelOptions)) {
+					if (entry.length === 4 && entry.slice(0, 3).every((token) => token.value === "."))
+						spreadOptions.add(entry[3]!);
+				}
+			}
 			if (
 				field?.length === 3 &&
 				field[0]?.value === value[0].value &&
@@ -1206,11 +1214,41 @@ class PossibleStagesScanner {
 			const destructured =
 				body[index - 2]?.value === "}" && body[index - 1]?.value === "=" && body[index + 1]?.value === ";";
 			if (destructured) {
+				let matched = false;
 				for (let open = 0; open < index - 2; open += 1) {
 					if (body[open]?.value !== "{" || matchBracket(body, open, "{", "}") !== index - 2) continue;
-					if (body.slice(open + 1, index - 2).some((token) => token.value === "possibleStageNames"))
-						return undefined;
+					if (body[open - 1]?.value !== "const") return undefined;
+					matched = true;
+					for (const entry of arrayElements(body.slice(open, index - 1))) {
+						if (entry.length === 1 && entry[0]?.kind === "ident" && entry[0].value !== "possibleStageNames")
+							continue;
+						// A rest copy still aliases the metadata array. Only inert concurrency
+						// extraction and direct parallel-option spreads are supported uses.
+						if (
+							entry.length !== 4 ||
+							!entry.slice(0, 3).every((token) => token.value === ".") ||
+							entry[3]?.kind !== "ident"
+						)
+							return undefined;
+						const rest = entry[3];
+						for (let use = 0; use < body.length; use += 1) {
+							const token = body[use];
+							if (token?.kind !== "ident" || token.value !== rest.value || token === rest) continue;
+							if (spreadOptions.has(token)) continue;
+							if (
+								body[use - 3]?.value === "const" &&
+								body[use - 2]?.kind === "ident" &&
+								body[use - 1]?.value === "=" &&
+								body[use + 1]?.value === "." &&
+								body[use + 2]?.value === "concurrency" &&
+								body[use + 3]?.value === ";"
+							)
+								continue;
+							return undefined;
+						}
+					}
 				}
+				if (!matched) return undefined;
 			}
 			// Support only the two authored shapes: direct metadata forwarding and
 			// destructuring plain caller fields. Other member uses may execute or escape.

--- a/packages/workflows/src/shared/possible-stages.ts
+++ b/packages/workflows/src/shared/possible-stages.ts
@@ -1139,6 +1139,17 @@ class PossibleStagesScanner {
 		return resolveRelativeSpecifier(specifier, importingFile);
 	}
 
+	/** Caller options must expose ordinary own data fields, not executable members or a custom prototype. */
+	private hasDataOnlyDiscoveryOptions(argument: readonly Token[] | undefined): boolean {
+		if (argument?.[0]?.value !== "{" || argument.at(-1)?.value !== "}") return false;
+		return arrayElements(argument).every(
+			(field) =>
+				(field[0]?.kind === "ident" || field[0]?.kind === "string") &&
+				field[0].value !== "__proto__" &&
+				field[1]?.value === ":",
+		);
+	}
+
 	private discoveryNames(call: CtxCall, unit: FileUnit, path: string): readonly string[] | undefined {
 		if (call.method !== "parallel") return undefined;
 		const value = discoveryField(splitTopLevelArguments(call, unit.tokens)[1]);
@@ -1157,6 +1168,18 @@ class PossibleStagesScanner {
 		if (owner === undefined || !owner.declaration) return undefined;
 		const parameter = owner.params.findIndex((param) => param[0]?.value === value[0]?.value);
 		if (parameter < 0) return undefined;
+		// Parameter initializers execute before the body. Only inert defaults are supported.
+		for (const param of owner.params) {
+			if (param[0]?.kind !== "ident") return undefined;
+			const assignment = param.findIndex((token) => token.value === "=");
+			if (assignment < 0) continue;
+			const initial = param.slice(assignment + 1);
+			const emptyObject = initial.length === 2 && initial[0]?.value === "{" && initial[1]?.value === "}";
+			const scalar =
+				initial.length === 1 &&
+				(initial[0]?.kind === "string" || ["true", "false", "null", "undefined"].includes(initial[0]?.value ?? ""));
+			if (!emptyObject && !scalar) return undefined;
+		}
 		// A property read may be repeated, but rebinding/shadowing the options parameter is not supported.
 		const body = unit.tokens.slice(owner.bodyOpen, owner.bodyClose);
 		if (hasDiscoveryDestructuringWrite(body, value[0].value)) return undefined;
@@ -1188,6 +1211,7 @@ class PossibleStagesScanner {
 				}
 			}
 			if (body[index + 1]?.value !== "." && !destructured) return undefined;
+			if (!destructured && ["(", ".", "[", "?", "?."].includes(body[index + 3]?.value ?? "")) return undefined;
 			if (["delete", "+", "-"].includes(body[index - 1]?.value ?? "")) return undefined;
 			if (["=", "+", "-", "*", "/", "%", "&", "|", "^", "?", "<", ">"].includes(body[index + 3]?.value ?? ""))
 				return undefined;
@@ -1219,6 +1243,7 @@ class PossibleStagesScanner {
 				if (calls === undefined) return undefined;
 				for (const argsOpen of calls) {
 					const argument = splitTopLevelArguments({ method: "parallel", argsOpen }, caller.tokens)[parameter];
+					if (!this.hasDataOnlyDiscoveryOptions(argument)) return undefined;
 					const declared = literalDiscoveryNames(discoveryField(argument));
 					if (declared === undefined) return undefined;
 					names.push(...declared);

--- a/packages/workflows/src/shared/possible-stages.ts
+++ b/packages/workflows/src/shared/possible-stages.ts
@@ -798,6 +798,94 @@ function collectDefinitionName(
 	return undefined;
 }
 
+/** Explicit metadata is intentionally literal and call-scoped, not a warning override. */
+function discoveryField(object: readonly Token[] | undefined): readonly Token[] | undefined {
+	if (object?.[0]?.value !== "{" || object.at(-1)?.value !== "}") return undefined;
+	let value: readonly Token[] | undefined;
+	for (const field of arrayElements(object)) {
+		if (field[0]?.value === ".") {
+			if (value !== undefined) return undefined;
+			continue;
+		}
+		if (field[0]?.value !== "possibleStageNames") continue;
+		if (value !== undefined || field[1]?.value !== ":") return undefined;
+		value = field.slice(2);
+	}
+	return value;
+}
+
+function literalDiscoveryNames(value: readonly Token[] | undefined): readonly string[] | undefined {
+	if (value?.[0]?.value !== "[" || value.at(-1)?.value !== "]") return undefined;
+	const names: string[] = [];
+	for (const element of arrayElements(value)) {
+		if (element.length !== 1 || element[0]?.kind !== "string") return undefined;
+		names.push(element[0].value);
+	}
+	return names.length > 0 ? names : undefined;
+}
+
+interface DiscoveryHelper {
+	readonly name: string;
+	readonly nameIndex: number;
+	readonly params: readonly (readonly Token[])[];
+	readonly bodyOpen: number;
+	readonly bodyClose: number;
+}
+
+/** Named declarations only. Arrow helpers and further forwarding remain unsupported. */
+function discoveryHelpers(tokens: readonly Token[]): DiscoveryHelper[] {
+	const helpers: DiscoveryHelper[] = [];
+	for (let index = 0; index < tokens.length; index += 1) {
+		if (tokens[index]?.value !== "function" || tokens[index + 1]?.kind !== "ident") continue;
+		let open = index + 2;
+		if (tokens[open]?.value === "<") open = (matchBracket(tokens, open, "<", ">") ?? tokens.length) + 1;
+		if (tokens[open]?.value !== "(") continue;
+		const close = matchBracket(tokens, open, "(", ")");
+		if (close === undefined) continue;
+		let bodyOpen = close + 1;
+		while (bodyOpen < tokens.length && tokens[bodyOpen]?.value !== "{") bodyOpen += 1;
+		const bodyClose = matchBracket(tokens, bodyOpen, "{", "}");
+		if (bodyClose === undefined) continue;
+		helpers.push({
+			name: tokens[index + 1]!.value,
+			nameIndex: index + 1,
+			params: splitTopLevelArguments({ method: "parallel", argsOpen: open }, tokens),
+			bodyOpen,
+			bodyClose,
+		});
+	}
+	return helpers;
+}
+
+/** Fail closed on aliases, rebindings and shadowed names rather than borrowing another scope's metadata. */
+function discoveryCalls(tokens: readonly Token[], name: string, declaration?: number): number[] | undefined {
+	const calls: number[] = [];
+	for (let index = 0; index < tokens.length; index += 1) {
+		if (tokens[index]?.value === "import") {
+			while (index < tokens.length && tokens[index]?.kind !== "string") index += 1;
+			continue;
+		}
+		if (tokens[index]?.value === "export" && tokens[index + 1]?.value === "{") {
+			const close = matchBracket(tokens, index + 1, "{", "}") ?? tokens.length;
+			const exported = tokens.slice(index + 2, close);
+			if (
+				exported.some(
+					(token, offset) =>
+						token.value === name && (declaration === undefined || exported[offset + 1]?.value === "as"),
+				)
+			)
+				return undefined;
+			index = close;
+			continue;
+		}
+		if (tokens[index]?.kind !== "ident" || tokens[index]?.value !== name || index === declaration) continue;
+		if (tokens[index + 1]?.value !== "(" || [".", "?.", "function"].includes(tokens[index - 1]?.value ?? ""))
+			return undefined;
+		calls.push(index + 1);
+	}
+	return calls;
+}
+
 // ---------------------------------------------------------------------------
 // Scanner
 // ---------------------------------------------------------------------------
@@ -811,6 +899,7 @@ class PossibleStagesScanner {
 	/** Context-like aliases (e.g. `designContext`) seen anywhere in this scan, so helper
 	 * modules that receive the context under another name still resolve its stage calls. */
 	private readonly aliasPool = new Set<string>();
+	private closure: readonly string[] = [];
 
 	constructor(maxDepth: number) {
 		this.maxDepth = maxDepth;
@@ -861,10 +950,16 @@ class PossibleStagesScanner {
 				this.aliasPool.add(alias);
 			}
 		}
-		for (const path of ordered) {
-			const unit = this.units.get(path);
-			if (unit === undefined) continue;
-			this.scanUnit(unit, path, boundaryPrefix, depth, ancestorStack);
+		const previousClosure = this.closure;
+		this.closure = ordered;
+		try {
+			for (const path of ordered) {
+				const unit = this.units.get(path);
+				if (unit === undefined) continue;
+				this.scanUnit(unit, path, boundaryPrefix, depth, ancestorStack);
+			}
+		} finally {
+			this.closure = previousClosure;
 		}
 	}
 
@@ -1024,8 +1119,75 @@ class PossibleStagesScanner {
 		return resolveRelativeSpecifier(specifier, importingFile);
 	}
 
+	private discoveryNames(call: CtxCall, unit: FileUnit, path: string): readonly string[] | undefined {
+		if (call.method !== "parallel") return undefined;
+		const value = discoveryField(splitTopLevelArguments(call, unit.tokens)[1]);
+		const literal = literalDiscoveryNames(value);
+		if (literal !== undefined) return literal;
+		if (
+			value?.length !== 3 ||
+			value[0]?.kind !== "ident" ||
+			value[1]?.value !== "." ||
+			value[2]?.value !== "possibleStageNames"
+		)
+			return undefined;
+		const owner = discoveryHelpers(unit.tokens)
+			.filter((helper) => helper.bodyOpen < call.argsOpen && helper.bodyClose > call.argsOpen)
+			.at(-1);
+		if (owner === undefined) return undefined;
+		const parameter = owner.params.findIndex((param) => param[0]?.value === value[0]?.value);
+		if (parameter < 0) return undefined;
+		// A property read may be repeated, but rebinding/shadowing the options parameter is not supported.
+		const body = unit.tokens.slice(owner.bodyOpen, owner.bodyClose);
+		for (let index = 0; index < body.length; index += 1) {
+			if (body[index]?.value !== value[0]?.value) continue;
+			const destructured =
+				body[index - 2]?.value === "}" && body[index - 1]?.value === "=" && body[index + 1]?.value === ";";
+			if (body[index + 1]?.value !== "." && !destructured) return undefined;
+			if (["=", "+", "-"].includes(body[index + 3]?.value ?? "")) return undefined;
+		}
+		const names: string[] = [];
+		for (const callerPath of this.closure) {
+			const caller = this.units.get(callerPath);
+			if (caller === undefined) continue;
+			if (
+				[...caller.imports.values()].some(
+					(binding) =>
+						binding.importedName === undefined &&
+						resolveRelativeSpecifier(binding.specifier, callerPath) === path,
+				)
+			)
+				return undefined;
+			const references =
+				callerPath === path
+					? [owner.name]
+					: [...caller.imports]
+							.filter(
+								([, binding]) =>
+									binding.importedName === owner.name &&
+									resolveRelativeSpecifier(binding.specifier, callerPath) === path,
+							)
+							.map(([local]) => local);
+			for (const reference of references) {
+				const calls = discoveryCalls(caller.tokens, reference, callerPath === path ? owner.nameIndex : undefined);
+				if (calls === undefined) return undefined;
+				for (const argsOpen of calls) {
+					const argument = splitTopLevelArguments({ method: "parallel", argsOpen }, caller.tokens)[parameter];
+					const declared = literalDiscoveryNames(discoveryField(argument));
+					if (declared === undefined) return undefined;
+					names.push(...declared);
+				}
+			}
+		}
+		// Importing a module for another export does not invoke this annotated helper.
+		// Every reference above was checked; an opaque caller would already have bailed out.
+		return names.length > 0 || this.closure[0] !== path ? names : undefined;
+	}
+
 	/** Step `name:` patterns for a `chain`/`parallel` call's first argument. */
 	private stepNamesForStepsCall(call: CtxCall, unit: FileUnit, path: string): readonly string[] {
+		const declared = this.discoveryNames(call, unit, path);
+		if (declared !== undefined) return declared;
 		const first = firstArgumentTokens(call, unit.tokens);
 		if (first === undefined || first.length === 0) return [];
 		const head = first[0]!;

--- a/test/unit/verification-prompt-layout.test.ts
+++ b/test/unit/verification-prompt-layout.test.ts
@@ -12,6 +12,7 @@ import type {
 	WorkflowTaskResult,
 	WorkflowTaskStep,
 } from "../../packages/workflows/src/shared/types.js";
+import { createStore, mockSession, run, workflow } from "./executor-shared.js";
 
 const criterionA = { id: "correctness", name: "Correctness", description: "The candidate is correct." };
 const criterionB = { id: "evidence", name: "Evidence", description: "The candidate cites evidence." };
@@ -195,4 +196,132 @@ describe("prompt-layout", () => {
 		);
 		assert.deepEqual(calls, [["a-1", "b-1"], ["a-2"]]);
 	});
+
+	// Regression #3001: discovery metadata must not alter the warm/rest state transitions.
+	test("#3001 metadata preserves warm barrier, result identity, caps and rest-error precedence", async () => {
+		const input = steps("a-1", "a-2", "b-1", "b-2");
+		const reports = input.map((step) => result(step.name));
+		const calls: string[][] = [];
+		let releaseWarm!: () => void;
+		const warmBarrier = new Promise<void>((resolve) => {
+			releaseWarm = resolve;
+		});
+		const ctx = {
+			parallel: async (phase: readonly WorkflowTaskStep[], options: WorkflowParallelOptions = {}) => {
+				calls.push(phase.map((step) => step.name));
+				assert.equal(options.concurrency, 1);
+				if (calls.length === 1) {
+					assert.equal(options.failFast, false);
+					await warmBarrier;
+				}
+				return phase.map((step) => reports[input.indexOf(step)]!);
+			},
+		};
+		const pending = warm_first_fan_out(ctx, input, (step) => step.prompt, {
+			concurrency: 1,
+			possibleStageNames: ["a-*", "b-*"],
+		});
+		assert.deepEqual(calls, [["a-1", "b-1"]]);
+		releaseWarm();
+		const output = await pending;
+		assert.deepEqual(calls, [
+			["a-1", "b-1"],
+			["a-2", "b-2"],
+		]);
+		output.forEach((report, index) => {
+			assert.equal(report, reports[index]);
+		});
+		const restError = new Error("rest failed");
+		let phase = 0;
+		await assert.rejects(
+			warm_first_fan_out(
+				{
+					parallel: async () => {
+						phase += 1;
+						throw phase === 1 ? new Error("warm failed") : restError;
+					},
+				},
+				input,
+				(step) => step.prompt,
+				{ possibleStageNames: ["a-*", "b-*"] },
+			),
+			(error) => error === restError,
+		);
+		assert.equal(phase, 2);
+		assert.deepEqual(await warm_first_fan_out(ctx, [], (step) => step.prompt, { possibleStageNames: [] }), []);
+	});
+});
+
+// Regression #3001: exercise the actual workflow engine and parallel scheduler, not only a helper stub.
+test("#3001 engine executes annotated warm/rest groups at the same concurrency", async () => {
+	const names = ["a-1", "a-2", "b-1", "b-2"];
+	const started: string[] = [];
+	let active = 0;
+	let peak = 0;
+	let releaseWarm!: () => void;
+	let markWarmReady!: () => void;
+	const warmBarrier = new Promise<void>((resolve) => {
+		releaseWarm = resolve;
+	});
+	const warmReady = new Promise<void>((resolve) => {
+		markWarmReady = resolve;
+	});
+	const definition = workflow({
+		name: "issue-3001-runtime",
+		description: "",
+		inputs: {},
+		outputs: {},
+		run: async (ctx) => {
+			const results = await warm_first_fan_out(
+				ctx,
+				names.map((name) => ({ name, prompt: name })),
+				(step) => step.name[0],
+				{
+					concurrency: 2,
+					possibleStageNames: ["a-*", "b-*"],
+				},
+			);
+			assert.deepEqual(
+				results.map((report) => report.name),
+				names,
+			);
+			return {};
+		},
+	});
+	const execution = run(
+		definition,
+		{},
+		{
+			store: createStore(),
+			adapters: {
+				agentSession: {
+					create: async () => ({
+						...mockSession(),
+						prompt: async (text) => {
+							const name = names.find((candidate) => text.includes(candidate));
+							assert.ok(name);
+							started.push(name);
+							active += 1;
+							peak = Math.max(peak, active);
+							if (name.endsWith("-1")) {
+								if (started.length === 2) markWarmReady();
+								await warmBarrier;
+							}
+							active -= 1;
+						},
+					}),
+				},
+			},
+		},
+	);
+	await warmReady;
+	try {
+		assert.deepEqual(started, ["a-1", "b-1"]);
+	} finally {
+		releaseWarm();
+	}
+	const completed = await execution;
+	assert.equal(completed.status, "completed", completed.error);
+	assert.deepEqual(started, ["a-1", "b-1", "a-2", "b-2"]);
+	assert.equal(peak, 2);
 });

--- a/test/unit/workflow-possible-stages-scan.test.ts
+++ b/test/unit/workflow-possible-stages-scan.test.ts
@@ -178,6 +178,16 @@ for (const extension of ["ts", "js"]) {
 		["logical", "options.possibleStageNames ||= unknownNames;"],
 		["delete", "delete options.possibleStageNames;"],
 		["prefix", "++options.possibleStageNames;"],
+		["element", "options.possibleStageNames[0] = 'actual';"],
+		["length", "options.possibleStageNames.length = 0;"],
+		["splice", "options.possibleStageNames.splice(0, 1, 'actual');"],
+		["push", "options.possibleStageNames.push('actual');"],
+		["fill", "options.possibleStageNames.fill('actual');"],
+		["computed-method", "options.possibleStageNames['splice'](0, 1, 'actual');"],
+		["optional-method", "options.possibleStageNames?.splice(0, 1, 'actual');"],
+		["array-alias", "const names = options.possibleStageNames; names[0] = 'actual';"],
+		["array-escape", "mutate(options.possibleStageNames);"],
+		["destructured-array-alias", "const { possibleStageNames: names } = options; names[0] = 'actual';"],
 	]) {
 		test(`#3001 ${extension} ${variant} metadata write retains both warnings`, () => {
 			const result = scanFile(
@@ -209,6 +219,11 @@ for (const extension of ["ts", "js"]) {
 		"['possibleStageNames']: unknownNames",
 		"[key]: unknownNames",
 		"get ['possibleStageNames']() { return unknownNames; }",
+		"get possibleStageNames() { return unknownNames; }",
+		"set possibleStageNames(value) {}",
+		"async possibleStageNames() {}",
+		"*possibleStageNames() {}",
+		"async *possibleStageNames() {}",
 	]) {
 		test(`#3001 ${extension} computed override retains both warnings: ${override}`, () => {
 			const result = scanFile(

--- a/test/unit/workflow-possible-stages-scan.test.ts
+++ b/test/unit/workflow-possible-stages-scan.test.ts
@@ -283,6 +283,16 @@ for (const extension of ["ts", "js"]) {
 		["array-alias", "const names = options.possibleStageNames; names[0] = 'actual';"],
 		["array-escape", "mutate(options.possibleStageNames);"],
 		["destructured-array-alias", "const { possibleStageNames: names } = options; names[0] = 'actual';"],
+		["rest-array-alias", "const { concurrency, ...rest } = options; rest.possibleStageNames.splice(0, 1, 'actual');"],
+		[
+			"computed-array-alias",
+			"const key = 'possibleStageNames'; const { [key]: names } = options; names[0] = 'actual';",
+		],
+		["rest-alias-escape", "const { concurrency, ...rest } = options; mutate(rest);"],
+		[
+			"rest-alias-rebind",
+			"const { concurrency, ...rest } = options; const copy = rest; copy.possibleStageNames[0] = 'actual';",
+		],
 	]) {
 		test(`#3001 ${extension} ${variant} metadata write retains both warnings`, () => {
 			const result = scanFile(

--- a/test/unit/workflow-possible-stages-scan.test.ts
+++ b/test/unit/workflow-possible-stages-scan.test.ts
@@ -166,6 +166,105 @@ describe("#3001 call-scoped discovery metadata", () => {
 	});
 });
 
+// Regression #3001: writes through destructuring and other property-write forms invalidate caller metadata.
+for (const extension of ["ts", "js"]) {
+	for (const [variant, mutation] of [
+		["array", "[options.possibleStageNames] = [unknownNames];"],
+		["nested-array", "[[options.possibleStageNames]] = [[unknownNames]];"],
+		["object", "({ names: options.possibleStageNames } = source);"],
+		["nested-object", "({ names: [options.possibleStageNames] } = source);"],
+		["rest", "[...options.possibleStageNames] = source;"],
+		["loop", "for ([options.possibleStageNames] of source) {}"],
+		["logical", "options.possibleStageNames ||= unknownNames;"],
+		["delete", "delete options.possibleStageNames;"],
+		["prefix", "++options.possibleStageNames;"],
+	]) {
+		test(`#3001 ${extension} ${variant} metadata write retains both warnings`, () => {
+			const result = scanFile(
+				`write-${extension}-${variant}.${extension}`,
+				`
+				async function fan(ctx, steps, options) {
+					${mutation}
+					const warmSteps = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+					const restSteps = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+					await ctx.parallel(warmSteps, { possibleStageNames: options.possibleStageNames });
+					await ctx.parallel(restSteps, { possibleStageNames: options.possibleStageNames });
+				}
+				export default workflow({ name: "write", async run(ctx) {
+					await fan(ctx, opaque(), { possibleStageNames: ['a-*'] });
+				} });
+			`,
+			);
+			assert.deepEqual(result.stages, []);
+			assert.equal(result.warnings.length, 2);
+			for (const group of ["warmSteps", "restSteps"])
+				assert.ok(result.warnings.some((w) => w.includes(`"${group}"`)));
+		});
+	}
+}
+
+// Regression #3001: an unknown computed key can replace earlier literal metadata.
+for (const extension of ["ts", "js"]) {
+	for (const override of [
+		"['possibleStageNames']: unknownNames",
+		"[key]: unknownNames",
+		"get ['possibleStageNames']() { return unknownNames; }",
+	]) {
+		test(`#3001 ${extension} computed override retains both warnings: ${override}`, () => {
+			const result = scanFile(
+				`computed-${extension}-${override.length}.${extension}`,
+				`
+				async function fan(ctx, steps, options) {
+					const warmSteps = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+					const restSteps = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+					await ctx.parallel(warmSteps, { possibleStageNames: options.possibleStageNames });
+					await ctx.parallel(restSteps, { possibleStageNames: options.possibleStageNames });
+				}
+				export default workflow({ name: "computed", async run(ctx) {
+					await fan(ctx, opaque(), { possibleStageNames: ['a-*'], ${override} });
+				} });
+			`,
+			);
+			assert.deepEqual(result.stages, []);
+			assert.equal(result.warnings.length, 2);
+			for (const group of ["warmSteps", "restSteps"])
+				assert.ok(result.warnings.some((w) => w.includes(`"${group}"`)));
+		});
+	}
+}
+
+// Regression #3001: expression-local names do not prove an imported helper is unused.
+for (const extension of ["ts", "js"]) {
+	for (const bound of [false, true]) {
+		test(`#3001 ${extension} ${bound ? "bound" : "exported"} function expressions retain both warnings`, () => {
+			const stem = `expression-${extension}-${bound}`;
+			writeFixture(
+				`${stem}-helper.${extension}`,
+				`
+				${bound ? "const impl" : "export const fan"} = async function internalFan(ctx, steps, options) {
+					const warmSteps = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+					const restSteps = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+					await ctx.parallel(warmSteps, { possibleStageNames: options.possibleStageNames });
+					await ctx.parallel(restSteps, { possibleStageNames: options.possibleStageNames });
+				};
+				${bound ? "export const fan = impl;" : ""}
+			`,
+			);
+			const result = scanFile(
+				`${stem}.${extension}`,
+				`
+				import { fan } from "./${stem}-helper.js";
+				export default workflow({ name: "expression", async run(ctx) { await fan(ctx, opaque(), {}); } });
+			`,
+			);
+			assert.deepEqual(result.stages, []);
+			assert.equal(result.warnings.length, 2);
+			for (const group of ["warmSteps", "restSteps"])
+				assert.ok(result.warnings.some((w) => w.includes(`"${group}"`)));
+		});
+	}
+}
+
 // Regression #3001: use real package build output, not a hand-written JavaScript proxy.
 test("#3001 packaged builtin JavaScript discovers warm/rest names", () => {
 	const bundled = join(BUILTIN_DIR, "..", "..", "coding-agent", "dist", "builtin", "workflows", "builtin");

--- a/test/unit/workflow-possible-stages-scan.test.ts
+++ b/test/unit/workflow-possible-stages-scan.test.ts
@@ -166,6 +166,68 @@ describe("#3001 call-scoped discovery metadata", () => {
 	});
 });
 
+// Regression #3001: parameter initialization runs before body-only provenance checks.
+for (const extension of ["ts", "js"]) {
+	for (const initializer of [
+		"ignored = (options.possibleStageNames = ['actual-*'])",
+		"ignored = options.possibleStageNames.splice(0, 1, 'actual-*')",
+		"{ ignored = (options.possibleStageNames = ['actual-*']) } = {}",
+	]) {
+		test(`#3001 ${extension} parameter side effect retains both warnings: ${initializer}`, () => {
+			const result = scanFile(
+				`parameter-${extension}-${initializer.length}.${extension}`,
+				`
+				async function fan(ctx, steps, options, ${initializer}) {
+					const warmSteps = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+					const restSteps = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+					await ctx.parallel(warmSteps, { possibleStageNames: options.possibleStageNames });
+					await ctx.parallel(restSteps, { possibleStageNames: options.possibleStageNames });
+				}
+				export default workflow({ name: 'parameter', async run(ctx) {
+					await fan(ctx, opaque(), { possibleStageNames: ['stale-*'] });
+				} });
+			`,
+			);
+			assert.deepEqual(result.stages, []);
+			assert.equal(result.warnings.length, 2);
+			for (const group of ["warmSteps", "restSteps"])
+				assert.ok(result.warnings.some((warning) => warning.includes(`"${group}"`)));
+		});
+	}
+}
+
+// Regression #3001: caller methods/getters must not mutate metadata behind a member read.
+for (const extension of ["ts", "js"]) {
+	for (const [access, field] of [
+		["options.mutate();", "mutate() { this.possibleStageNames = ['actual-*']; }"],
+		["const cap = options.concurrency;", "get concurrency() { this.possibleStageNames = ['actual-*']; return 2; }"],
+		["const { concurrency } = options;", "get concurrency() { this.possibleStageNames = ['actual-*']; return 2; }"],
+		["options.mutate?.();", "mutate: () => sideEffect()"],
+	]) {
+		test(`#3001 ${extension} options side effect retains both warnings: ${access}`, () => {
+			const result = scanFile(
+				`side-effect-${extension}-${access.length}.${extension}`,
+				`
+				async function fan(ctx, steps, options) {
+					${access}
+					const warmSteps = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+					const restSteps = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+					await ctx.parallel(warmSteps, { possibleStageNames: options.possibleStageNames });
+					await ctx.parallel(restSteps, { possibleStageNames: options.possibleStageNames });
+				}
+				export default workflow({ name: 'side-effect', async run(ctx) {
+					await fan(ctx, opaque(), { possibleStageNames: ['stale-*'], ${field} });
+				} });
+			`,
+			);
+			assert.deepEqual(result.stages, []);
+			assert.equal(result.warnings.length, 2);
+			for (const group of ["warmSteps", "restSteps"])
+				assert.ok(result.warnings.some((warning) => warning.includes(`"${group}"`)));
+		});
+	}
+}
+
 // Regression #3001: writes through destructuring and other property-write forms invalidate caller metadata.
 for (const extension of ["ts", "js"]) {
 	for (const [variant, mutation] of [

--- a/test/unit/workflow-possible-stages-scan.test.ts
+++ b/test/unit/workflow-possible-stages-scan.test.ts
@@ -166,6 +166,36 @@ describe("#3001 call-scoped discovery metadata", () => {
 	});
 });
 
+// Regression #3001: arguments exposes a second reference to the caller options object.
+for (const extension of ["ts", "js"]) {
+	for (const access of [
+		"arguments[2].possibleStageNames = ['actual-*'];",
+		"const alias = arguments[2]; alias.possibleStageNames = ['actual-*'];",
+	]) {
+		test(`#3001 ${extension} arguments alias retains both warnings: ${access}`, () => {
+			const result = scanFile(
+				`arguments-${extension}-${access.length}.${extension}`,
+				`
+				async function fan(ctx, steps, options) {
+					${access}
+					const warmSteps = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+					const restSteps = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+					await ctx.parallel(warmSteps, { possibleStageNames: options.possibleStageNames });
+					await ctx.parallel(restSteps, { possibleStageNames: options.possibleStageNames });
+				}
+				export default workflow({ name: 'arguments', async run(ctx) {
+					await fan(ctx, opaque(), { possibleStageNames: ['stale-*'] });
+				} });
+			`,
+			);
+			assert.deepEqual(result.stages, []);
+			assert.equal(result.warnings.length, 2);
+			for (const group of ["warmSteps", "restSteps"])
+				assert.ok(result.warnings.some((warning) => warning.includes(`"${group}"`)));
+		});
+	}
+}
+
 // Regression #3001: parameter initialization runs before body-only provenance checks.
 for (const extension of ["ts", "js"]) {
 	for (const initializer of [
@@ -203,6 +233,9 @@ for (const extension of ["ts", "js"]) {
 		["const cap = options.concurrency;", "get concurrency() { this.possibleStageNames = ['actual-*']; return 2; }"],
 		["const { concurrency } = options;", "get concurrency() { this.possibleStageNames = ['actual-*']; return 2; }"],
 		["options.mutate?.();", "mutate: () => sideEffect()"],
+		["options.reset`x`;", "reset: function() { this.possibleStageNames = ['actual-*']; }"],
+		[`options.reset\`\${1}\`;`, "reset: function() { this.possibleStageNames = ['actual-*']; }"],
+		["const reset = options.reset; reset();", "reset: () => sideEffect()"],
 	]) {
 		test(`#3001 ${extension} options side effect retains both warnings: ${access}`, () => {
 			const result = scanFile(

--- a/test/unit/workflow-possible-stages-scan.test.ts
+++ b/test/unit/workflow-possible-stages-scan.test.ts
@@ -25,6 +25,179 @@ function scanFile(name: string, source: string, options?: { readonly maxDepth?: 
 	return scanPossibleStagesFromSource(writeFixture(name, source), options);
 }
 
+// Regression #3001: warm/rest indexed maps must advertise names, not just hide warnings.
+test("#3001 builtin warm-first groups expose conservative names", () => {
+	for (const [name, expected] of [
+		["adversarial-verification", "verifier-*-*-*"],
+		["tournament", "judge-*-*-*-r*"],
+	]) {
+		const result = scanPossibleStagesFromSource(join(BUILTIN_DIR, `${name}.ts`));
+		assert.ok(result.stages.includes(expected!), JSON.stringify(result));
+		assert.equal(
+			result.warnings.some((warning) => /"(?:warmSteps|restSteps)"/.test(warning)),
+			false,
+		);
+	}
+});
+
+describe("#3001 call-scoped discovery metadata", () => {
+	for (const extension of ["ts", "js"]) {
+		for (const group of ["warmSteps", "restSteps"]) {
+			// Regression #3001: test each indexed group independently, including stripped non-null assertions.
+			test(`${extension} ${group} follows a named import alias without inventing other names`, () => {
+				const stem = `metadata-${extension}-${group}`;
+				writeFixture(
+					`${stem}-helper.${extension}`,
+					`
+					export async function fanOut(ctx, steps, options = {}) {
+						const ${group} = indices.map(index => steps[index]${extension === "ts" ? "!" : ""});
+						await ctx.parallel(${group}, { possibleStageNames: options.possibleStageNames });
+						await ctx.parallel(unsupported);
+					}
+				`,
+				);
+				const result = scanFile(
+					`${stem}.${extension}`,
+					`
+					import { fanOut as launch } from "./${stem}-helper.js"
+					export default workflow({ name: "metadata", run: async ctx => {
+						await launch(ctx, opaque(), { possibleStageNames: ["review-a", "review-*", "review-a", " raw "] });
+					}});
+				`,
+				);
+				assert.deepEqual(result.stages, [" raw ", "review-*", "review-a"]);
+				assert.equal(result.warnings.length, 1);
+				assert.match(result.warnings[0]!, /steps argument "unsupported"/);
+			});
+		}
+	}
+	// Regression #3001: one annotated call cannot cover another opaque caller or a shadowed binding.
+	for (const extra of [
+		`await launch(ctx, opaque(), {});`,
+		`await launch(ctx, opaque(), { possibleStageNames: [] });`,
+		`await launch(ctx, opaque(), { possibleStageNames: dynamic });`,
+		`const alias = launch; await alias(ctx, opaque(), { possibleStageNames: ["wrong"] });`,
+		`function nested(launch) { launch(ctx, opaque(), { possibleStageNames: ["wrong"] }); }`,
+	]) {
+		test(`unproven helper caller retains diagnostics: ${extra}`, () => {
+			writeFixture(
+				"opaque-helper.ts",
+				`export async function fanOut(ctx, steps, options) {
+				const warmSteps = indices.map(index => steps[index]!);
+				await ctx.parallel(warmSteps, { possibleStageNames: options.possibleStageNames });
+			}`,
+			);
+			const result = scanFile(
+				"opaque-caller.ts",
+				`
+				import { fanOut as launch } from "./opaque-helper.js";
+				export default workflow({ name: "opaque", run: async ctx => {
+					await launch(ctx, opaque(), { possibleStageNames: ["review-*"] });
+					${extra}
+				}});
+			`,
+			);
+			assert.deepEqual(result.stages, []);
+			assert.ok(result.warnings.some((warning) => warning.includes('"warmSteps"')));
+		});
+	}
+	// Regression #3001: renamed exports are not proof that all calls carry the named import's metadata.
+	test("#3001 renamed helper exports do not borrow another caller's metadata", () => {
+		writeFixture(
+			"export-helper.ts",
+			`export async function fanOut(ctx, steps, options) {
+			await ctx.parallel(opaque, { possibleStageNames: options.possibleStageNames });
+		}
+		export { fanOut as another };
+		`,
+		);
+		const result = scanFile(
+			"export-caller.ts",
+			`
+			import { fanOut, another } from "./export-helper.js";
+			export default workflow({ name: "export-alias", run: async ctx => {
+				await fanOut(ctx, [], { possibleStageNames: ["known"] });
+				await another(ctx, opaque(), {});
+			}});
+		`,
+		);
+		assert.deepEqual(result.stages, []);
+		assert.equal(result.warnings.length, 1);
+	});
+	// Regression #3001: a namespace use cannot be covered by another caller's literal list.
+	test("#3001 namespace helper calls retain diagnostics beside an annotated named import", () => {
+		writeFixture(
+			"namespace-helper.ts",
+			`export async function fanOut(ctx, steps, options) {
+			await ctx.parallel(opaque, { possibleStageNames: options.possibleStageNames });
+		}`,
+		);
+		const result = scanFile(
+			"namespace-caller.ts",
+			`
+			import { fanOut as launch } from "./namespace-helper.js";
+			import * as helpers from "./namespace-helper.js";
+			export default workflow({ name: "namespace", run: async ctx => {
+				await launch(ctx, [], { possibleStageNames: ["known"] });
+				await helpers.fanOut(ctx, opaque(), {});
+			}});
+		`,
+		);
+		assert.deepEqual(result.stages, []);
+		assert.equal(result.warnings.length, 1);
+	});
+	// Regression #3001: an options alias must not make stale caller metadata authoritative.
+	test("#3001 options alias mutation retains the opaque-array warning", () => {
+		const result = scanFile(
+			"metadata-mutation.ts",
+			`
+			async function fanOut(ctx, steps, options) {
+				const alias = options;
+				alias.possibleStageNames = ["changed"];
+				await ctx.parallel(opaque, { possibleStageNames: options.possibleStageNames });
+			}
+			export default workflow({ name: "mutation", run: async ctx => {
+				await fanOut(ctx, [], { possibleStageNames: ["stale"] });
+			}});
+		`,
+		);
+		assert.deepEqual(result.stages, []);
+		assert.equal(result.warnings.length, 1);
+	});
+});
+
+// Regression #3001: use real package build output, not a hand-written JavaScript proxy.
+test("#3001 packaged builtin JavaScript discovers warm/rest names", () => {
+	const bundled = join(BUILTIN_DIR, "..", "..", "coding-agent", "dist", "builtin", "workflows", "builtin");
+	for (const [name, patterns] of [
+		["adversarial-verification", ["verifier-*-*-*", "verifier-*-*-*-reask-*"]],
+		["tournament", ["judge-*-*-*-r*"]],
+	] as const) {
+		const entry = join(bundled, `${name}.js`);
+		assert.ok(existsSync(entry), "Run npm run build before the unit suite");
+		const result = scanPossibleStagesFromSource(entry);
+		for (const pattern of patterns) assert.ok(result.stages.includes(pattern), JSON.stringify(result));
+		assert.equal(
+			result.warnings.some((warning) => /"(?:warmSteps|restSteps)"/.test(warning)),
+			false,
+		);
+	}
+});
+
+// Regression #3001: goal imports scoring prompts, not the warm-first helper from that same module.
+test("#3001 source and bundled goal do not warn on an unused annotated helper or invent its stages", () => {
+	const bundled = join(BUILTIN_DIR, "..", "..", "coding-agent", "dist", "builtin", "workflows", "builtin");
+	for (const entry of [join(BUILTIN_DIR, "goal.ts"), join(bundled, "goal.js")]) {
+		const result = scanPossibleStagesFromSource(entry);
+		assert.ok(result.stages.includes("orchestrator-*"));
+		assert.deepEqual(result.warnings, []);
+		assert.equal(
+			result.stages.some((name) => /(?:verifier-|judge-)/.test(name)),
+			false,
+		);
+	}
+});
+
 // ---------------------------------------------------------------------------
 // D2 — stage-name pattern extraction
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix advance possible-stage discovery for the builtin warm-first verifier and tournament judge groups. Both `warmSteps` and `restSteps` now advertise conservative names in source and packaged JavaScript instead of producing opaque-array warnings.

Closes #3001

## Changes

- Add optional `WorkflowParallelOptions.possibleStageNames` literal metadata and forward it through both warm-first parallel calls.
- Resolve supported named-helper callers, including relative named-import aliases, within the current discovery closure. Fall back to existing diagnostics for unproven callers, mutation, aliases, computed overrides, and unsupported forwarding.
- Declare verifier and judge name patterns at their callers. Do not infer arbitrary indexed-map JavaScript or suppress unsupported user warnings.
- Add issue-tagged source, stripped-JavaScript, real bundled-output, provenance, and actual-engine regressions. Document the supported metadata shape and add an Unreleased fix entry.

Runtime scheduling is unchanged. Metadata does not control execution, concurrency, warm-first ordering, results, or errors. No dependency, version, or workflows build-step changes.

## Verification

Reviewed candidate: `82c997138f584d977ce2c70a6afc72f660ea2022`, tree `f792e35b1a95183befdda3337d323637c02859df`, based on `ff55b141109e3f9f5980c1f0c718dea39f6b2fd9`.

The completed goal's receipts and three independent final reviews report the following for this candidate. The PR handoff inspected the approval artifacts and current build/test logs; it did not rerun the full suites.

- `npm run build`: passed, including packaged builtin JavaScript.
- `npm run check`: passed.
- `npm run test:unit`: 810 files passed, 8,376 tests passed, 23 existing skips.
- `npm run test:unit -- test/unit/workflow-possible-stages-scan.test.ts test/unit/workflow-possible-stages-persistence.test.ts test/unit/verification-prompt-layout.test.ts`: 160 passed.
- Independent executable checks covered four isolated warm/rest TypeScript and transpiled-JavaScript fixtures, six source/bundle scans, 24 baseline/candidate diagnostic cases, 60 runtime comparisons, two warm barriers, nesting/path isolation, and source/generated API types.
- Docs and builtin packaging checks passed. Read-only qlty metrics/smells supplemented the authoritative repository checks.

The nine-file merge-base diff is the issue fix. `main` advanced during implementation; the approved branch has not been rebased, so local validation does not claim to test the eventual merge with current `main`. GitHub CI remains to be evaluated. No UI recording applies to this static-discovery change.

## Contract amendments received

Inherited steering kept the original #3001 scope unchanged: require concrete baseline-versus-candidate evidence for introduced lost diagnostics or stale names; do not expand into general JavaScript inference or pre-existing parser repairs; prefer small supported structural shapes with conservative fallback. Create the PR only after approval. Do not merge or publish releases.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/3007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791795280&installation_model_id=10562&pr_number=3007&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F3007&signature=d45a2ffcb933d2103704c35b13a3b2e474347bf053df4068c0e9925427fb18ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63391998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: discovery recognizes the supported metadata forwarding path, retains diagnostics for unsupported callers, and preserves warm/rest scheduling behavior.

What we checked:
- Authored and executed the possible-stage discovery verification script from the codebase; the run completed with exit code 0. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validated the negative-control stage discovery test run by inspecting the before-log, which showed 5 tests passed and exit code 0. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validated the after-stage discovery test run by inspecting the after-log, which showed 3 tests across 2 files passed and exit code 0. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Reviewed the code references to confirm the forwarding logic and scanner recognition are implemented in the relevant modules. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- No merge-blocking issues found. The new metadata exposes conservative verifier and judge stage patterns for dynamically generated warm-first parallel work, including the packaged workflow output, without changing execution scheduling.

<sub>Reviews (1) · Last reviewed commit: ["fix(workflows): constrain destructured d..."](https://github.com/bastani-inc/atomic/commit/82c997138f584d977ce2c70a6afc72f660ea2022)</sub>

<!-- /greptile_comment -->