### PR TITLE
docs(release): prepare 0.9.19-alpha.7 changelogs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.7] - 2026-09-12
+
 ### Fixed
 
 - Reduced CPU work in long `/tasks` live transcripts on Windows by reusing unchanged message rendering during streaming, without dropping history or delaying live updates.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.19-alpha.7] - 2026-09-12
+
 ### Fixed
 
 - `fetch_content` now shows each URL's error and recovery steps when an entire batch fails, instead of hiding the causes behind a generic failure count. Retained partial content is shown as incomplete excerpts rather than incorrectly reported as absent.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.19-alpha.7] - 2026-09-12
+
 ### Fixed
 
 - Warm-first verifier and tournament judge groups now advertise conservative possible-stage names in source and bundled workflows without the builtin `warmSteps`/`restSteps` discovery warnings. Call-scoped `possibleStageNames` metadata leaves execution unchanged and retains diagnostics for unsupported dynamic calls ([#3001](https://github.com/bastani-inc/atomic/issues/3001)).


### PR DESCRIPTION
## Summary

Prepare the 0.9.19-alpha.7 prerelease notes in the coding-agent, web-access, and workflows changelogs. The diff adds release headings only and preserves all existing entries.

## Changes

- Include Windows live transcript rendering improvements.
- Include per-URL failure details and retained partial content for fetch_content.
- Include warm-first workflow discovery and fixes for quit, readiness questions, and failed cancellation.

## Validation

- Confirmed the entire branch diff contains only the three intended changelogs.
- Confirmed all eight packages/*/package.json manifests and workspace lock entries remain at 0.0.0. Cargo files and generated version files are unchanged.
- bun run scripts/build-release-notes.ts 0.9.19-alpha.7 passed.
- bun run scripts/generate-coding-agent-shrinkwrap.mjs --check passed.
- bun run test:unit -- test/unit/build-release-notes.test.ts test/unit/bump-version-script.test.ts passed, 10 tests.
- bun run check and all applicable commit hooks passed. Three existing informational lint notices were left unchanged.
- git diff --check passed.

## Release boundary

This PR does not stamp package versions. Only scripts/cut-release.ts may stamp 0.9.19-alpha.7 on the detached Release commit after this PR merges. No merge, tag, publication, or duplicate release workflow was initiated in this stage. The eventual version-tag push starts publish.yml without a separate normal-publication dispatch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/3009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791820919&installation_model_id=10562&pr_number=3009&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F3009&signature=639de0b3c5eb5814013885bf5c1667d0385e3d622577300408b3aa4d797400b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63442712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The changelog-only PR appears safe to merge.

<h3>Summary</h3>

- Adds matching 0.9.19-alpha.7 headings to the coding-agent, web-access, and workflows changelogs.
- Preserves every existing changelog entry without modifying package versions or implementation code.
- Follows the established changelog structure and release-heading convention.

<sub>Reviews (1) · Last reviewed commit: ["docs(release): prepare 0.9.19-alpha.7 ch..."](https://github.com/bastani-inc/atomic/commit/3e30ff0d432b8cf2174e093c7478bac01c4c5dcb)</sub>

<!-- /greptile_comment -->