### PR TITLE
fix(intercom)!: prioritize exact targets and correlate replies

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Explicit Intercom `reply` selectors reject stale, unknown, empty, or sender-mismatched threads instead of falling back. Use `pending` and an exact `replyTo` for unresolved questions.
+
+### Changed
+
+- Intercom agent lists put exact copyable session IDs and workflow paths first, with useful metadata and meaningful names secondary rather than redundant generated aliases.
+
+### Fixed
+
+- Intercom targeted replies now complete the requested ask when an unrelated message is active, rather than delivering a response with the wrong thread ID or refusing it.
+
 ## [0.9.19-alpha.7] - 2026-09-12
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- Explicit Intercom `reply` selectors reject stale, unknown, empty, or sender-mismatched threads instead of falling back. Use `pending` and an exact `replyTo` for unresolved questions.
+- Explicit Intercom `action: "reply"` selectors reject stale, unknown, empty, or sender-mismatched threads instead of falling back. Use `action: "pending"` and `replyTo: "<pending-ask-id>"` for unresolved questions.
 
 ### Changed
 

--- a/packages/coding-agent/docs/intercom.md
+++ b/packages/coding-agent/docs/intercom.md
@@ -81,10 +81,10 @@ The agent can list sessions and send messages using the `intercom` tool. Tool ca
 ```typescript
 // List active sessions
 intercom({ action: "list" })
-// → **Current session:**
-// → • executor (20d43841-1111-4222-8333-123456789abc) — ~/projects/api (claude-sonnet-4) [self, idle]
-// → **Other sessions:**
-// → • research (6332faab-1111-4222-8333-123456789abc) — ~/projects/api (claude-sonnet-4) [same cwd, thinking]
+// → **Current session** (groups: default):
+// → - `20d43841-1111-4222-8333-123456789abc` [self, idle] ~/projects/api (claude-sonnet-4) name: executor
+// → **Other visible sessions and workflow stages:**
+// → - `6332faab-1111-4222-8333-123456789abc` [same cwd, thinking] ~/projects/api (claude-sonnet-4) name: research
 
 // Send a message
 intercom({ action: "send", to: "research", message: "Check if UserService.validate() handles null" })

--- a/packages/coding-agent/docs/intercom/reference.md
+++ b/packages/coding-agent/docs/intercom/reference.md
@@ -53,6 +53,8 @@ Sent and received messages are recorded in session history as `intercom_sent` / 
 
 Live-session lookup accepts only an exact full Intercom session ID or an exact case-insensitive session name. Workflow stages use the canonical `workflow:<rootRunId>/<segment>[/<segment>...]` path printed by `intercom list` and workflow status surfaces; an exact target works while the row is `PENDING` and after it becomes `RUNNING`. Each segment may be a stage name, run id, or glob: `*` matches one segment and may be embedded, while `**` matches any depth. Status surfaces label pending stages whose pre-start delivery capability is unavailable without presenting a usable target and never advertise a retained pending stage after its run terminates. The `sessionId` shown by `workflow status` belongs to the workflow SDK and is **not** an Intercom target.
 
+Agent list rows put the copyable exact ID or canonical workflow path first, followed by status and working directory. Meaningful names remain secondary metadata; redundant generated aliases are hidden only in the list, not removed from lookup. Pending and future workflow rows retain lifecycle and queued counts. Copy the target rather than reconstructing it from a name.
+
 Known non-agent IDs, names, and workflow paths are refused rather than delivered or queued for a future agent. This includes run-level `ctx.ui` prompts, synthetic prompt stages (including retained completed prompts), and `ctx.tool` nodes. Knowing an internal connection's ID does not bypass this broker policy, and supervisor delivery cannot bypass it either. Workflow patterns and `workflow:<rootRunId>/**` still queue for future agent stages, but never deliver to prompt/tool nodes or routing connections.
 
 This refusal also covers nested paths using boundary-stage names or IDs, mixed with materialized run-ID segments. The same spellings still resolve genuine agent stages.
@@ -99,6 +101,8 @@ An `idle` registration does not guarantee reply capability. Completed, failed, i
 **`contact_supervisor`** keeps a narrower policy: one blocking decision/interview wait per child may coexist with ordinary peer asks, but a second concurrent supervisor wait receives `Already waiting for a supervisor reply`. Claimed foreground handoffs allocate no waiter. Mutual peer asks are supported, although both sessions must process inbound work to reply; the per-waiter timeout remains the backstop.
 
 **`reply`** is receiver-side sugar for replying to an inbound ask. In the turn triggered by an incoming intercom message, `intercom({ action: "reply", message: "..." })` targets that exact sender and message automatically. If you reply later, it falls back to the single unresolved inbound ask; with multiple pending asks, use `pending` and pass `to`, or pass the listed message ID as `replyTo` to disambiguate multiple asks from the same sender. Under the hood this is still a normal `send` with the exact `replyTo` value.
+
+Explicit selectors override the active turn: `to` selects a pending ask from that exact name/full session ID, and `replyTo` selects only that pending ask or the exact active ordinary message. Stale, unknown, or empty thread IDs fail without falling back. If both selectors are supplied, the sender must match the thread. If an asker is still waiting, inspect `pending` and reply using its exact message ID rather than replying implicitly to an unrelated notification. Multiple asks from the same sender require `replyTo`.
 
 ### Attachments
 

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Explicit `reply` selectors now fail closed: stale, unknown, empty, or sender-mismatched `replyTo` values no longer fall back to another active or pending thread. Use `pending` to select the exact unresolved question.
+
+### Changed
+
+- Agent-visible Intercom lists lead with copyable full session IDs and canonical workflow paths, keeping status, working directory, meaningful names, and future queued counts without redundant generated aliases.
+
+### Fixed
+
+- Targeted replies select the requested sender's pending ask even when an unrelated message triggered the current turn, so a delivered reply no longer leaves that ask waiting on the wrong thread.
+
 ## [0.9.19-alpha.6] - 2026-09-11
 
 ### Fixed

--- a/packages/intercom/README.md
+++ b/packages/intercom/README.md
@@ -57,7 +57,7 @@ A session becomes intercom-connected when all of these are true:
 
 The session list, ALT+M picker, and group counts include connected agent sessions only. Internal workflow routing/control connections, model-less `ctx.ui` prompts, and `ctx.tool` nodes are hidden and cannot receive ordinary messages, even by a known ID or through a supervisor route. This includes run-level prompts and retained completed synthetic prompt stages. An agent executing a tool, including `tool:workflow`, or awaiting human input remains visible and messageable.
 
-If a session is unnamed, intercom exposes a runtime-only fallback alias like `subagent-chat-1a2b3c4d-1111-4222-8333-123456789abc` so other sessions can still target it. That alias is not persisted as the session title, so resume pickers can keep showing the transcript snippet instead of a generic `session-...` name.
+Unnamed sessions retain a runtime-only alias such as `subagent-chat-1a2b3c4d-1111-4222-8333-123456789abc` for name lookup. Agent lists omit this redundant alias and lead with the copyable full session ID. Meaningful names remain secondary metadata; resume titles are unchanged.
 
 ## Quick Start
 
@@ -76,10 +76,10 @@ The agent can list sessions and send messages using the `intercom` tool. Tool ca
 ```typescript
 // List active sessions
 intercom({ action: "list" })
-// → **Current session:**
-// → • executor (20d43841-1111-4222-8333-123456789abc) — ~/projects/api (claude-sonnet-4) [self, idle]
-// → **Other sessions:**
-// → • research (6332faab-1111-4222-8333-123456789abc) — ~/projects/api (claude-sonnet-4) [same cwd, thinking]
+// → **Current session** (groups: default):
+// → - `20d43841-1111-4222-8333-123456789abc` [self, idle] ~/projects/api (claude-sonnet-4) name: executor
+// → **Other visible sessions and workflow stages:**
+// → - `6332faab-1111-4222-8333-123456789abc` [same cwd, thinking] ~/projects/api (claude-sonnet-4) name: research
 
 // Add a named membership (it is created if no session is there yet)
 intercom({ action: "join", group: "api-review" })
@@ -156,7 +156,7 @@ Verify they see each other from either session:
 
 ```typescript
 intercom({ action: "list" })
-// → • worker — ~/projects/api (claude-sonnet-4) [idle]
+// → - `6332faab-1111-4222-8333-123456789abc` [same cwd, idle] ~/projects/api (claude-sonnet-4) name: worker
 ```
 
 ### The Conversation
@@ -383,7 +383,7 @@ When multiple live agent stages share a name, `ask` refuses the ambiguous target
 
 **`ask`** — Sends a message and waits for a live recipient to reply (10-minute timeout). Invocation control supports a live ask into an owned isolated subgroup, and the exact broker-recorded reply resolves the waiting tool call at the asker without opening reverse or lateral group access. Ask to an uninitialized stage remains refused with `pending_stage_ask_unsupported`; use queued `send` instead, because holding a reply waiter until a stage eventually starts would be unbounded. A recipient disconnect after live delivery fails only that peer's exact wait promptly; the timeout remains the backstop while the recipient stays connected. Up to `maxPendingAsks` blocking asks (default: 6) may run concurrently, including same-target and mixed-target fan-out. Replies resolve by exact sender and message ID, so out-of-order replies cannot cross-settle another call. When capacity is full, new asks receive a structured refusal.
 
-**`reply`** — Replies to the current intercom-triggered message if there is one. Otherwise it falls back to the single unresolved inbound ask. If multiple asks are pending, pass an exact name/full session ID in `to`, or the listed message ID in `replyTo`; use `pending` to inspect them first. `replyTo` also disambiguates multiple asks from the same sender. Under the hood this is still a normal `send` with the exact `replyTo` value.
+**`reply`** without selectors replies to the current intercom-triggered message, or otherwise the single unresolved inbound ask. Explicit `to` selects a pending ask from that exact name/full session ID, even during another sender's turn. If that sender has multiple asks, use `pending` and pass the exact message ID as `replyTo`. Explicit `replyTo` selects only that pending ask or the exact active ordinary message; stale, unknown, or empty IDs fail instead of falling back. When both selectors are supplied, the sender must match the selected thread. A successful reply keeps that sender/thread pair across internal retries.
 
 **`pending`** — Lists unresolved inbound asks with sender, message ID, elapsed time, and a short preview. Useful when replying after the original triggered turn.
 

--- a/packages/intercom/broker/client.ts
+++ b/packages/intercom/broker/client.ts
@@ -38,6 +38,8 @@ export interface SendOptions {
   logicalTarget?: string;
   /** Public reply must use the broker's exact pending reverse question route. */
   requirePendingReply?: true;
+  /** An explicit reply selector must resolve to this frozen recipient, never a namesake. */
+  expectedRecipientId?: string;
   /** Broker-authorized identity for a canonical-path ask, delivered before its recipient can reply. */
   onReplyTarget?: (sessionId: string) => void;
 }
@@ -1004,6 +1006,7 @@ export class IntercomClient extends EventEmitter {
 			transportTarget: to,
 			logicalSignature: buildSendSignature(options.logicalTarget ?? to, options),
 			requirePendingReply: options.requirePendingReply ?? false,
+			...(options.expectedRecipientId === undefined ? {} : { expectedRecipientId: options.expectedRecipientId }),
 		});
 		acquired = this.pendingSends.acquire(messageId, pendingSignature, 10000);
     } catch (error) {
@@ -1028,6 +1031,7 @@ export class IntercomClient extends EventEmitter {
 			to,
 			...(options.logicalTarget === undefined ? {} : { logicalTarget: options.logicalTarget }),
 			...(options.requirePendingReply === undefined ? {} : { requirePendingReply: options.requirePendingReply }),
+			...(options.expectedRecipientId === undefined ? {} : { expectedRecipientId: options.expectedRecipientId }),
       ...(options.onReplyTarget === undefined ? {} : { resolveReplyTarget: true as const }),
 			message,
 			attemptId: acquired.attempt.attemptId,

--- a/packages/intercom/broker/send-handler.ts
+++ b/packages/intercom/broker/send-handler.ts
@@ -143,6 +143,12 @@ export function handleBrokerSend(
     return;
   }
   const requirePendingReply = clientMessage.requirePendingReply === true;
+  const hasExpectedRecipientId = Object.prototype.hasOwnProperty.call(clientMessage, "expectedRecipientId");
+  if (hasExpectedRecipientId && (typeof clientMessage.expectedRecipientId !== "string" || !clientMessage.expectedRecipientId.trim())) {
+    write(socket, { type: "delivery_failed", messageId, attemptId, reason: "Invalid expectedRecipientId format" });
+    return;
+  }
+  const expectedRecipientId = hasExpectedRecipientId ? clientMessage.expectedRecipientId as string : undefined;
   if (Object.prototype.hasOwnProperty.call(clientMessage, "channel")) {
     write(socket, { type: "delivery_failed", messageId: message.id, attemptId, reason: "Invalid channel" });
     return;
@@ -150,6 +156,10 @@ export function handleBrokerSend(
   const supervisorSend = clientMessage.type === "supervisor_send";
   if (requirePendingReply && (supervisorSend || message.replyTo === undefined || message.expectsReply === true)) {
     write(socket, { type: "delivery_failed", messageId, attemptId, reason: "Invalid requirePendingReply message" });
+    return;
+  }
+  if (expectedRecipientId !== undefined && (supervisorSend || message.replyTo === undefined || message.expectsReply === true)) {
+    write(socket, { type: "delivery_failed", messageId, attemptId, reason: "Invalid expectedRecipientId message" });
     return;
   }
 
@@ -161,7 +171,8 @@ export function handleBrokerSend(
   }
 	const senderIdentity = fromSession.registrationReturnAddress ?? fromSession.info.id;
 	const logicalTarget = typeof clientMessage.logicalTarget === "string" ? clientMessage.logicalTarget : clientMessage.to;
-	const baseSignature = buildMessageSendSignature(logicalTarget, message, senderIdentity);
+	const messageSignature = buildMessageSendSignature(logicalTarget, message, senderIdentity);
+	const baseSignature = expectedRecipientId === undefined ? messageSignature : JSON.stringify({ expectedRecipientId, messageSignature });
 	const signature = requirePendingReply
 		? JSON.stringify({
 				requirePendingReply: true,
@@ -221,6 +232,12 @@ export function handleBrokerSend(
   const resolution = exactIdTarget
     ? ({ kind: "resolved", session: exactIdTarget.info } as const)
     : resolveSessionTarget(candidates, trimmedTo);
+  if (expectedRecipientId !== undefined && (resolution.kind !== "resolved" || resolution.session.id !== expectedRecipientId)) {
+    write(socket, { type: "delivery_failed", messageId, attemptId,
+      reason: resolution.kind === "resolved" ? "Reply target does not match the expected recipient" : sessionTargetFailureReason(clientMessage.to, resolution),
+    });
+    return;
+  }
   if (resolution.kind === "resolved") {
     const target = sessions.get(resolution.session.id);
     if (!target) {

--- a/packages/intercom/intercom-tool.ts
+++ b/packages/intercom/intercom-tool.ts
@@ -151,14 +151,14 @@ async function resolveReplySender(
 }
 
 function formatWorkflowStageRow(stage: WorkflowStageRosterEntry): string {
-	return `- **${stage.stageName}** — workflow stage [${stage.lifecycle.toUpperCase()}] — target: \`${stage.target}\`${
-		stage.sessionId === undefined ? "" : ` — intercom session: ${stage.sessionId}`
+	return `- \`${stage.target}\` [${stage.lifecycle.toUpperCase()}] workflow stage: ${stage.stageName}${
+		stage.sessionId === undefined ? "" : ` session: \`${stage.sessionId}\``
 	}`;
 }
 
 /** D7 (slice 4): one possible-future row from the run's persisted scan (or the `**` broadcast row). */
 function formatWorkflowFutureStageRow(stage: WorkflowFutureStageRosterEntry): string {
-	return `- future workflow stage \`${stage.target}\` — ${stage.queuedCount} queued message${
+	return `- \`${stage.target}\` [future] ${stage.queuedCount} queued message${
 		stage.queuedCount === 1 ? "" : "s"
 	}`;
 }
@@ -999,6 +999,7 @@ one shared membership; contact_supervisor remains the only cross-group path.`,
               messageId: replyMessageId,
               logicalTarget: replyLogicalTarget,
               ...(route.expectsReply ? { requirePendingReply: true as const } : {}),
+              ...(to === undefined ? {} : { expectedRecipientId: route.senderId }),
               text: message,
               attachments,
               replyTo: route.messageId,

--- a/packages/intercom/intercom-tool.ts
+++ b/packages/intercom/intercom-tool.ts
@@ -999,7 +999,7 @@ one shared membership; contact_supervisor remains the only cross-group path.`,
               messageId: replyMessageId,
               logicalTarget: replyLogicalTarget,
               ...(route.expectsReply ? { requirePendingReply: true as const } : {}),
-              ...(to === undefined ? {} : { expectedRecipientId: route.senderId }),
+              ...(to === undefined && replyTo === undefined ? {} : { expectedRecipientId: route.senderId }),
               text: message,
               attachments,
               replyTo: route.messageId,
@@ -1007,6 +1007,7 @@ one shared membership; contact_supervisor remains the only cross-group path.`,
             let result = await sendReply(replySendTo);
             if (
               to === undefined &&
+              replyTo === undefined &&
               result.delivered === false &&
               result.reasonCode === "session_not_found" &&
               route.senderName !== undefined

--- a/packages/intercom/intercom-utils.ts
+++ b/packages/intercom/intercom-utils.ts
@@ -407,14 +407,15 @@ export function formatSessionLabel(session: SessionInfo, duplicates: Set<string>
     : session.name;
 }
 export function formatSessionListRow(session: SessionInfo, currentCwd: string, isSelf: boolean): string {
-  const name = session.name || "Unnamed session";
+  const name = session.name && session.name !== session.id && session.name !== resolveIntercomPresenceName(undefined, session.id)
+    ? ` name: ${session.name}` : "";
   const normalizedGroup = normalizeGroup(session.group);
   const groupTag = normalizedGroup !== DEFAULT_GROUP ? `group: ${normalizedGroup}` : undefined;
   const capabilityTag = session.replyCapability === undefined ? undefined : `replyCapability: ${session.replyCapability}`;
   const tags = [isSelf ? "self" : session.cwd === currentCwd ? "same cwd" : undefined, session.status, capabilityTag, groupTag]
     .filter((tag): tag is string => Boolean(tag));
   const suffix = tags.length ? ` [${tags.join(", ")}]` : "";
-  return `• ${name} (${session.id}) — ${session.cwd} (${session.model})${suffix}`;
+  return `- \`${session.id}\`${suffix} ${session.cwd} (${session.model})${name}`;
 }
 export function previewText(value: unknown, maxLength = 72): string | undefined {
   if (typeof value !== "string") {

--- a/packages/intercom/reply-tracker.ts
+++ b/packages/intercom/reply-tracker.ts
@@ -58,22 +58,23 @@ export class ReplyTracker {
 
 	resolveReplyTarget(options: { to?: string; replyTo?: string }, now = Date.now()): IntercomContext {
 		this.pruneExpired(now);
-		if (options.replyTo) {
-			const exact = this.pendingAsks.get(options.replyTo);
-			if (exact) {
-				if (options.to) {
-					const resolution = resolveSessionTarget([exact.from], options.to);
-					if (resolution.kind !== "resolved") throw new Error(`Pending ask "${options.replyTo}" is not from "${options.to}"`);
-				}
-				return exact;
+		if (options.replyTo !== undefined) {
+			const exact = this.pendingAsks.get(options.replyTo) ??
+				(this.currentTurnContext?.message.id === options.replyTo && !this.currentTurnContext.message.expectsReply
+					? this.currentTurnContext : undefined);
+			if (!exact) throw new Error(`No reply context for "${options.replyTo}"`);
+			if (options.to !== undefined) {
+				const resolution = resolveSessionTarget([exact.from], options.to);
+				if (resolution.kind !== "resolved") throw new Error(`Reply context "${options.replyTo}" is not from "${options.to}"`);
 			}
+			return exact;
 		}
-    if (this.currentTurnContext) {
+    if (options.to === undefined && this.currentTurnContext) {
       return this.currentTurnContext;
     }
 
     const pending = Array.from(this.pendingAsks.values());
-    if (options.to) {
+    if (options.to !== undefined) {
       const senders = [...new Map(
         pending.map((context) => [context.from.id, context.from] as const),
       ).values()];

--- a/packages/intercom/skills/intercom/SKILL.md
+++ b/packages/intercom/skills/intercom/SKILL.md
@@ -67,11 +67,11 @@ intercom({
 
 ### Pattern 2: Quick Status Check
 
-Before sending, verify who's connected. The full session ID printed by `list` is directly usable by `send`, `ask`, and targeted `reply`:
+Before sending, verify who's connected. Each list row leads with a copyable full session ID or canonical workflow path. Names are secondary; redundant generated aliases are omitted from the list but remain valid targets.
 
 ```typescript
 intercom({ action: "list" })
-// → • planner (6332faab-1111-4222-8333-123456789abc) — /workspace (model) [idle]
+// → - `6332faab-1111-4222-8333-123456789abc` [idle] /workspace (model) name: planner
 intercom({ action: "ask", to: "6332faab-1111-4222-8333-123456789abc", message: "Which option should I use?" })
 ```
 
@@ -128,7 +128,7 @@ intercom({ action: "pending" })
 intercom({ action: "reply", to: "planner", message: "Use exponential backoff starting at 100ms." })
 ```
 
-`reply` still preserves exact threading under the hood by sending the response with the original `replyTo` value.
+Explicit `to` selects that sender's pending ask even if another message triggered the current turn. Use `pending` and an exact `replyTo` when the sender has several asks. Stale, unknown, empty, or sender-mismatched explicit selectors fail without replying to another thread. Omit both selectors only when you intend to reply to the active message, or otherwise the single pending ask.
 
 ### Pattern 4: Broadcast to Multiple Workers
 

--- a/packages/intercom/types.ts
+++ b/packages/intercom/types.ts
@@ -124,7 +124,7 @@ export type ClientMessage =
 	| { type: "join_group"; requestId: string; group: string }
 	| { type: "leave_group"; requestId: string; group?: string }
   | { type: "authorize_supervisor"; requestId: string; childName: string; capability?: string }
-  | { type: "send" | "supervisor_send"; to: string; logicalTarget?: string; requirePendingReply?: true; resolveReplyTarget?: true; message: Message; attemptId?: string }
+  | { type: "send" | "supervisor_send"; to: string; logicalTarget?: string; requirePendingReply?: true; expectedRecipientId?: string; resolveReplyTarget?: true; message: Message; attemptId?: string }
 	| {
 			type: "send_pending_stage_notification";
 			runId: string;

--- a/test/integration/intercom-reconnect-recovery.test.ts
+++ b/test/integration/intercom-reconnect-recovery.test.ts
@@ -664,7 +664,11 @@ test("a running workflow stage regains list visibility and both route aliases af
 
 		const baselineList = await sender.execute({ action: "list" });
 		assert.equal(baselineList.isError, false);
-		assert.match(baselineList.content[0]?.text ?? "", new RegExp(`workflow stage \\[RUNNING\\].*${stageTarget}`));
+		assert.ok(
+			(baselineList.content[0]?.text ?? "").includes(
+				`- \`${stageTarget}\` [RUNNING] workflow stage: reviewer session: \``,
+			),
+		);
 		for (const target of [stageTarget, stageNameTarget]) {
 			const sent = await sender.execute({ action: "send", to: target, message: `baseline to ${target}` });
 			assert.equal(sent.details.delivered, true, `baseline send to ${target} must be delivered live`);
@@ -691,9 +695,9 @@ test("a running workflow stage regains list visibility and both route aliases af
 		const recoveredList = await waitFor("the stage to return to the intercom roster", async () => {
 			const listed = await sender.execute({ action: "list" });
 			const text = listed.content[0]?.text ?? "";
-			return text.includes(`target: \`${stageTarget}\``) && text.includes("intercom session:") ? text : undefined;
+			return text.includes(`- \`${stageTarget}\` [RUNNING] workflow stage: reviewer session: \``) ? text : undefined;
 		});
-		assert.match(recoveredList, new RegExp(`workflow stage \\[RUNNING\\].*${stageTarget}`));
+		assert.ok(recoveredList.includes(`- \`${stageTarget}\` [RUNNING] workflow stage: reviewer session: \``));
 		assert.equal(forced.failures(), 1, "exactly one stage reconnect attempt must have been forced to fail");
 		assert.equal(stage.toolExecutions, 0, "the stage must recover without making an intercom tool call");
 

--- a/test/integration/workflow-pending-stage-delivery.test.ts
+++ b/test/integration/workflow-pending-stage-delivery.test.ts
@@ -2401,10 +2401,10 @@ test("an invocation controls pending and live delivery into an owned isolated st
 						);
 						const stageList = await executeIntercom(fixture, { action: "list" });
 						assert.equal(stageList.isError, false);
-						assert.match(stageList.content[0]?.text ?? "", /isolated-peer \([^)]+\)/);
+						assert.match(stageList.content[0]?.text ?? "", /^- `[^`]+` \[[^\n]+\].* name: isolated-peer$/m);
 						assert.doesNotMatch(stageList.content[0]?.text ?? "", /isolated-owner/);
 						const peerList = await executeIntercom(peer, { action: "list" });
-						assert.match(peerList.content[0]?.text ?? "", /isolated-stage \([^)]+\)/);
+						assert.match(peerList.content[0]?.text ?? "", /^- `[^`]+` \[[^\n]+\].* name: isolated-stage$/m);
 
 						const sent = await executeIntercom(fixture, {
 							action: "send",
@@ -2495,16 +2495,17 @@ test("an invocation controls pending and live delivery into an owned isolated st
 		assert.equal(store.runs()[0]?.stages[0]?.intercomGroup, isolatedGroup);
 		assert.equal(store.pendingStageMessagesFor(runId, "reviewer").length, 1);
 		assert.equal(backend.getWorkflow(runId)?.pendingStageMessages?.length, 1);
-		let roster: Array<{ target: string; group: string }> = [];
-		for (let attempt = 0; attempt < 20 && roster.length === 0; attempt += 1) {
-			const listed = await executeIntercom(workflowSender, { action: "list" });
-			if ((listed.content[0]?.text ?? "").includes(`target: \`workflow:${runId}/`)) {
-				roster = [{ target: `workflow:${runId}/${store.runs()[0]?.stages[0]?.id}`, group: isolatedGroup }];
-			}
-			if (roster.length === 0) await new Promise((resolve) => setTimeout(resolve, 10));
-		}
+		// PR #3018: list rows lead with the canonical target, not a trailing target label.
 		const stageTarget = `workflow:${runId}/${store.runs()[0]?.stages[0]?.id}`;
-		assert.deepEqual(roster, [{ target: stageTarget, group: isolatedGroup }]);
+		const pendingRow = `- \`${stageTarget}\` [PENDING] workflow stage: `;
+		let rosterText = "";
+		for (let attempt = 0; attempt < 20 && !rosterText.includes(pendingRow); attempt += 1) {
+			const listed = await executeIntercom(workflowSender, { action: "list" });
+			assert.equal(listed.isError, false);
+			rosterText = listed.content[0]?.text ?? "";
+			if (!rosterText.includes(pendingRow)) await new Promise((resolve) => setTimeout(resolve, 10));
+		}
+		assert.ok(rosterText.includes(pendingRow), rosterText);
 
 		releaseStageInitialization.resolve();
 		await stageReadyForInvocationAsk.promise;
@@ -2875,7 +2876,7 @@ test("route-neutral store churn preserves durable queueing and live delivery for
 		const pendingList = await executeIntercom(sender, { action: "list" });
 		assert.equal(pendingList.isError, false);
 		assert.equal(
-			(pendingList.content[0]?.text ?? "").includes(`[PENDING] — target: \`${idTarget}\``),
+			(pendingList.content[0]?.text ?? "").includes(`- \`${idTarget}\` [PENDING] workflow stage: reviewer`),
 			true,
 			pendingList.content[0]?.text,
 		);

--- a/test/unit/intercom-broker-send-handler.test.ts
+++ b/test/unit/intercom-broker-send-handler.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../../packages/intercom/broker/send-handler.js";
 import { buildMessageSendSignature } from "../../packages/intercom/broker/send-signature.js";
 import { SupervisorChannelCache } from "../../packages/intercom/broker/supervisor-channel.js";
-import type { BrokerMessage, Message, SessionInfo } from "../../packages/intercom/types.js";
+import type { BrokerMessage, ClientMessage, Message, SessionInfo } from "../../packages/intercom/types.js";
 
 function session(
 	id: string,
@@ -875,7 +875,12 @@ test("explicit reply recipient binding is validated, retained in authority, and 
 	const cache = new DeliveredMessageCache();
 	const writes: Array<{ socket: net.Socket; message: BrokerMessage }> = [];
 	let queued = 0;
-	const send = (frame: Record<string, unknown>) => {
+	type SendFrame = Extract<ClientMessage, { type: "send" | "supervisor_send" }>;
+	// Wire validation must also cover values excluded by the valid protocol type.
+	type SendOverrides = Partial<Omit<SendFrame, "expectedRecipientId">> & {
+		expectedRecipientId?: SendFrame["expectedRecipientId"] | null | false | 0;
+	};
+	const send = (frame: SendOverrides) => {
 		handleBrokerSend(
 			sender.socket,
 			{
@@ -900,7 +905,7 @@ test("explicit reply recipient binding is validated, retained in authority, and 
 		);
 		return writes.at(-1)!.message;
 	};
-	for (const expectedRecipientId of [undefined, null, false, 0, "", " "]) {
+	for (const expectedRecipientId of [undefined, null, false, 0, "", " "] as const) {
 		const result = send({ expectedRecipientId });
 		assert.equal(result.type, "delivery_failed");
 		if (result.type === "delivery_failed") assert.match(result.reason, /Invalid expectedRecipientId format/);
@@ -914,7 +919,7 @@ test("explicit reply recipient binding is validated, retained in authority, and 
 			message: { ...message("ask-not-reply"), replyTo: "thread", expectsReply: true },
 		},
 		{ expectedRecipientId: recipient.info.id, to: "workflow:11111111-1111-4111-8111-111111111111/future" },
-	])
+	] satisfies SendOverrides[])
 		assert.equal(send(frame).type, "delivery_failed");
 	assert.equal(queued, 0);
 	assert.equal(writes.filter((entry) => entry.socket === recipient.socket).length, 0);

--- a/test/unit/intercom-broker-send-handler.test.ts
+++ b/test/unit/intercom-broker-send-handler.test.ts
@@ -864,3 +864,65 @@ test("broker records delivered questions and clears them only after routing the 
 	);
 	assert.deepEqual(pending.takeForTarget("target-exact"), []);
 });
+
+test("explicit reply recipient binding is validated, retained in authority, and cannot queue", () => {
+	const sender = session("sender", "sender", {} as net.Socket);
+	const recipient = session("recipient", "recipient", {} as net.Socket);
+	const sessions = new Map([
+		[sender.info.id, sender],
+		[recipient.info.id, recipient],
+	]);
+	const cache = new DeliveredMessageCache();
+	const writes: Array<{ socket: net.Socket; message: BrokerMessage }> = [];
+	let queued = 0;
+	const send = (frame: Record<string, unknown>) => {
+		handleBrokerSend(
+			sender.socket,
+			{
+				type: "send",
+				to: "recipient",
+				message: { ...message("bound-reply"), replyTo: "ordinary-thread" },
+				...frame,
+			},
+			sender.info.id,
+			sessions,
+			cache,
+			(socket, message) => {
+				writes.push({ socket, message });
+				return true;
+			},
+			new SupervisorChannelCache(),
+			new PendingQuestionIndex(),
+			() => {
+				queued++;
+				return true;
+			},
+		);
+		return writes.at(-1)!.message;
+	};
+	for (const expectedRecipientId of [undefined, null, false, 0, "", " "]) {
+		const result = send({ expectedRecipientId });
+		assert.equal(result.type, "delivery_failed");
+		if (result.type === "delivery_failed") assert.match(result.reason, /Invalid expectedRecipientId format/);
+	}
+	for (const frame of [
+		{ expectedRecipientId: "other" },
+		{ expectedRecipientId: recipient.info.id, message: message("not-a-reply") },
+		{ expectedRecipientId: recipient.info.id, type: "supervisor_send" },
+		{
+			expectedRecipientId: recipient.info.id,
+			message: { ...message("ask-not-reply"), replyTo: "thread", expectsReply: true },
+		},
+		{ expectedRecipientId: recipient.info.id, to: "workflow:11111111-1111-4111-8111-111111111111/future" },
+	])
+		assert.equal(send(frame).type, "delivery_failed");
+	assert.equal(queued, 0);
+	assert.equal(writes.filter((entry) => entry.socket === recipient.socket).length, 0);
+	assert.equal(send({ expectedRecipientId: recipient.info.id }).type, "delivered");
+	assert.equal(send({ expectedRecipientId: recipient.info.id }).type, "delivered");
+	const changed = send({});
+	assert.equal(changed.type, "delivery_failed");
+	if (changed.type === "delivery_failed") assert.equal(changed.reasonCode, "message_id_conflict");
+	assert.equal(writes.filter((entry) => entry.socket === recipient.socket).length, 1);
+	assert.equal(send({ message: { ...message("unbound-reply"), replyTo: "ordinary-thread" } }).type, "delivered");
+});

--- a/test/unit/intercom-client-channel.test.ts
+++ b/test/unit/intercom-client-channel.test.ts
@@ -227,3 +227,37 @@ test("client lists every broker group with membership markers", async () => {
 
 	assert.deepEqual(await listed, groups);
 });
+
+test("reply recipient binding is omitted when absent and distinguishes concurrent send identities", async () => {
+	const client = new IntercomClient();
+	const frames: Array<{ message: Message; attemptId: string; expectedRecipientId?: string }> = [];
+	const internals = client as unknown as {
+		socket: { destroyed: boolean; writableEnded: boolean; writable: boolean; write(data: Buffer): boolean };
+		_sessionId: string;
+		handleBrokerMessage(message: unknown): void;
+	};
+	internals.socket = {
+		destroyed: false,
+		writableEnded: false,
+		writable: true,
+		write(data) {
+			frames.push(JSON.parse(data.subarray(4).toString("utf8")));
+			return true;
+		},
+	};
+	internals._sessionId = "self";
+	const options = { text: "answer", messageId: "bound", replyTo: "question", expectedRecipientId: "recipient" };
+	const bound = client.send("recipient-name", options);
+	assert.equal(frames[0]!.expectedRecipientId, "recipient");
+	await assert.rejects(
+		client.send("recipient-name", { ...options, expectedRecipientId: "other" }),
+		/different|conflict|mismatch/i,
+	);
+	assert.equal(frames.length, 1);
+	internals.handleBrokerMessage({ type: "delivered", messageId: "bound", attemptId: frames[0]!.attemptId });
+	assert.equal((await bound).delivered, true);
+	const unbound = client.send("recipient-name", { text: "answer", messageId: "unbound", replyTo: "question" });
+	assert.equal(Object.hasOwn(frames[1]!, "expectedRecipientId"), false);
+	internals.handleBrokerMessage({ type: "delivered", messageId: "unbound", attemptId: frames[1]!.attemptId });
+	assert.equal((await unbound).delivered, true);
+});

--- a/test/unit/intercom-client-channel.test.ts
+++ b/test/unit/intercom-client-channel.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { Socket } from "node:net";
+import { test, vi } from "vitest";
 import { IntercomClient } from "../../packages/intercom/broker/client.js";
-import type { Message, SessionInfo } from "../../packages/intercom/types.js";
+import type { BrokerMessage, Message, SessionInfo } from "../../packages/intercom/types.js";
 
 test("client preserves the supervisor channel on inbound broker messages", () => {
 	const client = new IntercomClient();
@@ -231,21 +232,15 @@ test("client lists every broker group with membership markers", async () => {
 test("reply recipient binding is omitted when absent and distinguishes concurrent send identities", async () => {
 	const client = new IntercomClient();
 	const frames: Array<{ message: Message; attemptId: string; expectedRecipientId?: string }> = [];
-	const internals = client as unknown as {
-		socket: { destroyed: boolean; writableEnded: boolean; writable: boolean; write(data: Buffer): boolean };
-		_sessionId: string;
-		handleBrokerMessage(message: unknown): void;
-	};
-	internals.socket = {
-		destroyed: false,
-		writableEnded: false,
-		writable: true,
-		write(data) {
-			frames.push(JSON.parse(data.subarray(4).toString("utf8")));
-			return true;
-		},
-	};
-	internals._sessionId = "self";
+	const socket = new Socket();
+	vi.spyOn(socket, "write").mockImplementation((data) => {
+		assert.ok(Buffer.isBuffer(data));
+		frames.push(JSON.parse(data.subarray(4).toString("utf8")));
+		return true;
+	});
+	client["socket"] = socket;
+	client["_sessionId"] = "self";
+	const receive = (message: BrokerMessage) => client["handleBrokerMessage"](message);
 	const options = { text: "answer", messageId: "bound", replyTo: "question", expectedRecipientId: "recipient" };
 	const bound = client.send("recipient-name", options);
 	assert.equal(frames[0]!.expectedRecipientId, "recipient");
@@ -254,10 +249,10 @@ test("reply recipient binding is omitted when absent and distinguishes concurren
 		/different|conflict|mismatch/i,
 	);
 	assert.equal(frames.length, 1);
-	internals.handleBrokerMessage({ type: "delivered", messageId: "bound", attemptId: frames[0]!.attemptId });
+	receive({ type: "delivered", messageId: "bound", attemptId: frames[0]!.attemptId });
 	assert.equal((await bound).delivered, true);
 	const unbound = client.send("recipient-name", { text: "answer", messageId: "unbound", replyTo: "question" });
 	assert.equal(Object.hasOwn(frames[1]!, "expectedRecipientId"), false);
-	internals.handleBrokerMessage({ type: "delivered", messageId: "unbound", attemptId: frames[1]!.attemptId });
+	receive({ type: "delivered", messageId: "unbound", attemptId: frames[1]!.attemptId });
 	assert.equal((await unbound).delivered, true);
 });

--- a/test/unit/intercom-id-targeting.test.ts
+++ b/test/unit/intercom-id-targeting.test.ts
@@ -4,7 +4,7 @@ import { registerIntercomTool } from "../../packages/intercom/intercom-tool.js";
 import { routeIncomingReply } from "../../packages/intercom/reply-routing.js";
 import { ReplyTracker } from "../../packages/intercom/reply-tracker.js";
 import { ReplyWaiterRegistry } from "../../packages/intercom/reply-waiter.js";
-import type { Message, SessionInfo } from "../../packages/intercom/types.js";
+import type { Message, SessionInfo, WorkflowStageRosterEntry } from "../../packages/intercom/types.js";
 import { sleep } from "../helpers/runtime.js";
 
 type ToolResult = {
@@ -15,7 +15,7 @@ type ToolResult = {
 type Tool = {
 	execute(
 		id: string,
-		params: { action?: string; to?: string; message?: string; group?: string },
+		params: { action?: string; to?: string; message?: string; group?: string; replyTo?: string },
 		signal: AbortSignal | undefined,
 		update: undefined,
 		ctx: object,
@@ -111,7 +111,7 @@ describe("Intercom full session ID targeting", () => {
 
 		const listed = await current.tool.execute("list-call", { action: "list" }, undefined, undefined, context);
 		const text = listed.content[0]?.text ?? "";
-		assert.match(text, new RegExp(`recipient \\(${recipient.id}\\)`));
+		assert.ok(text.includes(`- \`${recipient.id}\` [same cwd, idle] /worktree (test) name: recipient`));
 	});
 
 	test("send accepts an exact full session ID", async () => {
@@ -476,7 +476,7 @@ describe("intercom list renders possible future stage rows (D7)", () => {
 
 	function futureFixture(directory: {
 		sessions: SessionInfo[];
-		workflowStages: never[];
+		workflowStages: WorkflowStageRosterEntry[];
 		workflowFutureStages: readonly unknown[];
 	}) {
 		let tool: Tool | undefined;
@@ -509,6 +509,33 @@ describe("intercom list renders possible future stage rows (D7)", () => {
 		return { tool: tool! };
 	}
 
+	test("materialized pending and live workflow rows lead with canonical paths", async () => {
+		const stages: WorkflowStageRosterEntry[] = ["pending", "running"].map((lifecycle) => ({
+			kind: "workflow-stage",
+			runId: futureRow.runId,
+			stageId: lifecycle,
+			stageName: `review ${lifecycle}`,
+			target: `workflow:${futureRow.runId}/${lifecycle}`,
+			lifecycle: lifecycle as "pending" | "running",
+			group: futureRow.group,
+			...(lifecycle === "running" ? { sessionId: "full-live-session-id" } : {}),
+		}));
+		const { tool } = futureFixture({
+			sessions: [session("self-session-id", "self")],
+			workflowStages: stages,
+			workflowFutureStages: [],
+		});
+		const result = await tool.execute("list-stages", { action: "list" }, undefined, undefined, context);
+		assert.ok(
+			result.content[0]!.text.includes(`- \`${stages[0]!.target}\` [PENDING] workflow stage: review pending`),
+		);
+		assert.ok(
+			result.content[0]!.text.includes(
+				`- \`${stages[1]!.target}\` [RUNNING] workflow stage: review running session: \`full-live-session-id\``,
+			),
+		);
+	});
+
 	test("list renders the canonical target and the queued count for every future row", async () => {
 		const self = session("self-session-id", "self");
 		const { tool } = futureFixture({
@@ -520,12 +547,9 @@ describe("intercom list renders possible future stage rows (D7)", () => {
 		const text = result.content[0]?.text ?? "";
 		assert.match(
 			text,
-			/- future workflow stage `workflow:d7000009-0000-4000-8000-000000000009\/orchestrator-\*` — 2 queued messages\n/,
+			/- `workflow:d7000009-0000-4000-8000-000000000009\/orchestrator-\*` \[future\] 2 queued messages\n/,
 		);
-		assert.match(
-			text,
-			/- future workflow stage `workflow:d7000009-0000-4000-8000-000000000009\/\*\*` — 1 queued message(\n|$)/,
-		);
+		assert.match(text, /- `workflow:d7000009-0000-4000-8000-000000000009\/\*\*` \[future\] 1 queued message(\n|$)/);
 		const details = (result as unknown as { details?: { workflowFutureStages?: unknown[] } }).details;
 		assert.deepEqual(details?.workflowFutureStages, [futureRow, broadcastRow]);
 	});
@@ -539,7 +563,7 @@ describe("intercom list renders possible future stage rows (D7)", () => {
 		});
 		const result = await tool.execute("list-call", { action: "list" }, undefined, undefined, context);
 		const rowLine = (result.content[0]?.text ?? "").split("\n").find((line) => line.includes("orchestrator-"));
-		assert.match(rowLine ?? "", /— 1 queued message$/);
+		assert.match(rowLine ?? "", /\[future\] 1 queued message$/);
 	});
 
 	test("read-only group peek renders future rows returned for the peeked group", async () => {
@@ -588,9 +612,68 @@ describe("intercom list renders possible future stage rows (D7)", () => {
 		);
 		assert.match(
 			result.content[0]?.text ?? "",
-			/- future workflow stage `workflow:d7000009-0000-4000-8000-000000000009\/orchestrator-\*` — 2 queued messages/,
+			/- `workflow:d7000009-0000-4000-8000-000000000009\/orchestrator-\*` \[future\] 2 queued messages/,
 		);
 		const details = (result as unknown as { details?: { workflowFutureStages?: unknown[] } }).details;
 		assert.deepEqual(details?.workflowFutureStages, [futureRow]);
 	});
+});
+
+test("agent list leads with copyable IDs and keeps meaningful names secondary", async () => {
+	const self = session("self-session-id", "subagent-chat-self-session-id");
+	const peer = session("6332faab-1111-4222-8333-123456789abc", "research");
+	const custom = session("custom-id", "subagent-chat-my-project");
+	const current = toolFixture(new ReplyTracker(), [self, peer, custom]);
+	const result = await current.tool.execute("list-targets", { action: "list" }, undefined, undefined, context);
+	assert.equal(result.isError, false);
+	const rows = result.content[0]!.text.split("\n").filter((row) => row.startsWith("- "));
+	assert.deepEqual(rows, [
+		"- `self-session-id` [self, idle] /worktree (test)",
+		"- `6332faab-1111-4222-8333-123456789abc` [same cwd, idle] /worktree (test) name: research",
+		"- `custom-id` [same cwd, idle] /worktree (test) name: subagent-chat-my-project",
+	]);
+});
+
+test("explicit invalid and ambiguous reply selectors send nothing and preserve pending asks", async () => {
+	const sender = session("sender-id", "sender");
+	const tracker = new ReplyTracker();
+	tracker.queueTurnContext(tracker.recordIncomingMessage(sender, ask("first")));
+	tracker.beginTurn();
+	tracker.recordIncomingMessage(sender, ask("second"));
+	const current = toolFixture(tracker, [sender]);
+	for (const selectors of [
+		{ to: sender.id },
+		{ replyTo: "missing" },
+		{ replyTo: "" },
+		{ to: "", replyTo: "first" },
+		{ to: "other", replyTo: "first" },
+	]) {
+		const result = await current.tool.execute(
+			"invalid-reply",
+			{ action: "reply", message: "must not send", ...selectors },
+			undefined,
+			undefined,
+			context,
+		);
+		assert.equal(result.isError, true, JSON.stringify(selectors));
+		assert.deepEqual(current.sent, []);
+		assert.deepEqual(
+			tracker.listPending().map((pending) => pending.message.id),
+			["first", "second"],
+		);
+	}
+	const result = await current.tool.execute(
+		"exact-reply",
+		{ action: "reply", to: sender.id, replyTo: "second", message: "answer" },
+		undefined,
+		undefined,
+		context,
+	);
+	assert.equal(result.isError, false);
+	assert.equal(current.sent[0]!.to, sender.id);
+	assert.equal(current.sent[0]!.replyTo, "second");
+	assert.deepEqual(
+		tracker.listPending().map((pending) => pending.message.id),
+		["first"],
+	);
 });

--- a/test/unit/intercom-tool-retry-real-broker.test.ts
+++ b/test/unit/intercom-tool-retry-real-broker.test.ts
@@ -311,6 +311,73 @@ for (const hidden of [false, true]) {
 	}
 }
 
+for (const namesakeTarget of ["ID", "name"]) {
+	test(`replyTo-only ordinary replies retain the exact recipient after sender departure beside a ${namesakeTarget} namesake`, async () => {
+		const sender = await createClient("ordinary-sender");
+		const recipient = await createClient("recipient");
+		const tracker = new ReplyTracker();
+		const incoming: Message[] = [];
+		recipient.on("message", (from: SessionInfo, message: Message) => {
+			incoming.push(message);
+			tracker.queueTurnContext(tracker.recordIncomingMessage(from, message));
+		});
+		const tool = registerTool(recipient, { replyTracker: tracker });
+		const replies: Message[] = [];
+		sender.on("message", (_from: SessionInfo, message: Message) => replies.push(message));
+		await sender.send(recipient.sessionId!, { text: "connected ordinary message" });
+		await waitUntil(() => incoming.length === 1, "connected ordinary context");
+		tracker.beginTurn();
+		const connected = await tool.execute(
+			"connected-reply",
+			{
+				action: "reply",
+				replyTo: incoming[0]!.id,
+				message: "connected answer",
+			},
+			undefined,
+			undefined,
+			context,
+		);
+		assert.equal(connected.isError, false);
+		await waitUntil(() => replies.length === 1, "connected ordinary reply");
+		assert.equal(replies[0]!.replyTo, incoming[0]!.id);
+		assert.throws(() => tracker.resolveReplyTarget({ replyTo: incoming[0]!.id }));
+
+		await sender.send(recipient.sessionId!, { text: "ordinary message before departure" });
+		await waitUntil(() => incoming.length === 2, "departing sender context");
+		tracker.beginTurn();
+		const replyTo = incoming[1]!.id;
+		const originalContext = tracker.resolveReplyTarget({ replyTo });
+		const senderId = sender.sessionId!;
+		sender.disconnect();
+		await waitForSessionDeparture(recipient, senderId);
+		const namesake = await createClient(namesakeTarget === "ID" ? senderId : "ordinary-sender");
+		const misdeliveries: Message[] = [];
+		namesake.on("message", (_from: SessionInfo, message: Message) => misdeliveries.push(message));
+		const attempts: string[] = [];
+		const send = recipient.send.bind(recipient);
+		recipient.send = async (...args: Parameters<Client["send"]>) => {
+			attempts.push(args[0]);
+			return send(...args);
+		};
+		const result = await tool.execute(
+			"departed-reply",
+			{
+				action: "reply",
+				replyTo,
+				message: "private answer",
+			},
+			undefined,
+			undefined,
+			context,
+		);
+		assert.equal(result.isError, true, JSON.stringify(result));
+		assert.deepEqual(misdeliveries, []);
+		assert.deepEqual(attempts, [senderId], "explicit thread selection never falls back to a sender name");
+		assert.equal(tracker.resolveReplyTarget({ replyTo }), originalContext);
+	});
+}
+
 test("one send invocation keeps its broker-accepted ID when reconnect transport reorders attachment members", async () => {
 	const received: Message[] = [];
 	const recipient = await createClient("recipient");
@@ -360,83 +427,90 @@ test("one send invocation keeps its broker-accepted ID when reconnect transport 
 	assert.deepEqual(Object.keys(retryAttachments[0] ?? {}), ["language", "content", "name", "type"]);
 });
 
-test("one reply invocation keeps its broker-accepted ID and correlation when transport reorders attachment members", async () => {
-	const replies: Message[] = [];
-	const asker = await createClient("asker");
-	asker.on("message", (_from: SessionInfo, message: Message) => replies.push(message));
-	const replyTracker = new ReplyTracker();
-	const questions: Array<{ from: SessionInfo; message: Message }> = [];
-	const replier = await createClient("recipient");
-	replier.on("message", (from: SessionInfo, message: Message) => {
-		questions.push({ from, message });
-		replyTracker.recordIncomingMessage(from, message);
-	});
-	const questionResult = await asker.send("recipient", {
-		text: "question awaiting one durable reply",
-		expectsReply: true,
-	});
-	assert.equal(questionResult.delivered, true, questionResult.reason);
-	await waitUntil(() => questions.length === 1, "the replier records the pending question");
-	const question = questions[0]?.message;
-	assert.ok(question);
+for (const explicitTo of [true, false]) {
+	test(`one ${explicitTo ? "to and replyTo" : "replyTo-only"} reply invocation keeps its broker-accepted ID and correlation when transport reorders attachment members`, async () => {
+		const replies: Message[] = [];
+		const asker = await createClient("asker");
+		asker.on("message", (_from: SessionInfo, message: Message) => replies.push(message));
+		const replyTracker = new ReplyTracker();
+		const questions: Array<{ from: SessionInfo; message: Message }> = [];
+		const replier = await createClient("recipient");
+		replier.on("message", (from: SessionInfo, message: Message) => {
+			questions.push({ from, message });
+			replyTracker.recordIncomingMessage(from, message);
+		});
+		const questionResult = await asker.send("recipient", {
+			text: "question awaiting one durable reply",
+			expectsReply: true,
+		});
+		assert.equal(questionResult.delivered, true, questionResult.reason);
+		await waitUntil(() => questions.length === 1, "the replier records the pending question");
+		const question = questions[0]?.message;
+		assert.ok(question);
 
-	const tool = registerTool(replier, { connectionName: "recipient", replyTracker });
-	const firstAttachments = attachmentsInDeclaredOrder();
-	const retryAttachments = attachmentsInReorderedMemberOrder();
-	const attempts: SendOptions[] = [];
-	const firstReplierId = replier.sessionId;
-	const socket = (replier as unknown as { socket: net.Socket }).socket;
-	const send = replier.send.bind(replier);
-	let loseFirstAcknowledgement = true;
-	replier.send = async (...args: Parameters<Client["send"]>) => {
-		attempts.push(args[1]);
-		if (attempts.length > 1) args[1] = { ...args[1], attachments: retryAttachments };
-		if (loseFirstAcknowledgement) {
-			loseFirstAcknowledgement = false;
-			socket.pause();
-		}
-		return send(...args);
-	};
-	const firstExecution = tool.execute(
-		"first-reply",
-		{
-			action: "reply",
-			to: asker.sessionId!,
-			message: "one correlated answer",
-			attachments: firstAttachments,
-			replyTo: question.id,
-		},
-		undefined,
-		undefined,
-		context,
-	);
-	await waitUntil(() => replies.length === 1, "the broker forwards the accepted reply");
-	socket.destroy();
-	assert.equal(
-		replyTracker.listPending().length,
-		1,
-		"acknowledgement loss keeps the question replyable during recovery",
-	);
-	const retry = await firstExecution;
-	assertNoRetryToken(retry);
+		const tool = registerTool(replier, { connectionName: "recipient", replyTracker });
+		const firstAttachments = attachmentsInDeclaredOrder();
+		const retryAttachments = attachmentsInReorderedMemberOrder();
+		const attempts: SendOptions[] = [];
+		const firstReplierId = replier.sessionId;
+		const socket = (replier as unknown as { socket: net.Socket }).socket;
+		const send = replier.send.bind(replier);
+		let loseFirstAcknowledgement = true;
+		replier.send = async (...args: Parameters<Client["send"]>) => {
+			attempts.push(args[1]);
+			if (attempts.length > 1) args[1] = { ...args[1], attachments: retryAttachments };
+			if (loseFirstAcknowledgement) {
+				loseFirstAcknowledgement = false;
+				socket.pause();
+			}
+			return send(...args);
+		};
+		const firstExecution = tool.execute(
+			"first-reply",
+			{
+				action: "reply",
+				...(explicitTo ? { to: asker.sessionId! } : {}),
+				message: "one correlated answer",
+				attachments: firstAttachments,
+				replyTo: question.id,
+			},
+			undefined,
+			undefined,
+			context,
+		);
+		await waitUntil(() => replies.length === 1, "the broker forwards the accepted reply");
+		socket.destroy();
+		assert.equal(
+			replyTracker.listPending().length,
+			1,
+			"acknowledgement loss keeps the question replyable during recovery",
+		);
+		const retry = await firstExecution;
+		assertNoRetryToken(retry);
 
-	assert.equal(retry.isError, false, retry.content[0]?.text);
-	assert.notEqual(replier.sessionId, firstReplierId);
-	assert.deepEqual(
-		attempts.map(({ messageId }) => messageId),
-		[replies[0]?.id, replies[0]?.id],
-		"the retried reply retains the broker-accepted identity",
-	);
-	assert.deepEqual(
-		attempts.map(({ expectedRecipientId }) => expectedRecipientId),
-		[asker.sessionId, asker.sessionId],
-	);
-	assert.equal(replies.length, 1, "the asker observes one correlated reply");
-	assert.equal(replies[0]?.replyTo, question.id);
-	assert.deepEqual(Object.keys(replies[0]?.content.attachments?.[0] ?? {}), ["type", "name", "content", "language"]);
-	assert.deepEqual(Object.keys(retryAttachments[0] ?? {}), ["language", "content", "name", "type"]);
-	assert.deepEqual(replyTracker.listPending(), [], "the retained acknowledgement settles the exact pending ask");
-});
+		assert.equal(retry.isError, false, retry.content[0]?.text);
+		assert.notEqual(replier.sessionId, firstReplierId);
+		assert.deepEqual(
+			attempts.map(({ messageId }) => messageId),
+			[replies[0]?.id, replies[0]?.id],
+			"the retried reply retains the broker-accepted identity",
+		);
+		assert.deepEqual(
+			attempts.map(({ expectedRecipientId }) => expectedRecipientId),
+			[asker.sessionId, asker.sessionId],
+		);
+		assert.equal(replies.length, 1, "the asker observes one correlated reply");
+		assert.equal(replies[0]?.replyTo, question.id);
+		assert.deepEqual(Object.keys(replies[0]?.content.attachments?.[0] ?? {}), [
+			"type",
+			"name",
+			"content",
+			"language",
+		]);
+		assert.deepEqual(Object.keys(retryAttachments[0] ?? {}), ["language", "content", "name", "type"]);
+		assert.deepEqual(replyTracker.listPending(), [], "the retained acknowledgement settles the exact pending ask");
+	});
+}
 
 test("a name-addressed tool retry keeps one identity and delivery after the recipient reconnects", async () => {
 	const received: Message[] = [];

--- a/test/unit/intercom-tool-retry-real-broker.test.ts
+++ b/test/unit/intercom-tool-retry-real-broker.test.ts
@@ -214,6 +214,103 @@ afterAll(async () => {
 	rmSync(agentDir, { recursive: true, force: true });
 });
 
+for (const activeAsk of [false, true]) {
+	for (const useName of [false, true]) {
+		test(`explicit reply ${useName ? "name" : "ID"} settles the requested ask beside an active ${activeAsk ? "ask" : "send"}`, async () => {
+			const recipient = await createClient("recipient");
+			const unrelated = await createClient("unrelated");
+			const asker = await createClient("questioner");
+			const tracker = new ReplyTracker();
+			const incoming: Message[] = [];
+			recipient.on("message", (from: SessionInfo, message: Message) => {
+				const incomingContext = tracker.recordIncomingMessage(from, message);
+				tracker.queueTurnContext(incomingContext);
+				incoming.push(message);
+			});
+			const recipientTool = registerTool(recipient, { replyTracker: tracker });
+			const askerTool = registerTool(asker);
+			await unrelated.send(recipient.sessionId!, { text: "active unrelated context", expectsReply: activeAsk });
+			await waitUntil(() => incoming.length === 1, "ordinary context delivery");
+			tracker.beginTurn();
+			const cancellation = new AbortController();
+			let answer: ToolResult | undefined;
+			const asking = askerTool
+				.execute(
+					"question",
+					{ action: "ask", to: recipient.sessionId!, message: "answer me" },
+					cancellation.signal,
+					undefined,
+					context,
+				)
+				.then((result) => {
+					answer = result;
+					return result;
+				});
+			try {
+				await waitUntil(() => incoming.length === 2, "pending question delivery");
+				const replies: Message[] = [];
+				asker.on("message", (_from: SessionInfo, message: Message) => replies.push(message));
+				const result = await recipientTool.execute(
+					"answer",
+					{ action: "reply", to: useName ? "questioner" : asker.sessionId!, message: "correct answer" },
+					undefined,
+					undefined,
+					context,
+				);
+				assert.equal(result.isError, false, JSON.stringify(result));
+				await waitUntil(() => replies.length === 1, "reply delivery");
+				assert.equal(replies[0]!.replyTo, incoming[1]!.id);
+				await waitUntil(() => answer !== undefined, "original ask completion");
+				assert.equal(answer!.isError, false);
+				assert.match(answer!.content[0]!.text, /correct answer/);
+				assert.deepEqual(
+					tracker.listPending().map((pending) => pending.message.id),
+					activeAsk ? [incoming[0]!.id] : [],
+				);
+			} finally {
+				cancellation.abort();
+				await asking;
+			}
+		});
+	}
+}
+
+for (const hidden of [false, true]) {
+	for (const collision of ["exact ID", "duplicate name"]) {
+		test(`explicit replies reject a ${hidden ? "hidden-group" : "visible"} ${collision} collision instead of delivering to a pending namesake`, async () => {
+			const recipient = await createClient("recipient");
+			const selected = await createClient("duplicate");
+			if (hidden) {
+				await selected.joinGroup("hidden-collision-group");
+				await selected.leaveGroup("default");
+			}
+			const selector = collision === "exact ID" ? selected.sessionId! : "duplicate";
+			const namesake = await createClient(selector);
+			const tracker = new ReplyTracker();
+			recipient.on("message", (from: SessionInfo, message: Message) => tracker.recordIncomingMessage(from, message));
+			await namesake.send(recipient.sessionId!, { text: "pending namesake question", expectsReply: true });
+			await waitUntil(() => tracker.listPending().length === 1, "namesake question");
+			const questionId = tracker.listPending()[0]!.message.id;
+			const tool = registerTool(recipient, { replyTracker: tracker });
+			const delivered: Message[] = [];
+			for (const client of [selected, namesake])
+				client.on("message", (_from: SessionInfo, message: Message) => delivered.push(message));
+			for (const replyTo of [undefined, questionId]) {
+				const result = await tool.execute(
+					"reply-collision",
+					{ action: "reply", to: selector, replyTo, message: "private answer" },
+					undefined,
+					undefined,
+					context,
+				);
+				assert.equal(result.isError, true, JSON.stringify(result));
+				assert.deepEqual(delivered, []);
+				assert.equal(tracker.listPending()[0]!.message.id, questionId);
+			}
+		});
+	}
+}
+
 test("one send invocation keeps its broker-accepted ID when reconnect transport reorders attachment members", async () => {
 	const received: Message[] = [];
 	const recipient = await createClient("recipient");
@@ -304,6 +401,7 @@ test("one reply invocation keeps its broker-accepted ID and correlation when tra
 		"first-reply",
 		{
 			action: "reply",
+			to: asker.sessionId!,
 			message: "one correlated answer",
 			attachments: firstAttachments,
 			replyTo: question.id,
@@ -328,6 +426,10 @@ test("one reply invocation keeps its broker-accepted ID and correlation when tra
 		attempts.map(({ messageId }) => messageId),
 		[replies[0]?.id, replies[0]?.id],
 		"the retried reply retains the broker-accepted identity",
+	);
+	assert.deepEqual(
+		attempts.map(({ expectedRecipientId }) => expectedRecipientId),
+		[asker.sessionId, asker.sessionId],
 	);
 	assert.equal(replies.length, 1, "the asker observes one correlated reply");
 	assert.equal(replies[0]?.replyTo, question.id);
@@ -829,6 +931,16 @@ test("a public reply reaches a retried cross-group ask after the asker reconnect
 	assert.equal(recipientTracker.listPending().length, 1, "an ambiguous name must not consume the reply route");
 	await imposter.disconnect();
 	await waitForSessionDeparture(sender, imposterId);
+	// An explicit departed ID must not silently fall back to a namesake after reconnect.
+	const departedReply = await recipientTool.execute(
+		"departed-explicit-reply",
+		{ action: "reply", to: originalSenderId, message: "must not redirect" },
+		undefined,
+		undefined,
+		context,
+	);
+	assert.equal(departedReply.isError, true);
+	assert.equal(recipientTracker.listPending().length, 1);
 
 	const publicReply = await recipientTool.execute(
 		"public-reply",

--- a/test/unit/intercom-workflow-reply-tracker.test.ts
+++ b/test/unit/intercom-workflow-reply-tracker.test.ts
@@ -69,12 +69,23 @@ test("replyTo selects an exact ask when one sender has concurrent pending questi
 	assert.throws(() => tracker.resolveReplyTarget({ to: "another-session", replyTo: "message-1" }), /not from/);
 });
 
-test("a non-pending replyTo falls back to the active turn context", () => {
+test("explicit reply targets fail closed without redirecting the active ordinary thread", () => {
 	const tracker = new ReplyTracker();
 	const context = tracker.recordIncomingMessage(sender, { ...message, id: "plain", expectsReply: false });
 	tracker.queueTurnContext(context);
 	tracker.beginTurn();
-	assert.equal(tracker.resolveReplyTarget({ replyTo: "stale-thread" }), context);
+	tracker.recordIncomingMessage(sender, message);
+	for (const replyTo of ["stale-thread", ""]) {
+		assert.throws(() => tracker.resolveReplyTarget({ replyTo }), /No .*reply context/);
+	}
+	assert.throws(() => tracker.resolveReplyTarget({ to: "" }), /No pending ask/);
+	assert.throws(() => tracker.resolveReplyTarget({ to: "other", replyTo: "plain" }), /not from/);
+	assert.equal(tracker.resolveReplyTarget({ replyTo: "plain" }), context);
+	assert.equal(tracker.resolveReplyTarget({}), context);
+	assert.deepEqual(
+		tracker.listPending().map((pending) => pending.message.id),
+		[message.id],
+	);
 });
 
 test("parallel children keep every parent-targeted ask independently addressable", () => {


### PR DESCRIPTION
## Summary

Make Intercom lists easier for agents to target and fix explicit replies selecting an unrelated active thread, which can leave the intended ask waiting despite a delivered response.

## Changes

- Lead session and workflow rows with copyable full IDs or canonical paths. Keep status, working directory, meaningful names, capabilities and queued counts; hide only redundant generated aliases from display, not lookup.
- Resolve explicit `to` against pending asks rather than unrelated active context. Require explicit `replyTo` to identify an existing pending ask or the exact active ordinary message, with matching sender when both selectors are supplied.
- Bind either explicit selector to the original recipient through client/broker routing and retries. Refuse departed-sender namesakes instead of delivering private reply content to another session.
- Add actual-tool/real-broker regressions for correct ask completion beside unrelated traffic, selector refusal, recipient collisions and acknowledgement-loss retries. Update user guides, skill examples and both affected Unreleased changelogs.

## Breaking changes

Stale, unknown, empty, mismatched or ambiguous explicit reply selectors now fail closed instead of falling back to another thread or sender name. Inspect `intercom({ action: "pending" })` and use the exact `replyTo` for the intended question. Multiple asks from one sender require `replyTo`.

Fully implicit replies retain active-message-first behavior. Session-name lookup remains supported.

## Validation

Approved candidate: `739833c1e12362ae4d9827591599be5bfd84ebf8`.

The implementation receipts and three independent final reviews record:

- `npm run check`: passed.
- `npm run test:unit`: 816 files passed, 8,475 tests passed, 24 reported preexisting skips.
- Independent Intercom unit rerun: 65 files, 781 tests passed.
- Relevant runtime/workflow integrations: 4 files, 67 tests passed, including active subagent, active interruption, reconnect and completed-stage paths.
- Isolated current-source broker scenarios reproduced failing behavior before correction and passed afterward, including original ask completion and departed-sender misdelivery refusal.
- Normal commit hooks passed. No timeout, worker, serialization or skip policy changed.

The final PR stage reviewed all 18 changed files and confirmed both worktree and index diffs against `origin/main` match the approved SHA-256 `9c4a7d141702771109e773564088e2048a578b3932953d59faae2732f51e5302`. The worktree was clean and `git diff --check origin/main` passed. Tests above are recorded implementation/reviewer evidence, not fresh PR-stage reruns.

## Evidence limits

The original already-loaded live incident remains unattributed. The fixed equivalent defect has durable failing-before/passing-after transport coverage using isolated brokers importing current source. No Windows, interactive recording or modified-source validation of already-loaded sessions is claimed. The human picker is unchanged. No version bumps, merge or release actions are included.

## Goal report usage

The completed goal ledger, corrected orchestrator receipt and latest unanimous three-reviewer approval informed scope, validation and the limits above. The final repair includes the review-discovered `replyTo`-only recipient-binding gap; earlier rejected-candidate results are not used as final approval.

## Contract amendments received

- "so can you create a PR for the fix? no backwards compat pls"
- "use gh api for auth"

Explicit selector fallback compatibility was deliberately removed. PR creation follows approval as a separate stage. `gh api user` confirmed the authorized account as `lavaman131`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/3018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791844242&installation_model_id=10562&pr_number=3018&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F3018&signature=d96ab0182c6da91af5600a7a98658ef1b014e2b3c4046af38d27c096319b945f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63503421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Use Precise Test Types** <a href="https://github.com/bastani-inc/atomic/pull/3018#discussion_r3997870467">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
test/unit/intercom-broker-send-handler.test.ts:undefined-878
The new reply-binding helper accepts `Record<string, unknown>`, and the new client coverage casts through `unknown` and exposes an `unknown` broker-message parameter. This violates the repository directive requiring specific types instead of ambiguous `unknown` types. Define constrained send-frame and broker-message test types so these tests remain aligned with the protocol contract; this repository requirement must be satisfied before merging.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- This PR makes explicit Intercom reply selection fail closed, binds selected replies to the original recipient across routing and retries, and makes exact session and workflow targets more prominent. The test coverage now uses protocol-derived send-frame types while retaining explicit malformed-wire-value cases.

<sub>Reviews (2) · Last reviewed commit: ["test(intercom): align target-first asser..."](https://github.com/bastani-inc/atomic/commit/1a8caed03c7f01d32bdde7d1722db3f848ea00ea)</sub>

<!-- /greptile_comment -->