### PR TITLE
docs(release): prepare 0.9.19-alpha.8 changelog

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.19-alpha.8] - 2026-09-12
+
 ### Fixed
 
 - Workflow status detail now shows started and ended times in the system local timezone instead of UTC, preserving the compact `HH:mm:ss` display and elapsed durations ([#3008](https://github.com/bastani-inc/atomic/issues/3008)).


### PR DESCRIPTION
## Summary

Prepare the 0.9.19-alpha.8 prerelease notes in packages/workflows/CHANGELOG.md. Adds only the dated release heading, preserving existing notes and released history.

## Changes

- Include local-time workflow status timestamps.
- Include cleaner workflow graph cards and a separate queued-message row that preserves status and model details.

## Validation

- Confirmed one changelog-only commit and a clean worktree.
- All eight package manifests and workspace lock entries remain at 0.0.0. Cargo versions, the native dependency pin, shrinkwrap versions, and generated native version checks also remain at 0.0.0. These files are unchanged.
- `bun run scripts/build-release-notes.ts 0.9.19-alpha.8` passed.
- `bun run test:unit -- test/unit/changelog.test.ts test/unit/build-release-notes.test.ts test/unit/bump-version-script.test.ts` passed, 22 tests.
- `bun run check` and applicable commit hooks passed. Three existing informational lint notices were left unchanged.
- `git diff --check` passed.

## Release boundary

This PR changes release notes only. Only scripts/cut-release.ts may stamp 0.9.19-alpha.8 on the detached Release commit after this PR merges. The eventual version-tag push starts publish.yml without a duplicate normal-publication dispatch. This stage does not merge, tag, publish, or launch another release workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/3014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791834370&installation_model_id=10562&pr_number=3014&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F3014&signature=a54d9a1c0f89eb3e3aedd54ff2136d0b7457be1a4dc28c1dbc7ae9411b45f5a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63477766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge; the changelog entry is correctly delimited and generates the intended release notes.

What we checked:
- Reviewed the pre-change state where the generator failed with exit code 1 and produced no notes. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Executed the release-notes heading validation script for version 0.9.19-alpha.8 to generate the release notes. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Confirmed the run exited with code 0 and produced the expected Changed and Fixed notes. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Inspected the corresponding before and after artifacts to verify the validation results align with the claimed behavior. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- Adds the `0.9.19-alpha.8` release heading and date to the workflows changelog.
- The release-notes generator produces the expected Fixed and Changed entries for this version while keeping `Unreleased` separate.
- No issues found; the change is safe to merge.

<sub>Reviews (1) · Last reviewed commit: ["docs(release): prepare 0.9.19-alpha.8 ch..."](https://github.com/bastani-inc/atomic/commit/761c47244b55b30e8caba6108081d8dcf0506340)</sub>

<!-- /greptile_comment -->