### PR TITLE
fix(workflows): match tasks scroll hint copy

### DIFF
--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Model fallback releases the failed attempt's Intercom ownership before initializing its replacement, avoiding duplicate live-stage ownership warnings while retaining queued delivery handoff. Concurrent attachment and steering wait for cleanup and share successor creation. Cancellation during cleanup no longer starts a replacement session, and failed extension initialization cleans up its session. If that cleanup fails, the stage stops rather than retrying or creating another session, preserving both the initialization and cleanup errors for diagnosis ([#3020](https://github.com/bastani-inc/atomic/issues/3020)).
-- Removed the confusing visible-row counter from the main-chat workflow widget hint; the final hint now shows available scrolling shortcuts and wheel help.
+- Removed the confusing visible-row counter from the main-chat workflow widget hint; the final hint now reads `↑↓ scroll` followed by available scrolling shortcuts, matching the `/tasks` hint style.
 
 ## [0.9.19-alpha.9] - 2026-09-12
 

--- a/packages/workflows/src/tui/widget-scroll-hint.ts
+++ b/packages/workflows/src/tui/widget-scroll-hint.ts
@@ -32,5 +32,5 @@ export function workflowScrollHint(
 		})
 		.filter((key) => key !== undefined);
 	const label = keys.map((key) => key.replace(/^alt\+/i, platform === "darwin" ? "Option+" : "Alt+")).join("/");
-	return ` ${label ? `${label} · ` : ""}Wheel scroll workflows`;
+	return ` ↑↓ scroll${label ? ` · ${label}` : ""}`;
 }

--- a/test/unit/workflow-widget-scroll-input.test.ts
+++ b/test/unit/workflow-widget-scroll-input.test.ts
@@ -112,10 +112,10 @@ test("workflow actions resolve Alt letter and Page aliases, configurable empties
 	}
 	const duplicate = resolve({ ...defaults, "app.workflows.scrollUp": ["alt+j", "alt+j"] as KeyId[] });
 	assert.equal(duplicate.get("alt+j")?.keybinding, "app.workflows.scrollDown"); // Existing last-registration map policy.
-	assert.match(workflowScrollHint(defaults, "darwin"), /Option\+k\/Option\+j/);
-	assert.match(workflowScrollHint(defaults, "linux"), /Alt\+k\/Alt\+j/);
-	assert.match(workflowScrollHint(defaults, "win32"), /Alt\+k\/Alt\+j/);
-	assert.equal(workflowScrollHint(disabled, "darwin"), " Wheel scroll workflows");
+	assert.equal(workflowScrollHint(defaults, "darwin"), " ↑↓ scroll · Option+k/Option+j");
+	assert.equal(workflowScrollHint(defaults, "linux"), " ↑↓ scroll · Alt+k/Alt+j");
+	assert.equal(workflowScrollHint(defaults, "win32"), " ↑↓ scroll · Alt+k/Alt+j");
+	assert.equal(workflowScrollHint(disabled, "darwin"), " ↑↓ scroll");
 	assert.doesNotMatch(workflowScrollHint(vim, "darwin"), /Option\+[kj]/);
 });
 
@@ -136,7 +136,7 @@ test("workflow yields to editor modifier-order equivalents without rewriting con
 		false,
 	);
 	assert.deepEqual(bindings["app.workflows.scrollUp"], workflow);
-	assert.equal(workflowScrollHint(bindings, "darwin"), " Wheel scroll workflows");
+	assert.equal(workflowScrollHint(bindings, "darwin"), " ↑↓ scroll");
 });
 
 test("workflow yields to the editor's shift+enter when configured as shift+return", () => {
@@ -152,7 +152,7 @@ test("workflow yields to the editor's shift+enter when configured as shift+retur
 		[...shortcuts.keys()].some((key) => matchesKey(bytes, key)),
 		false,
 	);
-	assert.equal(workflowScrollHint(bindings, "linux"), " Wheel scroll workflows");
+	assert.equal(workflowScrollHint(bindings, "linux"), " ↑↓ scroll");
 });
 
 test("workflow esc yields to reserved escape, including without preferEditor", () => {
@@ -172,7 +172,7 @@ test("workflow esc yields to reserved escape, including without preferEditor", (
 			false,
 		);
 	}
-	assert.equal(workflowScrollHint(bindings, "win32"), " Wheel scroll workflows");
+	assert.equal(workflowScrollHint(bindings, "win32"), " ↑↓ scroll");
 });
 
 test("literal editor-first shortcuts yield to equivalent keys but legacy registrations still override", () => {
@@ -379,7 +379,7 @@ for (const route of ["native", "remote"])
 				assert.equal(escapes, scenario.editor === "escape" ? 1 : 0);
 				const sharedScroll = scenario.literal === false ? 1 : 0;
 				assert.equal(widget.scrollTop, sharedScroll);
-				assert.equal(workflowScrollHint(bindings.getEffectiveConfig(), "linux"), " Wheel scroll workflows");
+				assert.equal(workflowScrollHint(bindings.getEffectiveConfig(), "linux"), " ↑↓ scroll");
 				if (scenario.explicit) {
 					assert.ok(matchesKey(scenario.explicit, scenario.workflow));
 					assert.equal(matchesKey(scenario.explicit, scenario.editor), false);
@@ -483,7 +483,7 @@ test("workflow wheel uses actual clipped bounds, contains boundaries, preserves 
 		for (let i = 0; i < 80; i++) wheel(65);
 		assert.equal(transcript.scrollTop, 15);
 		const bottom = widget.scrollTop;
-		assert.match(getLayoutFrame(f.tui).lines.join("\n"), /Wheel scroll workflows/);
+		assert.match(getLayoutFrame(f.tui).lines.join("\n"), /↑↓ scroll/);
 		f.terminal.input("\x1b[<64;2;2M");
 		render();
 		assert.equal(widget.scrollTop, bottom);
@@ -592,7 +592,7 @@ test("remote workflow adapter synchronizes full content, wheel, shortcuts and fr
 		assert.equal(widget.maxHeight, 10);
 		const frame = messages.findLast((message) => message.type === "engine_custom_frame");
 		assert.ok(frame?.type === "engine_custom_frame" && frame.lines.length > 10);
-		assert.match(frame.lines.at(-1)!, /Wheel scroll workflows/);
+		assert.match(frame.lines.at(-1)!, /↑↓ scroll/);
 		assert.equal(frame.lines.at(-1)!.includes("1–4/4"), false);
 		const box = boxFor(getLayoutFrame(f.tui).root, widget)!;
 		f.terminal.input(`\x1b[<65;2;${box.rect.y + 1}M`);


### PR DESCRIPTION
## Summary

Match the workflow widget hint to the `/tasks` scroll hint style: `↑↓ scroll · Option+k/Option+j` on macOS, with the keybinding second. Other platforms retain Alt labels; disabled or conflicting bindings remain omitted.

## Validation

Verified commit `03697bd7b`:
- Focused widget input suite: 60 tests passed.
- Full `npm test`: passed, including scripts, root projects and workspace suites, with existing skips. Final rerun also passed after correcting worktree-local GenAI dependency resolution.
- All commit hooks, including `npm run check`: passed.

No scrolling behavior or keybindings changed. Prerelease publication remains stopped.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63576301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge; the updated footer behavior and terminal input handling are covered by focused and existing workflow-widget tests.

What we checked:
- Exercised the production scrolling-hint and shortcut-resolution behavior with workflow scroll bindings removed and with those bindings superseded by editor bindings. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Confirmed that the footer maintains its generic scrolling affordance, while Up and Down inputs do not dispatch workflow scrolling in either configuration. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Ran the existing workflow widget terminal-input test suite, which completed with 60 passing tests. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Compared before/after artifacts to confirm validation-only scope and that product code was not modified. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- This PR updates the workflow widget footer to show a compact scrolling affordance followed by any available platform-specific scroll shortcuts. Focused terminal-input coverage confirms the footer remains consistent when workflow scroll bindings are unavailable or conflict with other bindings.

<sub>Reviews (1) · Last reviewed commit: ["fix(workflows): match tasks scroll hint ..."](https://github.com/bastani-inc/atomic/commit/03697bd7b40a6d9082c49d441e8b3aac9ba94541)</sub>

<!-- /greptile_comment -->