### PR TITLE
docs(release): prepare 0.9.19-alpha.9 changelogs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.9] - 2026-09-12
+
 ### Breaking Changes
 
 - Explicit Intercom `action: "reply"` selectors reject stale, unknown, empty, or sender-mismatched threads instead of falling back. Use `action: "pending"` and `replyTo: "<pending-ask-id>"` for unresolved questions.

--- a/packages/intercom/CHANGELOG.md
+++ b/packages/intercom/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `pi-intercom` extension will be documented in this fi
 
 ## [Unreleased]
 
+## [0.9.19-alpha.9] - 2026-09-12
+
 ### Breaking Changes
 
 - Explicit `reply` selectors now fail closed: stale, unknown, empty, or sender-mismatched `replyTo` values no longer fall back to another active or pending thread. Use `pending` to select the exact unresolved question.

--- a/packages/web-access/CHANGELOG.md
+++ b/packages/web-access/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.19-alpha.9] - 2026-09-12
+
 ### Fixed
 
 - `fetch_content` ignores video frame options for non-video inputs, so webpages and mixed batches no longer fail with video-only errors. Tool and parameter descriptions now distinguish ordinary page fetching, video analysis, and frame extraction.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.19-alpha.9] - 2026-09-12
+
 ### Fixed
 
 - Kept the background workflow summary within narrow terminal widths, including 27 columns. The shared workflow widget now stays within ten rows, shrinks on short terminals, and scrolls one row at a time with Alt+PageUp / Alt+PageDown without taking focus from the editor. All workflow rows remain reachable when a multiline draft reduces the visible widget area ([#3015](https://github.com/bastani-inc/atomic/issues/3015)).


### PR DESCRIPTION
## Summary

Prepare the 0.9.19-alpha.9 prerelease notes in the coding-agent, intercom, web-access, and workflows changelogs. Adds only dated release headings, preserving existing notes and released history.

## Changes

- Document strict Intercom reply selectors, exact-target lists, and corrected reply correlation, including migration guidance.
- Include the fix for video frame options on ordinary webpages and mixed fetch batches.
- Include bounded, scrollable workflow summaries and preserved reading positions during live updates.

## Validation

- Confirmed one changelog-only commit, four files, eight added lines, and a clean worktree.
- All eight package manifests remain at 0.0.0. Workspace lock entries, shrinkwrap versions, first-party dependency pins, Cargo workspace and inherited crate versions, Cargo.lock, and generated native version checks remain at 0.0.0. These files are unchanged.
- `bun run scripts/build-release-notes.ts 0.9.19-alpha.9` passed.
- `bun run test:unit -- test/unit/changelog.test.ts test/unit/build-release-notes.test.ts test/unit/bump-version-script.test.ts` passed, 22 tests.
- `bun run check` and applicable commit hooks passed. Six existing informational lint notices were left unchanged.
- `git diff --check` passed.
- An additional ad hoc version assertion initially assumed a literal crate version. Corrected the assertion to resolve Cargo workspace inheritance and verified 0.0.0; no repository changes were needed.

## Release boundary

This PR changes release notes only. Only scripts/cut-release.ts may stamp 0.9.19-alpha.9 on the detached Release commit after this PR merges. The eventual version-tag push starts publish.yml without a duplicate normal-publication dispatch. This stage does not merge, tag, publish, or launch another release workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/3019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791848131&installation_model_id=10562&pr_number=3019&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F3019&signature=8eab1f313d550bf327d528b1f3fc69b9bba10cc6d4fca0fd4e4428727d503080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63512767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: the dated changelog sections generate the intended consolidated release notes.

What we checked:
- I compared the parent changelog snapshot with the updated release notes for 0.9.19-alpha.9 and confirmed that before the change, relevant entries remained under Unreleased and the release-note generator stopped. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- After the change, four dated sections were discovered, no relevant Unreleased entries remained, and the generator exited with seven entries in a single release-notes body. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- An authored command artifact trex-artifacts/changelog-release-notes-validation-command.sh was created and used to drive the validation checks. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- Release notes for `0.9.19-alpha.9` are correctly moved from Unreleased sections into dated headings across the affected packages.
- The generated release notes include the expected combined breaking-change, changed, and fixed entries.
- No issues were found that would prevent merging.

<sub>Reviews (1) · Last reviewed commit: ["docs(release): prepare 0.9.19-alpha.9 ch..."](https://github.com/bastani-inc/atomic/commit/faf2a81e66cfc3dd62b6db4dafa5b58b7a5b0b56)</sub>

<!-- /greptile_comment -->