### PR TITLE
docs(release): prepare 0.9.19-alpha.10 changelogs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.9.19-alpha.10] - 2026-09-13
+
 ### Added
 
 - Extension widgets can opt into a height-capped fullscreen viewport with widget-local wheel scrolling, an overflow-only scrollbar, and scroll-position feedback in both in-process and isolated-engine sessions. Existing widgets retain their default behavior.

--- a/packages/workflows/CHANGELOG.md
+++ b/packages/workflows/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.19-alpha.10] - 2026-09-13
+
 ### Added
 
 - Main-chat workflow cards now scroll with the wheel over their actual allocated viewport, with a slim scrollbar only when content overflows. Configurable Alt+K/J shortcuts, labeled Option on macOS, retain Alt+PageUp/PageDown aliases and yield to configured editor bindings. The ten-row/short-terminal cap, multiline-draft reachability and run-ID anchors remain intact across insertion, deletion, collapse and resize, including isolated-engine sessions.


### PR DESCRIPTION
## Summary

Prepare the 0.9.19-alpha.10 prerelease notes in the coding-agent and workflows changelogs. Adds only dated release headings, preserving existing notes and released history.

## Changes

- Include height-capped extension widget viewports and workflow wheel scrolling with configurable shortcuts.
- Include workflow model fallback ownership cleanup and the corrected scroll hint.

## Validation

- Changelog-only commit: two files, four added lines. Worktree clean after commit; applicable hooks passed.
- All eight workspace package manifests remain at 0.0.0. Workspace lock entries, shrinkwrap, native dependency pin, and Cargo workspace/crate/lock versions remain at 0.0.0. All non-changelog files, including generated version files, are unchanged.
- `bun run scripts/build-release-notes.ts 0.9.19-alpha.10` passed.
- `bun run test:unit -- test/unit/changelog.test.ts test/unit/build-release-notes.test.ts` passed, 19 tests.
- `bun run check` and the shrinkwrap check passed. Six existing informational lint notices were left unchanged.
- `git diff --check` passed.
- An initial ad hoc manifest assertion matched nested example packages. Corrected the selector to the eight release workspace manifests; no repository repair was needed.

## Release boundary

This PR changes release notes only. Only scripts/cut-release.ts may stamp 0.9.19-alpha.10 on the detached Release commit after this PR merges. The eventual version-tag push starts publish.yml without a duplicate normal-publication dispatch. This stage does not merge, tag, publish, or launch another release workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bastani-inc/codesmith/atomic/pr/3024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791877670&installation_model_id=10562&pr_number=3024&repository=bastani-inc%2Fatomic&return_to=https%3A%2F%2Fgithub.com%2Fbastani-inc%2Fatomic%2Fpull%2F3024&signature=6fd5c5a6e866970c3d6ec0c7436b0d5d6850a381dea61e2cfec7ff16e02707a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63577264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

What we checked:
- Executed the release notes validation wrapper script to exercise the changelog validation flow and captured its output; the targeted changelog tests passed and prerelease-note generation included Added and Fixed entries from both newly versioned changelog sections. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Observed that the generated release notes include entries from both newly headed package changelogs, confirming they were incorporated rather than being treated as Unreleased content. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- Adds 0.9.19-alpha.10 release sections to the coding-agent and workflows changelogs.
- The release sections retain the existing Added and Fixed notes while leaving Unreleased empty for future work.
- The prerelease notes are generated correctly from both changelogs.

<sub>Reviews (1) · Last reviewed commit: ["docs(release): prepare 0.9.19-alpha.10 c..."](https://github.com/bastani-inc/atomic/commit/4c9b0be8c6e8cbcd8d8c2e38fa96454b5f636c09)</sub>

<!-- /greptile_comment -->